### PR TITLE
Update the package name in go.mod.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ccloud-sdk-go-v2-public
+# ccloud-sdk-go-v2
 
 ## Compatibility
 

--- a/cmk/go.mod
+++ b/cmk/go.mod
@@ -1,4 +1,4 @@
-module github.com/confluentinc/ccloud-sdk-go-v2-public/cmk
+module github.com/confluentinc/ccloud-sdk-go-v2/cmk
 
 go 1.13
 

--- a/iam/go.mod
+++ b/iam/go.mod
@@ -1,4 +1,4 @@
-module github.com/confluentinc/ccloud-sdk-go-v2-public/iam
+module github.com/confluentinc/ccloud-sdk-go-v2/iam
 
 go 1.13
 

--- a/networking/go.mod
+++ b/networking/go.mod
@@ -1,4 +1,4 @@
-module github.com/confluentinc/ccloud-sdk-go-v2-public/networking
+module github.com/confluentinc/ccloud-sdk-go-v2/networking
 
 go 1.13
 

--- a/org/go.mod
+++ b/org/go.mod
@@ -1,4 +1,4 @@
-module github.com/confluentinc/ccloud-sdk-go-v2-public/org
+module github.com/confluentinc/ccloud-sdk-go-v2/org
 
 go 1.13
 


### PR DESCRIPTION
### What
After a [discussion](https://confluent.slack.com/archives/CULTFVBEY/p1631659081306600?thread_ts=1631640213.282100&cid=CULTFVBEY) on Slack, we agreed to rename:
* `ccloud-sdk-go-v2-internal` -> `ccloud-sdk-go-v2-internal`.
* `ccloud-sdk-go-v2-public` -> `ccloud-sdk-go-v2`.

This PR address the latter and updates the module names in the current `ccloud-sdk-go-v2` repository.