### PR TITLE
Fix a compilation error for mocks

### DIFF
--- a/cmk/v2/mock/api_clusters_cmk_v2.go
+++ b/cmk/v2/mock/api_clusters_cmk_v2.go
@@ -9,80 +9,80 @@ import (
 	net_http "net/http"
 	sync "sync"
 
-	github_com_confluentinc_ccloud_sdk_go_v2 "github.com/confluentinc/ccloud-sdk-go-v2"
+	github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2 "github.com/confluentinc/ccloud-sdk-go-v2/cmk/v2"
 )
 
 // ClustersCmkV2Api is a mock of ClustersCmkV2Api interface
 type ClustersCmkV2Api struct {
 	lockCreateCmkV2Cluster sync.Mutex
-	CreateCmkV2ClusterFunc func(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateCmkV2ClusterRequest
+	CreateCmkV2ClusterFunc func(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiCreateCmkV2ClusterRequest
 
 	lockCreateCmkV2ClusterExecute sync.Mutex
-	CreateCmkV2ClusterExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateCmkV2ClusterRequest) (github_com_confluentinc_ccloud_sdk_go_v2.CmkV2Cluster, *net_http.Response, error)
+	CreateCmkV2ClusterExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiCreateCmkV2ClusterRequest) (github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.CmkV2Cluster, *net_http.Response, error)
 
 	lockDeleteCmkV2Cluster sync.Mutex
-	DeleteCmkV2ClusterFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteCmkV2ClusterRequest
+	DeleteCmkV2ClusterFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiDeleteCmkV2ClusterRequest
 
 	lockDeleteCmkV2ClusterExecute sync.Mutex
-	DeleteCmkV2ClusterExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteCmkV2ClusterRequest) (*net_http.Response, error)
+	DeleteCmkV2ClusterExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiDeleteCmkV2ClusterRequest) (*net_http.Response, error)
 
 	lockGetCmkV2Cluster sync.Mutex
-	GetCmkV2ClusterFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiGetCmkV2ClusterRequest
+	GetCmkV2ClusterFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiGetCmkV2ClusterRequest
 
 	lockGetCmkV2ClusterExecute sync.Mutex
-	GetCmkV2ClusterExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiGetCmkV2ClusterRequest) (github_com_confluentinc_ccloud_sdk_go_v2.CmkV2Cluster, *net_http.Response, error)
+	GetCmkV2ClusterExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiGetCmkV2ClusterRequest) (github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.CmkV2Cluster, *net_http.Response, error)
 
 	lockListCmkV2Clusters sync.Mutex
-	ListCmkV2ClustersFunc func(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2.ApiListCmkV2ClustersRequest
+	ListCmkV2ClustersFunc func(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiListCmkV2ClustersRequest
 
 	lockListCmkV2ClustersExecute sync.Mutex
-	ListCmkV2ClustersExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiListCmkV2ClustersRequest) (github_com_confluentinc_ccloud_sdk_go_v2.CmkV2ClusterList, *net_http.Response, error)
+	ListCmkV2ClustersExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiListCmkV2ClustersRequest) (github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.CmkV2ClusterList, *net_http.Response, error)
 
 	lockUpdateCmkV2Cluster sync.Mutex
-	UpdateCmkV2ClusterFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateCmkV2ClusterRequest
+	UpdateCmkV2ClusterFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiUpdateCmkV2ClusterRequest
 
 	lockUpdateCmkV2ClusterExecute sync.Mutex
-	UpdateCmkV2ClusterExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateCmkV2ClusterRequest) (github_com_confluentinc_ccloud_sdk_go_v2.CmkV2Cluster, *net_http.Response, error)
+	UpdateCmkV2ClusterExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiUpdateCmkV2ClusterRequest) (github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.CmkV2Cluster, *net_http.Response, error)
 
 	calls struct {
 		CreateCmkV2Cluster []struct {
 			Ctx context.Context
 		}
 		CreateCmkV2ClusterExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateCmkV2ClusterRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiCreateCmkV2ClusterRequest
 		}
 		DeleteCmkV2Cluster []struct {
 			Ctx context.Context
 			Id  string
 		}
 		DeleteCmkV2ClusterExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteCmkV2ClusterRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiDeleteCmkV2ClusterRequest
 		}
 		GetCmkV2Cluster []struct {
 			Ctx context.Context
 			Id  string
 		}
 		GetCmkV2ClusterExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiGetCmkV2ClusterRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiGetCmkV2ClusterRequest
 		}
 		ListCmkV2Clusters []struct {
 			Ctx context.Context
 		}
 		ListCmkV2ClustersExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiListCmkV2ClustersRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiListCmkV2ClustersRequest
 		}
 		UpdateCmkV2Cluster []struct {
 			Ctx context.Context
 			Id  string
 		}
 		UpdateCmkV2ClusterExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateCmkV2ClusterRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiUpdateCmkV2ClusterRequest
 		}
 	}
 }
 
 // CreateCmkV2Cluster mocks base method by wrapping the associated func.
-func (m *ClustersCmkV2Api) CreateCmkV2Cluster(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateCmkV2ClusterRequest {
+func (m *ClustersCmkV2Api) CreateCmkV2Cluster(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiCreateCmkV2ClusterRequest {
 	m.lockCreateCmkV2Cluster.Lock()
 	defer m.lockCreateCmkV2Cluster.Unlock()
 
@@ -120,7 +120,7 @@ func (m *ClustersCmkV2Api) CreateCmkV2ClusterCalls() []struct {
 }
 
 // CreateCmkV2ClusterExecute mocks base method by wrapping the associated func.
-func (m *ClustersCmkV2Api) CreateCmkV2ClusterExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateCmkV2ClusterRequest) (github_com_confluentinc_ccloud_sdk_go_v2.CmkV2Cluster, *net_http.Response, error) {
+func (m *ClustersCmkV2Api) CreateCmkV2ClusterExecute(r github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiCreateCmkV2ClusterRequest) (github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.CmkV2Cluster, *net_http.Response, error) {
 	m.lockCreateCmkV2ClusterExecute.Lock()
 	defer m.lockCreateCmkV2ClusterExecute.Unlock()
 
@@ -129,7 +129,7 @@ func (m *ClustersCmkV2Api) CreateCmkV2ClusterExecute(r github_com_confluentinc_c
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateCmkV2ClusterRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiCreateCmkV2ClusterRequest
 	}{
 		R: r,
 	}
@@ -149,7 +149,7 @@ func (m *ClustersCmkV2Api) CreateCmkV2ClusterExecuteCalled() bool {
 
 // CreateCmkV2ClusterExecuteCalls returns the calls made to CreateCmkV2ClusterExecute.
 func (m *ClustersCmkV2Api) CreateCmkV2ClusterExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateCmkV2ClusterRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiCreateCmkV2ClusterRequest
 } {
 	m.lockCreateCmkV2ClusterExecute.Lock()
 	defer m.lockCreateCmkV2ClusterExecute.Unlock()
@@ -158,7 +158,7 @@ func (m *ClustersCmkV2Api) CreateCmkV2ClusterExecuteCalls() []struct {
 }
 
 // DeleteCmkV2Cluster mocks base method by wrapping the associated func.
-func (m *ClustersCmkV2Api) DeleteCmkV2Cluster(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteCmkV2ClusterRequest {
+func (m *ClustersCmkV2Api) DeleteCmkV2Cluster(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiDeleteCmkV2ClusterRequest {
 	m.lockDeleteCmkV2Cluster.Lock()
 	defer m.lockDeleteCmkV2Cluster.Unlock()
 
@@ -199,7 +199,7 @@ func (m *ClustersCmkV2Api) DeleteCmkV2ClusterCalls() []struct {
 }
 
 // DeleteCmkV2ClusterExecute mocks base method by wrapping the associated func.
-func (m *ClustersCmkV2Api) DeleteCmkV2ClusterExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteCmkV2ClusterRequest) (*net_http.Response, error) {
+func (m *ClustersCmkV2Api) DeleteCmkV2ClusterExecute(r github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiDeleteCmkV2ClusterRequest) (*net_http.Response, error) {
 	m.lockDeleteCmkV2ClusterExecute.Lock()
 	defer m.lockDeleteCmkV2ClusterExecute.Unlock()
 
@@ -208,7 +208,7 @@ func (m *ClustersCmkV2Api) DeleteCmkV2ClusterExecute(r github_com_confluentinc_c
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteCmkV2ClusterRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiDeleteCmkV2ClusterRequest
 	}{
 		R: r,
 	}
@@ -228,7 +228,7 @@ func (m *ClustersCmkV2Api) DeleteCmkV2ClusterExecuteCalled() bool {
 
 // DeleteCmkV2ClusterExecuteCalls returns the calls made to DeleteCmkV2ClusterExecute.
 func (m *ClustersCmkV2Api) DeleteCmkV2ClusterExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteCmkV2ClusterRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiDeleteCmkV2ClusterRequest
 } {
 	m.lockDeleteCmkV2ClusterExecute.Lock()
 	defer m.lockDeleteCmkV2ClusterExecute.Unlock()
@@ -237,7 +237,7 @@ func (m *ClustersCmkV2Api) DeleteCmkV2ClusterExecuteCalls() []struct {
 }
 
 // GetCmkV2Cluster mocks base method by wrapping the associated func.
-func (m *ClustersCmkV2Api) GetCmkV2Cluster(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiGetCmkV2ClusterRequest {
+func (m *ClustersCmkV2Api) GetCmkV2Cluster(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiGetCmkV2ClusterRequest {
 	m.lockGetCmkV2Cluster.Lock()
 	defer m.lockGetCmkV2Cluster.Unlock()
 
@@ -278,7 +278,7 @@ func (m *ClustersCmkV2Api) GetCmkV2ClusterCalls() []struct {
 }
 
 // GetCmkV2ClusterExecute mocks base method by wrapping the associated func.
-func (m *ClustersCmkV2Api) GetCmkV2ClusterExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiGetCmkV2ClusterRequest) (github_com_confluentinc_ccloud_sdk_go_v2.CmkV2Cluster, *net_http.Response, error) {
+func (m *ClustersCmkV2Api) GetCmkV2ClusterExecute(r github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiGetCmkV2ClusterRequest) (github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.CmkV2Cluster, *net_http.Response, error) {
 	m.lockGetCmkV2ClusterExecute.Lock()
 	defer m.lockGetCmkV2ClusterExecute.Unlock()
 
@@ -287,7 +287,7 @@ func (m *ClustersCmkV2Api) GetCmkV2ClusterExecute(r github_com_confluentinc_cclo
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiGetCmkV2ClusterRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiGetCmkV2ClusterRequest
 	}{
 		R: r,
 	}
@@ -307,7 +307,7 @@ func (m *ClustersCmkV2Api) GetCmkV2ClusterExecuteCalled() bool {
 
 // GetCmkV2ClusterExecuteCalls returns the calls made to GetCmkV2ClusterExecute.
 func (m *ClustersCmkV2Api) GetCmkV2ClusterExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiGetCmkV2ClusterRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiGetCmkV2ClusterRequest
 } {
 	m.lockGetCmkV2ClusterExecute.Lock()
 	defer m.lockGetCmkV2ClusterExecute.Unlock()
@@ -316,7 +316,7 @@ func (m *ClustersCmkV2Api) GetCmkV2ClusterExecuteCalls() []struct {
 }
 
 // ListCmkV2Clusters mocks base method by wrapping the associated func.
-func (m *ClustersCmkV2Api) ListCmkV2Clusters(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2.ApiListCmkV2ClustersRequest {
+func (m *ClustersCmkV2Api) ListCmkV2Clusters(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiListCmkV2ClustersRequest {
 	m.lockListCmkV2Clusters.Lock()
 	defer m.lockListCmkV2Clusters.Unlock()
 
@@ -354,7 +354,7 @@ func (m *ClustersCmkV2Api) ListCmkV2ClustersCalls() []struct {
 }
 
 // ListCmkV2ClustersExecute mocks base method by wrapping the associated func.
-func (m *ClustersCmkV2Api) ListCmkV2ClustersExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiListCmkV2ClustersRequest) (github_com_confluentinc_ccloud_sdk_go_v2.CmkV2ClusterList, *net_http.Response, error) {
+func (m *ClustersCmkV2Api) ListCmkV2ClustersExecute(r github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiListCmkV2ClustersRequest) (github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.CmkV2ClusterList, *net_http.Response, error) {
 	m.lockListCmkV2ClustersExecute.Lock()
 	defer m.lockListCmkV2ClustersExecute.Unlock()
 
@@ -363,7 +363,7 @@ func (m *ClustersCmkV2Api) ListCmkV2ClustersExecute(r github_com_confluentinc_cc
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiListCmkV2ClustersRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiListCmkV2ClustersRequest
 	}{
 		R: r,
 	}
@@ -383,7 +383,7 @@ func (m *ClustersCmkV2Api) ListCmkV2ClustersExecuteCalled() bool {
 
 // ListCmkV2ClustersExecuteCalls returns the calls made to ListCmkV2ClustersExecute.
 func (m *ClustersCmkV2Api) ListCmkV2ClustersExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiListCmkV2ClustersRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiListCmkV2ClustersRequest
 } {
 	m.lockListCmkV2ClustersExecute.Lock()
 	defer m.lockListCmkV2ClustersExecute.Unlock()
@@ -392,7 +392,7 @@ func (m *ClustersCmkV2Api) ListCmkV2ClustersExecuteCalls() []struct {
 }
 
 // UpdateCmkV2Cluster mocks base method by wrapping the associated func.
-func (m *ClustersCmkV2Api) UpdateCmkV2Cluster(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateCmkV2ClusterRequest {
+func (m *ClustersCmkV2Api) UpdateCmkV2Cluster(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiUpdateCmkV2ClusterRequest {
 	m.lockUpdateCmkV2Cluster.Lock()
 	defer m.lockUpdateCmkV2Cluster.Unlock()
 
@@ -433,7 +433,7 @@ func (m *ClustersCmkV2Api) UpdateCmkV2ClusterCalls() []struct {
 }
 
 // UpdateCmkV2ClusterExecute mocks base method by wrapping the associated func.
-func (m *ClustersCmkV2Api) UpdateCmkV2ClusterExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateCmkV2ClusterRequest) (github_com_confluentinc_ccloud_sdk_go_v2.CmkV2Cluster, *net_http.Response, error) {
+func (m *ClustersCmkV2Api) UpdateCmkV2ClusterExecute(r github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiUpdateCmkV2ClusterRequest) (github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.CmkV2Cluster, *net_http.Response, error) {
 	m.lockUpdateCmkV2ClusterExecute.Lock()
 	defer m.lockUpdateCmkV2ClusterExecute.Unlock()
 
@@ -442,7 +442,7 @@ func (m *ClustersCmkV2Api) UpdateCmkV2ClusterExecute(r github_com_confluentinc_c
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateCmkV2ClusterRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiUpdateCmkV2ClusterRequest
 	}{
 		R: r,
 	}
@@ -462,7 +462,7 @@ func (m *ClustersCmkV2Api) UpdateCmkV2ClusterExecuteCalled() bool {
 
 // UpdateCmkV2ClusterExecuteCalls returns the calls made to UpdateCmkV2ClusterExecute.
 func (m *ClustersCmkV2Api) UpdateCmkV2ClusterExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateCmkV2ClusterRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_cmk_v2.ApiUpdateCmkV2ClusterRequest
 } {
 	m.lockUpdateCmkV2ClusterExecute.Lock()
 	defer m.lockUpdateCmkV2ClusterExecute.Unlock()

--- a/iam/v2/mock/api_service_accounts_iam_v2.go
+++ b/iam/v2/mock/api_service_accounts_iam_v2.go
@@ -9,80 +9,80 @@ import (
 	net_http "net/http"
 	sync "sync"
 
-	github_com_confluentinc_ccloud_sdk_go_v2 "github.com/confluentinc/ccloud-sdk-go-v2"
+	github_com_confluentinc_ccloud_sdk_go_v2_iam_v2 "github.com/confluentinc/ccloud-sdk-go-v2/iam/v2"
 )
 
 // ServiceAccountsIamV2Api is a mock of ServiceAccountsIamV2Api interface
 type ServiceAccountsIamV2Api struct {
 	lockCreateIamV2ServiceAccount sync.Mutex
-	CreateIamV2ServiceAccountFunc func(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateIamV2ServiceAccountRequest
+	CreateIamV2ServiceAccountFunc func(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiCreateIamV2ServiceAccountRequest
 
 	lockCreateIamV2ServiceAccountExecute sync.Mutex
-	CreateIamV2ServiceAccountExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateIamV2ServiceAccountRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2ServiceAccount, *net_http.Response, error)
+	CreateIamV2ServiceAccountExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiCreateIamV2ServiceAccountRequest) (github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.IamV2ServiceAccount, *net_http.Response, error)
 
 	lockDeleteIamV2ServiceAccount sync.Mutex
-	DeleteIamV2ServiceAccountFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2ServiceAccountRequest
+	DeleteIamV2ServiceAccountFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiDeleteIamV2ServiceAccountRequest
 
 	lockDeleteIamV2ServiceAccountExecute sync.Mutex
-	DeleteIamV2ServiceAccountExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2ServiceAccountRequest) (*net_http.Response, error)
+	DeleteIamV2ServiceAccountExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiDeleteIamV2ServiceAccountRequest) (*net_http.Response, error)
 
 	lockGetIamV2ServiceAccount sync.Mutex
-	GetIamV2ServiceAccountFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2ServiceAccountRequest
+	GetIamV2ServiceAccountFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiGetIamV2ServiceAccountRequest
 
 	lockGetIamV2ServiceAccountExecute sync.Mutex
-	GetIamV2ServiceAccountExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2ServiceAccountRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2ServiceAccount, *net_http.Response, error)
+	GetIamV2ServiceAccountExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiGetIamV2ServiceAccountRequest) (github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.IamV2ServiceAccount, *net_http.Response, error)
 
 	lockListIamV2ServiceAccounts sync.Mutex
-	ListIamV2ServiceAccountsFunc func(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2ServiceAccountsRequest
+	ListIamV2ServiceAccountsFunc func(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiListIamV2ServiceAccountsRequest
 
 	lockListIamV2ServiceAccountsExecute sync.Mutex
-	ListIamV2ServiceAccountsExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2ServiceAccountsRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2ServiceAccountList, *net_http.Response, error)
+	ListIamV2ServiceAccountsExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiListIamV2ServiceAccountsRequest) (github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.IamV2ServiceAccountList, *net_http.Response, error)
 
 	lockUpdateIamV2ServiceAccount sync.Mutex
-	UpdateIamV2ServiceAccountFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateIamV2ServiceAccountRequest
+	UpdateIamV2ServiceAccountFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiUpdateIamV2ServiceAccountRequest
 
 	lockUpdateIamV2ServiceAccountExecute sync.Mutex
-	UpdateIamV2ServiceAccountExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateIamV2ServiceAccountRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2ServiceAccount, *net_http.Response, error)
+	UpdateIamV2ServiceAccountExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiUpdateIamV2ServiceAccountRequest) (github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.IamV2ServiceAccount, *net_http.Response, error)
 
 	calls struct {
 		CreateIamV2ServiceAccount []struct {
 			Ctx context.Context
 		}
 		CreateIamV2ServiceAccountExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateIamV2ServiceAccountRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiCreateIamV2ServiceAccountRequest
 		}
 		DeleteIamV2ServiceAccount []struct {
 			Ctx context.Context
 			Id  string
 		}
 		DeleteIamV2ServiceAccountExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2ServiceAccountRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiDeleteIamV2ServiceAccountRequest
 		}
 		GetIamV2ServiceAccount []struct {
 			Ctx context.Context
 			Id  string
 		}
 		GetIamV2ServiceAccountExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2ServiceAccountRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiGetIamV2ServiceAccountRequest
 		}
 		ListIamV2ServiceAccounts []struct {
 			Ctx context.Context
 		}
 		ListIamV2ServiceAccountsExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2ServiceAccountsRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiListIamV2ServiceAccountsRequest
 		}
 		UpdateIamV2ServiceAccount []struct {
 			Ctx context.Context
 			Id  string
 		}
 		UpdateIamV2ServiceAccountExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateIamV2ServiceAccountRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiUpdateIamV2ServiceAccountRequest
 		}
 	}
 }
 
 // CreateIamV2ServiceAccount mocks base method by wrapping the associated func.
-func (m *ServiceAccountsIamV2Api) CreateIamV2ServiceAccount(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateIamV2ServiceAccountRequest {
+func (m *ServiceAccountsIamV2Api) CreateIamV2ServiceAccount(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiCreateIamV2ServiceAccountRequest {
 	m.lockCreateIamV2ServiceAccount.Lock()
 	defer m.lockCreateIamV2ServiceAccount.Unlock()
 
@@ -120,7 +120,7 @@ func (m *ServiceAccountsIamV2Api) CreateIamV2ServiceAccountCalls() []struct {
 }
 
 // CreateIamV2ServiceAccountExecute mocks base method by wrapping the associated func.
-func (m *ServiceAccountsIamV2Api) CreateIamV2ServiceAccountExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateIamV2ServiceAccountRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2ServiceAccount, *net_http.Response, error) {
+func (m *ServiceAccountsIamV2Api) CreateIamV2ServiceAccountExecute(r github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiCreateIamV2ServiceAccountRequest) (github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.IamV2ServiceAccount, *net_http.Response, error) {
 	m.lockCreateIamV2ServiceAccountExecute.Lock()
 	defer m.lockCreateIamV2ServiceAccountExecute.Unlock()
 
@@ -129,7 +129,7 @@ func (m *ServiceAccountsIamV2Api) CreateIamV2ServiceAccountExecute(r github_com_
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateIamV2ServiceAccountRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiCreateIamV2ServiceAccountRequest
 	}{
 		R: r,
 	}
@@ -149,7 +149,7 @@ func (m *ServiceAccountsIamV2Api) CreateIamV2ServiceAccountExecuteCalled() bool 
 
 // CreateIamV2ServiceAccountExecuteCalls returns the calls made to CreateIamV2ServiceAccountExecute.
 func (m *ServiceAccountsIamV2Api) CreateIamV2ServiceAccountExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateIamV2ServiceAccountRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiCreateIamV2ServiceAccountRequest
 } {
 	m.lockCreateIamV2ServiceAccountExecute.Lock()
 	defer m.lockCreateIamV2ServiceAccountExecute.Unlock()
@@ -158,7 +158,7 @@ func (m *ServiceAccountsIamV2Api) CreateIamV2ServiceAccountExecuteCalls() []stru
 }
 
 // DeleteIamV2ServiceAccount mocks base method by wrapping the associated func.
-func (m *ServiceAccountsIamV2Api) DeleteIamV2ServiceAccount(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2ServiceAccountRequest {
+func (m *ServiceAccountsIamV2Api) DeleteIamV2ServiceAccount(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiDeleteIamV2ServiceAccountRequest {
 	m.lockDeleteIamV2ServiceAccount.Lock()
 	defer m.lockDeleteIamV2ServiceAccount.Unlock()
 
@@ -199,7 +199,7 @@ func (m *ServiceAccountsIamV2Api) DeleteIamV2ServiceAccountCalls() []struct {
 }
 
 // DeleteIamV2ServiceAccountExecute mocks base method by wrapping the associated func.
-func (m *ServiceAccountsIamV2Api) DeleteIamV2ServiceAccountExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2ServiceAccountRequest) (*net_http.Response, error) {
+func (m *ServiceAccountsIamV2Api) DeleteIamV2ServiceAccountExecute(r github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiDeleteIamV2ServiceAccountRequest) (*net_http.Response, error) {
 	m.lockDeleteIamV2ServiceAccountExecute.Lock()
 	defer m.lockDeleteIamV2ServiceAccountExecute.Unlock()
 
@@ -208,7 +208,7 @@ func (m *ServiceAccountsIamV2Api) DeleteIamV2ServiceAccountExecute(r github_com_
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2ServiceAccountRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiDeleteIamV2ServiceAccountRequest
 	}{
 		R: r,
 	}
@@ -228,7 +228,7 @@ func (m *ServiceAccountsIamV2Api) DeleteIamV2ServiceAccountExecuteCalled() bool 
 
 // DeleteIamV2ServiceAccountExecuteCalls returns the calls made to DeleteIamV2ServiceAccountExecute.
 func (m *ServiceAccountsIamV2Api) DeleteIamV2ServiceAccountExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2ServiceAccountRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiDeleteIamV2ServiceAccountRequest
 } {
 	m.lockDeleteIamV2ServiceAccountExecute.Lock()
 	defer m.lockDeleteIamV2ServiceAccountExecute.Unlock()
@@ -237,7 +237,7 @@ func (m *ServiceAccountsIamV2Api) DeleteIamV2ServiceAccountExecuteCalls() []stru
 }
 
 // GetIamV2ServiceAccount mocks base method by wrapping the associated func.
-func (m *ServiceAccountsIamV2Api) GetIamV2ServiceAccount(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2ServiceAccountRequest {
+func (m *ServiceAccountsIamV2Api) GetIamV2ServiceAccount(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiGetIamV2ServiceAccountRequest {
 	m.lockGetIamV2ServiceAccount.Lock()
 	defer m.lockGetIamV2ServiceAccount.Unlock()
 
@@ -278,7 +278,7 @@ func (m *ServiceAccountsIamV2Api) GetIamV2ServiceAccountCalls() []struct {
 }
 
 // GetIamV2ServiceAccountExecute mocks base method by wrapping the associated func.
-func (m *ServiceAccountsIamV2Api) GetIamV2ServiceAccountExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2ServiceAccountRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2ServiceAccount, *net_http.Response, error) {
+func (m *ServiceAccountsIamV2Api) GetIamV2ServiceAccountExecute(r github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiGetIamV2ServiceAccountRequest) (github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.IamV2ServiceAccount, *net_http.Response, error) {
 	m.lockGetIamV2ServiceAccountExecute.Lock()
 	defer m.lockGetIamV2ServiceAccountExecute.Unlock()
 
@@ -287,7 +287,7 @@ func (m *ServiceAccountsIamV2Api) GetIamV2ServiceAccountExecute(r github_com_con
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2ServiceAccountRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiGetIamV2ServiceAccountRequest
 	}{
 		R: r,
 	}
@@ -307,7 +307,7 @@ func (m *ServiceAccountsIamV2Api) GetIamV2ServiceAccountExecuteCalled() bool {
 
 // GetIamV2ServiceAccountExecuteCalls returns the calls made to GetIamV2ServiceAccountExecute.
 func (m *ServiceAccountsIamV2Api) GetIamV2ServiceAccountExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2ServiceAccountRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiGetIamV2ServiceAccountRequest
 } {
 	m.lockGetIamV2ServiceAccountExecute.Lock()
 	defer m.lockGetIamV2ServiceAccountExecute.Unlock()
@@ -316,7 +316,7 @@ func (m *ServiceAccountsIamV2Api) GetIamV2ServiceAccountExecuteCalls() []struct 
 }
 
 // ListIamV2ServiceAccounts mocks base method by wrapping the associated func.
-func (m *ServiceAccountsIamV2Api) ListIamV2ServiceAccounts(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2ServiceAccountsRequest {
+func (m *ServiceAccountsIamV2Api) ListIamV2ServiceAccounts(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiListIamV2ServiceAccountsRequest {
 	m.lockListIamV2ServiceAccounts.Lock()
 	defer m.lockListIamV2ServiceAccounts.Unlock()
 
@@ -354,7 +354,7 @@ func (m *ServiceAccountsIamV2Api) ListIamV2ServiceAccountsCalls() []struct {
 }
 
 // ListIamV2ServiceAccountsExecute mocks base method by wrapping the associated func.
-func (m *ServiceAccountsIamV2Api) ListIamV2ServiceAccountsExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2ServiceAccountsRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2ServiceAccountList, *net_http.Response, error) {
+func (m *ServiceAccountsIamV2Api) ListIamV2ServiceAccountsExecute(r github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiListIamV2ServiceAccountsRequest) (github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.IamV2ServiceAccountList, *net_http.Response, error) {
 	m.lockListIamV2ServiceAccountsExecute.Lock()
 	defer m.lockListIamV2ServiceAccountsExecute.Unlock()
 
@@ -363,7 +363,7 @@ func (m *ServiceAccountsIamV2Api) ListIamV2ServiceAccountsExecute(r github_com_c
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2ServiceAccountsRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiListIamV2ServiceAccountsRequest
 	}{
 		R: r,
 	}
@@ -383,7 +383,7 @@ func (m *ServiceAccountsIamV2Api) ListIamV2ServiceAccountsExecuteCalled() bool {
 
 // ListIamV2ServiceAccountsExecuteCalls returns the calls made to ListIamV2ServiceAccountsExecute.
 func (m *ServiceAccountsIamV2Api) ListIamV2ServiceAccountsExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2ServiceAccountsRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiListIamV2ServiceAccountsRequest
 } {
 	m.lockListIamV2ServiceAccountsExecute.Lock()
 	defer m.lockListIamV2ServiceAccountsExecute.Unlock()
@@ -392,7 +392,7 @@ func (m *ServiceAccountsIamV2Api) ListIamV2ServiceAccountsExecuteCalls() []struc
 }
 
 // UpdateIamV2ServiceAccount mocks base method by wrapping the associated func.
-func (m *ServiceAccountsIamV2Api) UpdateIamV2ServiceAccount(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateIamV2ServiceAccountRequest {
+func (m *ServiceAccountsIamV2Api) UpdateIamV2ServiceAccount(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiUpdateIamV2ServiceAccountRequest {
 	m.lockUpdateIamV2ServiceAccount.Lock()
 	defer m.lockUpdateIamV2ServiceAccount.Unlock()
 
@@ -433,7 +433,7 @@ func (m *ServiceAccountsIamV2Api) UpdateIamV2ServiceAccountCalls() []struct {
 }
 
 // UpdateIamV2ServiceAccountExecute mocks base method by wrapping the associated func.
-func (m *ServiceAccountsIamV2Api) UpdateIamV2ServiceAccountExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateIamV2ServiceAccountRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2ServiceAccount, *net_http.Response, error) {
+func (m *ServiceAccountsIamV2Api) UpdateIamV2ServiceAccountExecute(r github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiUpdateIamV2ServiceAccountRequest) (github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.IamV2ServiceAccount, *net_http.Response, error) {
 	m.lockUpdateIamV2ServiceAccountExecute.Lock()
 	defer m.lockUpdateIamV2ServiceAccountExecute.Unlock()
 
@@ -442,7 +442,7 @@ func (m *ServiceAccountsIamV2Api) UpdateIamV2ServiceAccountExecute(r github_com_
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateIamV2ServiceAccountRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiUpdateIamV2ServiceAccountRequest
 	}{
 		R: r,
 	}
@@ -462,7 +462,7 @@ func (m *ServiceAccountsIamV2Api) UpdateIamV2ServiceAccountExecuteCalled() bool 
 
 // UpdateIamV2ServiceAccountExecuteCalls returns the calls made to UpdateIamV2ServiceAccountExecute.
 func (m *ServiceAccountsIamV2Api) UpdateIamV2ServiceAccountExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateIamV2ServiceAccountRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiUpdateIamV2ServiceAccountRequest
 } {
 	m.lockUpdateIamV2ServiceAccountExecute.Lock()
 	defer m.lockUpdateIamV2ServiceAccountExecute.Unlock()

--- a/iam/v2/mock/api_users_iam_v2.go
+++ b/iam/v2/mock/api_users_iam_v2.go
@@ -9,34 +9,34 @@ import (
 	net_http "net/http"
 	sync "sync"
 
-	github_com_confluentinc_ccloud_sdk_go_v2 "github.com/confluentinc/ccloud-sdk-go-v2"
+	github_com_confluentinc_ccloud_sdk_go_v2_iam_v2 "github.com/confluentinc/ccloud-sdk-go-v2/iam/v2"
 )
 
 // UsersIamV2Api is a mock of UsersIamV2Api interface
 type UsersIamV2Api struct {
 	lockDeleteIamV2User sync.Mutex
-	DeleteIamV2UserFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2UserRequest
+	DeleteIamV2UserFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiDeleteIamV2UserRequest
 
 	lockDeleteIamV2UserExecute sync.Mutex
-	DeleteIamV2UserExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2UserRequest) (*net_http.Response, error)
+	DeleteIamV2UserExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiDeleteIamV2UserRequest) (*net_http.Response, error)
 
 	lockGetIamV2User sync.Mutex
-	GetIamV2UserFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2UserRequest
+	GetIamV2UserFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiGetIamV2UserRequest
 
 	lockGetIamV2UserExecute sync.Mutex
-	GetIamV2UserExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2UserRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2User, *net_http.Response, error)
+	GetIamV2UserExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiGetIamV2UserRequest) (github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.IamV2User, *net_http.Response, error)
 
 	lockListIamV2Users sync.Mutex
-	ListIamV2UsersFunc func(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2UsersRequest
+	ListIamV2UsersFunc func(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiListIamV2UsersRequest
 
 	lockListIamV2UsersExecute sync.Mutex
-	ListIamV2UsersExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2UsersRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2UserList, *net_http.Response, error)
+	ListIamV2UsersExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiListIamV2UsersRequest) (github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.IamV2UserList, *net_http.Response, error)
 
 	lockUpdateIamV2User sync.Mutex
-	UpdateIamV2UserFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateIamV2UserRequest
+	UpdateIamV2UserFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiUpdateIamV2UserRequest
 
 	lockUpdateIamV2UserExecute sync.Mutex
-	UpdateIamV2UserExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateIamV2UserRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2User, *net_http.Response, error)
+	UpdateIamV2UserExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiUpdateIamV2UserRequest) (github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.IamV2User, *net_http.Response, error)
 
 	calls struct {
 		DeleteIamV2User []struct {
@@ -44,33 +44,33 @@ type UsersIamV2Api struct {
 			Id  string
 		}
 		DeleteIamV2UserExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2UserRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiDeleteIamV2UserRequest
 		}
 		GetIamV2User []struct {
 			Ctx context.Context
 			Id  string
 		}
 		GetIamV2UserExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2UserRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiGetIamV2UserRequest
 		}
 		ListIamV2Users []struct {
 			Ctx context.Context
 		}
 		ListIamV2UsersExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2UsersRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiListIamV2UsersRequest
 		}
 		UpdateIamV2User []struct {
 			Ctx context.Context
 			Id  string
 		}
 		UpdateIamV2UserExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateIamV2UserRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiUpdateIamV2UserRequest
 		}
 	}
 }
 
 // DeleteIamV2User mocks base method by wrapping the associated func.
-func (m *UsersIamV2Api) DeleteIamV2User(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2UserRequest {
+func (m *UsersIamV2Api) DeleteIamV2User(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiDeleteIamV2UserRequest {
 	m.lockDeleteIamV2User.Lock()
 	defer m.lockDeleteIamV2User.Unlock()
 
@@ -111,7 +111,7 @@ func (m *UsersIamV2Api) DeleteIamV2UserCalls() []struct {
 }
 
 // DeleteIamV2UserExecute mocks base method by wrapping the associated func.
-func (m *UsersIamV2Api) DeleteIamV2UserExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2UserRequest) (*net_http.Response, error) {
+func (m *UsersIamV2Api) DeleteIamV2UserExecute(r github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiDeleteIamV2UserRequest) (*net_http.Response, error) {
 	m.lockDeleteIamV2UserExecute.Lock()
 	defer m.lockDeleteIamV2UserExecute.Unlock()
 
@@ -120,7 +120,7 @@ func (m *UsersIamV2Api) DeleteIamV2UserExecute(r github_com_confluentinc_ccloud_
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2UserRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiDeleteIamV2UserRequest
 	}{
 		R: r,
 	}
@@ -140,7 +140,7 @@ func (m *UsersIamV2Api) DeleteIamV2UserExecuteCalled() bool {
 
 // DeleteIamV2UserExecuteCalls returns the calls made to DeleteIamV2UserExecute.
 func (m *UsersIamV2Api) DeleteIamV2UserExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2UserRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiDeleteIamV2UserRequest
 } {
 	m.lockDeleteIamV2UserExecute.Lock()
 	defer m.lockDeleteIamV2UserExecute.Unlock()
@@ -149,7 +149,7 @@ func (m *UsersIamV2Api) DeleteIamV2UserExecuteCalls() []struct {
 }
 
 // GetIamV2User mocks base method by wrapping the associated func.
-func (m *UsersIamV2Api) GetIamV2User(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2UserRequest {
+func (m *UsersIamV2Api) GetIamV2User(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiGetIamV2UserRequest {
 	m.lockGetIamV2User.Lock()
 	defer m.lockGetIamV2User.Unlock()
 
@@ -190,7 +190,7 @@ func (m *UsersIamV2Api) GetIamV2UserCalls() []struct {
 }
 
 // GetIamV2UserExecute mocks base method by wrapping the associated func.
-func (m *UsersIamV2Api) GetIamV2UserExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2UserRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2User, *net_http.Response, error) {
+func (m *UsersIamV2Api) GetIamV2UserExecute(r github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiGetIamV2UserRequest) (github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.IamV2User, *net_http.Response, error) {
 	m.lockGetIamV2UserExecute.Lock()
 	defer m.lockGetIamV2UserExecute.Unlock()
 
@@ -199,7 +199,7 @@ func (m *UsersIamV2Api) GetIamV2UserExecute(r github_com_confluentinc_ccloud_sdk
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2UserRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiGetIamV2UserRequest
 	}{
 		R: r,
 	}
@@ -219,7 +219,7 @@ func (m *UsersIamV2Api) GetIamV2UserExecuteCalled() bool {
 
 // GetIamV2UserExecuteCalls returns the calls made to GetIamV2UserExecute.
 func (m *UsersIamV2Api) GetIamV2UserExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2UserRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiGetIamV2UserRequest
 } {
 	m.lockGetIamV2UserExecute.Lock()
 	defer m.lockGetIamV2UserExecute.Unlock()
@@ -228,7 +228,7 @@ func (m *UsersIamV2Api) GetIamV2UserExecuteCalls() []struct {
 }
 
 // ListIamV2Users mocks base method by wrapping the associated func.
-func (m *UsersIamV2Api) ListIamV2Users(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2UsersRequest {
+func (m *UsersIamV2Api) ListIamV2Users(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiListIamV2UsersRequest {
 	m.lockListIamV2Users.Lock()
 	defer m.lockListIamV2Users.Unlock()
 
@@ -266,7 +266,7 @@ func (m *UsersIamV2Api) ListIamV2UsersCalls() []struct {
 }
 
 // ListIamV2UsersExecute mocks base method by wrapping the associated func.
-func (m *UsersIamV2Api) ListIamV2UsersExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2UsersRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2UserList, *net_http.Response, error) {
+func (m *UsersIamV2Api) ListIamV2UsersExecute(r github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiListIamV2UsersRequest) (github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.IamV2UserList, *net_http.Response, error) {
 	m.lockListIamV2UsersExecute.Lock()
 	defer m.lockListIamV2UsersExecute.Unlock()
 
@@ -275,7 +275,7 @@ func (m *UsersIamV2Api) ListIamV2UsersExecute(r github_com_confluentinc_ccloud_s
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2UsersRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiListIamV2UsersRequest
 	}{
 		R: r,
 	}
@@ -295,7 +295,7 @@ func (m *UsersIamV2Api) ListIamV2UsersExecuteCalled() bool {
 
 // ListIamV2UsersExecuteCalls returns the calls made to ListIamV2UsersExecute.
 func (m *UsersIamV2Api) ListIamV2UsersExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2UsersRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiListIamV2UsersRequest
 } {
 	m.lockListIamV2UsersExecute.Lock()
 	defer m.lockListIamV2UsersExecute.Unlock()
@@ -304,7 +304,7 @@ func (m *UsersIamV2Api) ListIamV2UsersExecuteCalls() []struct {
 }
 
 // UpdateIamV2User mocks base method by wrapping the associated func.
-func (m *UsersIamV2Api) UpdateIamV2User(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateIamV2UserRequest {
+func (m *UsersIamV2Api) UpdateIamV2User(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiUpdateIamV2UserRequest {
 	m.lockUpdateIamV2User.Lock()
 	defer m.lockUpdateIamV2User.Unlock()
 
@@ -345,7 +345,7 @@ func (m *UsersIamV2Api) UpdateIamV2UserCalls() []struct {
 }
 
 // UpdateIamV2UserExecute mocks base method by wrapping the associated func.
-func (m *UsersIamV2Api) UpdateIamV2UserExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateIamV2UserRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2User, *net_http.Response, error) {
+func (m *UsersIamV2Api) UpdateIamV2UserExecute(r github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiUpdateIamV2UserRequest) (github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.IamV2User, *net_http.Response, error) {
 	m.lockUpdateIamV2UserExecute.Lock()
 	defer m.lockUpdateIamV2UserExecute.Unlock()
 
@@ -354,7 +354,7 @@ func (m *UsersIamV2Api) UpdateIamV2UserExecute(r github_com_confluentinc_ccloud_
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateIamV2UserRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiUpdateIamV2UserRequest
 	}{
 		R: r,
 	}
@@ -374,7 +374,7 @@ func (m *UsersIamV2Api) UpdateIamV2UserExecuteCalled() bool {
 
 // UpdateIamV2UserExecuteCalls returns the calls made to UpdateIamV2UserExecute.
 func (m *UsersIamV2Api) UpdateIamV2UserExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateIamV2UserRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_iam_v2.ApiUpdateIamV2UserRequest
 } {
 	m.lockUpdateIamV2UserExecute.Lock()
 	defer m.lockUpdateIamV2UserExecute.Unlock()

--- a/mds/v2/mock/api_role_bindings_iam_v2.go
+++ b/mds/v2/mock/api_role_bindings_iam_v2.go
@@ -9,67 +9,67 @@ import (
 	net_http "net/http"
 	sync "sync"
 
-	github_com_confluentinc_ccloud_sdk_go_v2 "github.com/confluentinc/ccloud-sdk-go-v2"
+	github_com_confluentinc_ccloud_sdk_go_v2_mds_v2 "github.com/confluentinc/ccloud-sdk-go-v2/mds/v2"
 )
 
 // RoleBindingsIamV2Api is a mock of RoleBindingsIamV2Api interface
 type RoleBindingsIamV2Api struct {
 	lockCreateIamV2RoleBinding sync.Mutex
-	CreateIamV2RoleBindingFunc func(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateIamV2RoleBindingRequest
+	CreateIamV2RoleBindingFunc func(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiCreateIamV2RoleBindingRequest
 
 	lockCreateIamV2RoleBindingExecute sync.Mutex
-	CreateIamV2RoleBindingExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateIamV2RoleBindingRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2RoleBinding, *net_http.Response, error)
+	CreateIamV2RoleBindingExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiCreateIamV2RoleBindingRequest) (github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.IamV2RoleBinding, *net_http.Response, error)
 
 	lockDeleteIamV2RoleBinding sync.Mutex
-	DeleteIamV2RoleBindingFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2RoleBindingRequest
+	DeleteIamV2RoleBindingFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiDeleteIamV2RoleBindingRequest
 
 	lockDeleteIamV2RoleBindingExecute sync.Mutex
-	DeleteIamV2RoleBindingExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2RoleBindingRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2RoleBinding, *net_http.Response, error)
+	DeleteIamV2RoleBindingExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiDeleteIamV2RoleBindingRequest) (github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.IamV2RoleBinding, *net_http.Response, error)
 
 	lockGetIamV2RoleBinding sync.Mutex
-	GetIamV2RoleBindingFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2RoleBindingRequest
+	GetIamV2RoleBindingFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiGetIamV2RoleBindingRequest
 
 	lockGetIamV2RoleBindingExecute sync.Mutex
-	GetIamV2RoleBindingExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2RoleBindingRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2RoleBinding, *net_http.Response, error)
+	GetIamV2RoleBindingExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiGetIamV2RoleBindingRequest) (github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.IamV2RoleBinding, *net_http.Response, error)
 
 	lockListIamV2RoleBindings sync.Mutex
-	ListIamV2RoleBindingsFunc func(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2RoleBindingsRequest
+	ListIamV2RoleBindingsFunc func(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiListIamV2RoleBindingsRequest
 
 	lockListIamV2RoleBindingsExecute sync.Mutex
-	ListIamV2RoleBindingsExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2RoleBindingsRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2RoleBindingList, *net_http.Response, error)
+	ListIamV2RoleBindingsExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiListIamV2RoleBindingsRequest) (github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.IamV2RoleBindingList, *net_http.Response, error)
 
 	calls struct {
 		CreateIamV2RoleBinding []struct {
 			Ctx context.Context
 		}
 		CreateIamV2RoleBindingExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateIamV2RoleBindingRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiCreateIamV2RoleBindingRequest
 		}
 		DeleteIamV2RoleBinding []struct {
 			Ctx context.Context
 			Id  string
 		}
 		DeleteIamV2RoleBindingExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2RoleBindingRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiDeleteIamV2RoleBindingRequest
 		}
 		GetIamV2RoleBinding []struct {
 			Ctx context.Context
 			Id  string
 		}
 		GetIamV2RoleBindingExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2RoleBindingRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiGetIamV2RoleBindingRequest
 		}
 		ListIamV2RoleBindings []struct {
 			Ctx context.Context
 		}
 		ListIamV2RoleBindingsExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2RoleBindingsRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiListIamV2RoleBindingsRequest
 		}
 	}
 }
 
 // CreateIamV2RoleBinding mocks base method by wrapping the associated func.
-func (m *RoleBindingsIamV2Api) CreateIamV2RoleBinding(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateIamV2RoleBindingRequest {
+func (m *RoleBindingsIamV2Api) CreateIamV2RoleBinding(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiCreateIamV2RoleBindingRequest {
 	m.lockCreateIamV2RoleBinding.Lock()
 	defer m.lockCreateIamV2RoleBinding.Unlock()
 
@@ -107,7 +107,7 @@ func (m *RoleBindingsIamV2Api) CreateIamV2RoleBindingCalls() []struct {
 }
 
 // CreateIamV2RoleBindingExecute mocks base method by wrapping the associated func.
-func (m *RoleBindingsIamV2Api) CreateIamV2RoleBindingExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateIamV2RoleBindingRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2RoleBinding, *net_http.Response, error) {
+func (m *RoleBindingsIamV2Api) CreateIamV2RoleBindingExecute(r github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiCreateIamV2RoleBindingRequest) (github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.IamV2RoleBinding, *net_http.Response, error) {
 	m.lockCreateIamV2RoleBindingExecute.Lock()
 	defer m.lockCreateIamV2RoleBindingExecute.Unlock()
 
@@ -116,7 +116,7 @@ func (m *RoleBindingsIamV2Api) CreateIamV2RoleBindingExecute(r github_com_conflu
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateIamV2RoleBindingRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiCreateIamV2RoleBindingRequest
 	}{
 		R: r,
 	}
@@ -136,7 +136,7 @@ func (m *RoleBindingsIamV2Api) CreateIamV2RoleBindingExecuteCalled() bool {
 
 // CreateIamV2RoleBindingExecuteCalls returns the calls made to CreateIamV2RoleBindingExecute.
 func (m *RoleBindingsIamV2Api) CreateIamV2RoleBindingExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateIamV2RoleBindingRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiCreateIamV2RoleBindingRequest
 } {
 	m.lockCreateIamV2RoleBindingExecute.Lock()
 	defer m.lockCreateIamV2RoleBindingExecute.Unlock()
@@ -145,7 +145,7 @@ func (m *RoleBindingsIamV2Api) CreateIamV2RoleBindingExecuteCalls() []struct {
 }
 
 // DeleteIamV2RoleBinding mocks base method by wrapping the associated func.
-func (m *RoleBindingsIamV2Api) DeleteIamV2RoleBinding(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2RoleBindingRequest {
+func (m *RoleBindingsIamV2Api) DeleteIamV2RoleBinding(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiDeleteIamV2RoleBindingRequest {
 	m.lockDeleteIamV2RoleBinding.Lock()
 	defer m.lockDeleteIamV2RoleBinding.Unlock()
 
@@ -186,7 +186,7 @@ func (m *RoleBindingsIamV2Api) DeleteIamV2RoleBindingCalls() []struct {
 }
 
 // DeleteIamV2RoleBindingExecute mocks base method by wrapping the associated func.
-func (m *RoleBindingsIamV2Api) DeleteIamV2RoleBindingExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2RoleBindingRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2RoleBinding, *net_http.Response, error) {
+func (m *RoleBindingsIamV2Api) DeleteIamV2RoleBindingExecute(r github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiDeleteIamV2RoleBindingRequest) (github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.IamV2RoleBinding, *net_http.Response, error) {
 	m.lockDeleteIamV2RoleBindingExecute.Lock()
 	defer m.lockDeleteIamV2RoleBindingExecute.Unlock()
 
@@ -195,7 +195,7 @@ func (m *RoleBindingsIamV2Api) DeleteIamV2RoleBindingExecute(r github_com_conflu
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2RoleBindingRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiDeleteIamV2RoleBindingRequest
 	}{
 		R: r,
 	}
@@ -215,7 +215,7 @@ func (m *RoleBindingsIamV2Api) DeleteIamV2RoleBindingExecuteCalled() bool {
 
 // DeleteIamV2RoleBindingExecuteCalls returns the calls made to DeleteIamV2RoleBindingExecute.
 func (m *RoleBindingsIamV2Api) DeleteIamV2RoleBindingExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteIamV2RoleBindingRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiDeleteIamV2RoleBindingRequest
 } {
 	m.lockDeleteIamV2RoleBindingExecute.Lock()
 	defer m.lockDeleteIamV2RoleBindingExecute.Unlock()
@@ -224,7 +224,7 @@ func (m *RoleBindingsIamV2Api) DeleteIamV2RoleBindingExecuteCalls() []struct {
 }
 
 // GetIamV2RoleBinding mocks base method by wrapping the associated func.
-func (m *RoleBindingsIamV2Api) GetIamV2RoleBinding(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2RoleBindingRequest {
+func (m *RoleBindingsIamV2Api) GetIamV2RoleBinding(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiGetIamV2RoleBindingRequest {
 	m.lockGetIamV2RoleBinding.Lock()
 	defer m.lockGetIamV2RoleBinding.Unlock()
 
@@ -265,7 +265,7 @@ func (m *RoleBindingsIamV2Api) GetIamV2RoleBindingCalls() []struct {
 }
 
 // GetIamV2RoleBindingExecute mocks base method by wrapping the associated func.
-func (m *RoleBindingsIamV2Api) GetIamV2RoleBindingExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2RoleBindingRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2RoleBinding, *net_http.Response, error) {
+func (m *RoleBindingsIamV2Api) GetIamV2RoleBindingExecute(r github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiGetIamV2RoleBindingRequest) (github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.IamV2RoleBinding, *net_http.Response, error) {
 	m.lockGetIamV2RoleBindingExecute.Lock()
 	defer m.lockGetIamV2RoleBindingExecute.Unlock()
 
@@ -274,7 +274,7 @@ func (m *RoleBindingsIamV2Api) GetIamV2RoleBindingExecute(r github_com_confluent
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2RoleBindingRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiGetIamV2RoleBindingRequest
 	}{
 		R: r,
 	}
@@ -294,7 +294,7 @@ func (m *RoleBindingsIamV2Api) GetIamV2RoleBindingExecuteCalled() bool {
 
 // GetIamV2RoleBindingExecuteCalls returns the calls made to GetIamV2RoleBindingExecute.
 func (m *RoleBindingsIamV2Api) GetIamV2RoleBindingExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiGetIamV2RoleBindingRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiGetIamV2RoleBindingRequest
 } {
 	m.lockGetIamV2RoleBindingExecute.Lock()
 	defer m.lockGetIamV2RoleBindingExecute.Unlock()
@@ -303,7 +303,7 @@ func (m *RoleBindingsIamV2Api) GetIamV2RoleBindingExecuteCalls() []struct {
 }
 
 // ListIamV2RoleBindings mocks base method by wrapping the associated func.
-func (m *RoleBindingsIamV2Api) ListIamV2RoleBindings(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2RoleBindingsRequest {
+func (m *RoleBindingsIamV2Api) ListIamV2RoleBindings(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiListIamV2RoleBindingsRequest {
 	m.lockListIamV2RoleBindings.Lock()
 	defer m.lockListIamV2RoleBindings.Unlock()
 
@@ -341,7 +341,7 @@ func (m *RoleBindingsIamV2Api) ListIamV2RoleBindingsCalls() []struct {
 }
 
 // ListIamV2RoleBindingsExecute mocks base method by wrapping the associated func.
-func (m *RoleBindingsIamV2Api) ListIamV2RoleBindingsExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2RoleBindingsRequest) (github_com_confluentinc_ccloud_sdk_go_v2.IamV2RoleBindingList, *net_http.Response, error) {
+func (m *RoleBindingsIamV2Api) ListIamV2RoleBindingsExecute(r github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiListIamV2RoleBindingsRequest) (github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.IamV2RoleBindingList, *net_http.Response, error) {
 	m.lockListIamV2RoleBindingsExecute.Lock()
 	defer m.lockListIamV2RoleBindingsExecute.Unlock()
 
@@ -350,7 +350,7 @@ func (m *RoleBindingsIamV2Api) ListIamV2RoleBindingsExecute(r github_com_conflue
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2RoleBindingsRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiListIamV2RoleBindingsRequest
 	}{
 		R: r,
 	}
@@ -370,7 +370,7 @@ func (m *RoleBindingsIamV2Api) ListIamV2RoleBindingsExecuteCalled() bool {
 
 // ListIamV2RoleBindingsExecuteCalls returns the calls made to ListIamV2RoleBindingsExecute.
 func (m *RoleBindingsIamV2Api) ListIamV2RoleBindingsExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiListIamV2RoleBindingsRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_mds_v2.ApiListIamV2RoleBindingsRequest
 } {
 	m.lockListIamV2RoleBindingsExecute.Lock()
 	defer m.lockListIamV2RoleBindingsExecute.Unlock()

--- a/org/v2/mock/api_environments_org_v2.go
+++ b/org/v2/mock/api_environments_org_v2.go
@@ -9,80 +9,80 @@ import (
 	net_http "net/http"
 	sync "sync"
 
-	github_com_confluentinc_ccloud_sdk_go_v2 "github.com/confluentinc/ccloud-sdk-go-v2"
+	github_com_confluentinc_ccloud_sdk_go_v2_org_v2 "github.com/confluentinc/ccloud-sdk-go-v2/org/v2"
 )
 
 // EnvironmentsOrgV2Api is a mock of EnvironmentsOrgV2Api interface
 type EnvironmentsOrgV2Api struct {
 	lockCreateOrgV2Environment sync.Mutex
-	CreateOrgV2EnvironmentFunc func(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateOrgV2EnvironmentRequest
+	CreateOrgV2EnvironmentFunc func(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiCreateOrgV2EnvironmentRequest
 
 	lockCreateOrgV2EnvironmentExecute sync.Mutex
-	CreateOrgV2EnvironmentExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateOrgV2EnvironmentRequest) (github_com_confluentinc_ccloud_sdk_go_v2.OrgV2Environment, *net_http.Response, error)
+	CreateOrgV2EnvironmentExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiCreateOrgV2EnvironmentRequest) (github_com_confluentinc_ccloud_sdk_go_v2_org_v2.OrgV2Environment, *net_http.Response, error)
 
 	lockDeleteOrgV2Environment sync.Mutex
-	DeleteOrgV2EnvironmentFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteOrgV2EnvironmentRequest
+	DeleteOrgV2EnvironmentFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiDeleteOrgV2EnvironmentRequest
 
 	lockDeleteOrgV2EnvironmentExecute sync.Mutex
-	DeleteOrgV2EnvironmentExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteOrgV2EnvironmentRequest) (*net_http.Response, error)
+	DeleteOrgV2EnvironmentExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiDeleteOrgV2EnvironmentRequest) (*net_http.Response, error)
 
 	lockGetOrgV2Environment sync.Mutex
-	GetOrgV2EnvironmentFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiGetOrgV2EnvironmentRequest
+	GetOrgV2EnvironmentFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiGetOrgV2EnvironmentRequest
 
 	lockGetOrgV2EnvironmentExecute sync.Mutex
-	GetOrgV2EnvironmentExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiGetOrgV2EnvironmentRequest) (github_com_confluentinc_ccloud_sdk_go_v2.OrgV2Environment, *net_http.Response, error)
+	GetOrgV2EnvironmentExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiGetOrgV2EnvironmentRequest) (github_com_confluentinc_ccloud_sdk_go_v2_org_v2.OrgV2Environment, *net_http.Response, error)
 
 	lockListOrgV2Environments sync.Mutex
-	ListOrgV2EnvironmentsFunc func(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2.ApiListOrgV2EnvironmentsRequest
+	ListOrgV2EnvironmentsFunc func(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiListOrgV2EnvironmentsRequest
 
 	lockListOrgV2EnvironmentsExecute sync.Mutex
-	ListOrgV2EnvironmentsExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiListOrgV2EnvironmentsRequest) (github_com_confluentinc_ccloud_sdk_go_v2.OrgV2EnvironmentList, *net_http.Response, error)
+	ListOrgV2EnvironmentsExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiListOrgV2EnvironmentsRequest) (github_com_confluentinc_ccloud_sdk_go_v2_org_v2.OrgV2EnvironmentList, *net_http.Response, error)
 
 	lockUpdateOrgV2Environment sync.Mutex
-	UpdateOrgV2EnvironmentFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateOrgV2EnvironmentRequest
+	UpdateOrgV2EnvironmentFunc func(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiUpdateOrgV2EnvironmentRequest
 
 	lockUpdateOrgV2EnvironmentExecute sync.Mutex
-	UpdateOrgV2EnvironmentExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateOrgV2EnvironmentRequest) (github_com_confluentinc_ccloud_sdk_go_v2.OrgV2Environment, *net_http.Response, error)
+	UpdateOrgV2EnvironmentExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiUpdateOrgV2EnvironmentRequest) (github_com_confluentinc_ccloud_sdk_go_v2_org_v2.OrgV2Environment, *net_http.Response, error)
 
 	calls struct {
 		CreateOrgV2Environment []struct {
 			Ctx context.Context
 		}
 		CreateOrgV2EnvironmentExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateOrgV2EnvironmentRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiCreateOrgV2EnvironmentRequest
 		}
 		DeleteOrgV2Environment []struct {
 			Ctx context.Context
 			Id  string
 		}
 		DeleteOrgV2EnvironmentExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteOrgV2EnvironmentRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiDeleteOrgV2EnvironmentRequest
 		}
 		GetOrgV2Environment []struct {
 			Ctx context.Context
 			Id  string
 		}
 		GetOrgV2EnvironmentExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiGetOrgV2EnvironmentRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiGetOrgV2EnvironmentRequest
 		}
 		ListOrgV2Environments []struct {
 			Ctx context.Context
 		}
 		ListOrgV2EnvironmentsExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiListOrgV2EnvironmentsRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiListOrgV2EnvironmentsRequest
 		}
 		UpdateOrgV2Environment []struct {
 			Ctx context.Context
 			Id  string
 		}
 		UpdateOrgV2EnvironmentExecute []struct {
-			R github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateOrgV2EnvironmentRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiUpdateOrgV2EnvironmentRequest
 		}
 	}
 }
 
 // CreateOrgV2Environment mocks base method by wrapping the associated func.
-func (m *EnvironmentsOrgV2Api) CreateOrgV2Environment(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateOrgV2EnvironmentRequest {
+func (m *EnvironmentsOrgV2Api) CreateOrgV2Environment(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiCreateOrgV2EnvironmentRequest {
 	m.lockCreateOrgV2Environment.Lock()
 	defer m.lockCreateOrgV2Environment.Unlock()
 
@@ -120,7 +120,7 @@ func (m *EnvironmentsOrgV2Api) CreateOrgV2EnvironmentCalls() []struct {
 }
 
 // CreateOrgV2EnvironmentExecute mocks base method by wrapping the associated func.
-func (m *EnvironmentsOrgV2Api) CreateOrgV2EnvironmentExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateOrgV2EnvironmentRequest) (github_com_confluentinc_ccloud_sdk_go_v2.OrgV2Environment, *net_http.Response, error) {
+func (m *EnvironmentsOrgV2Api) CreateOrgV2EnvironmentExecute(r github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiCreateOrgV2EnvironmentRequest) (github_com_confluentinc_ccloud_sdk_go_v2_org_v2.OrgV2Environment, *net_http.Response, error) {
 	m.lockCreateOrgV2EnvironmentExecute.Lock()
 	defer m.lockCreateOrgV2EnvironmentExecute.Unlock()
 
@@ -129,7 +129,7 @@ func (m *EnvironmentsOrgV2Api) CreateOrgV2EnvironmentExecute(r github_com_conflu
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateOrgV2EnvironmentRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiCreateOrgV2EnvironmentRequest
 	}{
 		R: r,
 	}
@@ -149,7 +149,7 @@ func (m *EnvironmentsOrgV2Api) CreateOrgV2EnvironmentExecuteCalled() bool {
 
 // CreateOrgV2EnvironmentExecuteCalls returns the calls made to CreateOrgV2EnvironmentExecute.
 func (m *EnvironmentsOrgV2Api) CreateOrgV2EnvironmentExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiCreateOrgV2EnvironmentRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiCreateOrgV2EnvironmentRequest
 } {
 	m.lockCreateOrgV2EnvironmentExecute.Lock()
 	defer m.lockCreateOrgV2EnvironmentExecute.Unlock()
@@ -158,7 +158,7 @@ func (m *EnvironmentsOrgV2Api) CreateOrgV2EnvironmentExecuteCalls() []struct {
 }
 
 // DeleteOrgV2Environment mocks base method by wrapping the associated func.
-func (m *EnvironmentsOrgV2Api) DeleteOrgV2Environment(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteOrgV2EnvironmentRequest {
+func (m *EnvironmentsOrgV2Api) DeleteOrgV2Environment(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiDeleteOrgV2EnvironmentRequest {
 	m.lockDeleteOrgV2Environment.Lock()
 	defer m.lockDeleteOrgV2Environment.Unlock()
 
@@ -199,7 +199,7 @@ func (m *EnvironmentsOrgV2Api) DeleteOrgV2EnvironmentCalls() []struct {
 }
 
 // DeleteOrgV2EnvironmentExecute mocks base method by wrapping the associated func.
-func (m *EnvironmentsOrgV2Api) DeleteOrgV2EnvironmentExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteOrgV2EnvironmentRequest) (*net_http.Response, error) {
+func (m *EnvironmentsOrgV2Api) DeleteOrgV2EnvironmentExecute(r github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiDeleteOrgV2EnvironmentRequest) (*net_http.Response, error) {
 	m.lockDeleteOrgV2EnvironmentExecute.Lock()
 	defer m.lockDeleteOrgV2EnvironmentExecute.Unlock()
 
@@ -208,7 +208,7 @@ func (m *EnvironmentsOrgV2Api) DeleteOrgV2EnvironmentExecute(r github_com_conflu
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteOrgV2EnvironmentRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiDeleteOrgV2EnvironmentRequest
 	}{
 		R: r,
 	}
@@ -228,7 +228,7 @@ func (m *EnvironmentsOrgV2Api) DeleteOrgV2EnvironmentExecuteCalled() bool {
 
 // DeleteOrgV2EnvironmentExecuteCalls returns the calls made to DeleteOrgV2EnvironmentExecute.
 func (m *EnvironmentsOrgV2Api) DeleteOrgV2EnvironmentExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiDeleteOrgV2EnvironmentRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiDeleteOrgV2EnvironmentRequest
 } {
 	m.lockDeleteOrgV2EnvironmentExecute.Lock()
 	defer m.lockDeleteOrgV2EnvironmentExecute.Unlock()
@@ -237,7 +237,7 @@ func (m *EnvironmentsOrgV2Api) DeleteOrgV2EnvironmentExecuteCalls() []struct {
 }
 
 // GetOrgV2Environment mocks base method by wrapping the associated func.
-func (m *EnvironmentsOrgV2Api) GetOrgV2Environment(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiGetOrgV2EnvironmentRequest {
+func (m *EnvironmentsOrgV2Api) GetOrgV2Environment(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiGetOrgV2EnvironmentRequest {
 	m.lockGetOrgV2Environment.Lock()
 	defer m.lockGetOrgV2Environment.Unlock()
 
@@ -278,7 +278,7 @@ func (m *EnvironmentsOrgV2Api) GetOrgV2EnvironmentCalls() []struct {
 }
 
 // GetOrgV2EnvironmentExecute mocks base method by wrapping the associated func.
-func (m *EnvironmentsOrgV2Api) GetOrgV2EnvironmentExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiGetOrgV2EnvironmentRequest) (github_com_confluentinc_ccloud_sdk_go_v2.OrgV2Environment, *net_http.Response, error) {
+func (m *EnvironmentsOrgV2Api) GetOrgV2EnvironmentExecute(r github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiGetOrgV2EnvironmentRequest) (github_com_confluentinc_ccloud_sdk_go_v2_org_v2.OrgV2Environment, *net_http.Response, error) {
 	m.lockGetOrgV2EnvironmentExecute.Lock()
 	defer m.lockGetOrgV2EnvironmentExecute.Unlock()
 
@@ -287,7 +287,7 @@ func (m *EnvironmentsOrgV2Api) GetOrgV2EnvironmentExecute(r github_com_confluent
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiGetOrgV2EnvironmentRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiGetOrgV2EnvironmentRequest
 	}{
 		R: r,
 	}
@@ -307,7 +307,7 @@ func (m *EnvironmentsOrgV2Api) GetOrgV2EnvironmentExecuteCalled() bool {
 
 // GetOrgV2EnvironmentExecuteCalls returns the calls made to GetOrgV2EnvironmentExecute.
 func (m *EnvironmentsOrgV2Api) GetOrgV2EnvironmentExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiGetOrgV2EnvironmentRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiGetOrgV2EnvironmentRequest
 } {
 	m.lockGetOrgV2EnvironmentExecute.Lock()
 	defer m.lockGetOrgV2EnvironmentExecute.Unlock()
@@ -316,7 +316,7 @@ func (m *EnvironmentsOrgV2Api) GetOrgV2EnvironmentExecuteCalls() []struct {
 }
 
 // ListOrgV2Environments mocks base method by wrapping the associated func.
-func (m *EnvironmentsOrgV2Api) ListOrgV2Environments(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2.ApiListOrgV2EnvironmentsRequest {
+func (m *EnvironmentsOrgV2Api) ListOrgV2Environments(ctx context.Context) github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiListOrgV2EnvironmentsRequest {
 	m.lockListOrgV2Environments.Lock()
 	defer m.lockListOrgV2Environments.Unlock()
 
@@ -354,7 +354,7 @@ func (m *EnvironmentsOrgV2Api) ListOrgV2EnvironmentsCalls() []struct {
 }
 
 // ListOrgV2EnvironmentsExecute mocks base method by wrapping the associated func.
-func (m *EnvironmentsOrgV2Api) ListOrgV2EnvironmentsExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiListOrgV2EnvironmentsRequest) (github_com_confluentinc_ccloud_sdk_go_v2.OrgV2EnvironmentList, *net_http.Response, error) {
+func (m *EnvironmentsOrgV2Api) ListOrgV2EnvironmentsExecute(r github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiListOrgV2EnvironmentsRequest) (github_com_confluentinc_ccloud_sdk_go_v2_org_v2.OrgV2EnvironmentList, *net_http.Response, error) {
 	m.lockListOrgV2EnvironmentsExecute.Lock()
 	defer m.lockListOrgV2EnvironmentsExecute.Unlock()
 
@@ -363,7 +363,7 @@ func (m *EnvironmentsOrgV2Api) ListOrgV2EnvironmentsExecute(r github_com_conflue
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiListOrgV2EnvironmentsRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiListOrgV2EnvironmentsRequest
 	}{
 		R: r,
 	}
@@ -383,7 +383,7 @@ func (m *EnvironmentsOrgV2Api) ListOrgV2EnvironmentsExecuteCalled() bool {
 
 // ListOrgV2EnvironmentsExecuteCalls returns the calls made to ListOrgV2EnvironmentsExecute.
 func (m *EnvironmentsOrgV2Api) ListOrgV2EnvironmentsExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiListOrgV2EnvironmentsRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiListOrgV2EnvironmentsRequest
 } {
 	m.lockListOrgV2EnvironmentsExecute.Lock()
 	defer m.lockListOrgV2EnvironmentsExecute.Unlock()
@@ -392,7 +392,7 @@ func (m *EnvironmentsOrgV2Api) ListOrgV2EnvironmentsExecuteCalls() []struct {
 }
 
 // UpdateOrgV2Environment mocks base method by wrapping the associated func.
-func (m *EnvironmentsOrgV2Api) UpdateOrgV2Environment(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateOrgV2EnvironmentRequest {
+func (m *EnvironmentsOrgV2Api) UpdateOrgV2Environment(ctx context.Context, id string) github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiUpdateOrgV2EnvironmentRequest {
 	m.lockUpdateOrgV2Environment.Lock()
 	defer m.lockUpdateOrgV2Environment.Unlock()
 
@@ -433,7 +433,7 @@ func (m *EnvironmentsOrgV2Api) UpdateOrgV2EnvironmentCalls() []struct {
 }
 
 // UpdateOrgV2EnvironmentExecute mocks base method by wrapping the associated func.
-func (m *EnvironmentsOrgV2Api) UpdateOrgV2EnvironmentExecute(r github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateOrgV2EnvironmentRequest) (github_com_confluentinc_ccloud_sdk_go_v2.OrgV2Environment, *net_http.Response, error) {
+func (m *EnvironmentsOrgV2Api) UpdateOrgV2EnvironmentExecute(r github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiUpdateOrgV2EnvironmentRequest) (github_com_confluentinc_ccloud_sdk_go_v2_org_v2.OrgV2Environment, *net_http.Response, error) {
 	m.lockUpdateOrgV2EnvironmentExecute.Lock()
 	defer m.lockUpdateOrgV2EnvironmentExecute.Unlock()
 
@@ -442,7 +442,7 @@ func (m *EnvironmentsOrgV2Api) UpdateOrgV2EnvironmentExecute(r github_com_conflu
 	}
 
 	call := struct {
-		R github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateOrgV2EnvironmentRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiUpdateOrgV2EnvironmentRequest
 	}{
 		R: r,
 	}
@@ -462,7 +462,7 @@ func (m *EnvironmentsOrgV2Api) UpdateOrgV2EnvironmentExecuteCalled() bool {
 
 // UpdateOrgV2EnvironmentExecuteCalls returns the calls made to UpdateOrgV2EnvironmentExecute.
 func (m *EnvironmentsOrgV2Api) UpdateOrgV2EnvironmentExecuteCalls() []struct {
-	R github_com_confluentinc_ccloud_sdk_go_v2.ApiUpdateOrgV2EnvironmentRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_org_v2.ApiUpdateOrgV2EnvironmentRequest
 } {
 	m.lockUpdateOrgV2EnvironmentExecute.Lock()
 	defer m.lockUpdateOrgV2EnvironmentExecute.Unlock()


### PR DESCRIPTION
### What
We added mocks in #15 but we need to update imports to fix compilation errors like
```
does not contain package [github.com/confluentinc/ccloud-sdk-go-v2](http://github.com/confluentinc/ccloud-sdk-go-v2) error (the whole v2 is not an actual package?)
```

Sample diff:
![image](https://user-images.githubusercontent.com/5459870/153367033-9825d327-e3b6-474e-8059-74fa89c6f602.png)
