### PR TITLE
Fix imports for `kafkarest/v3/mock`

### DIFF
--- a/kafkarest/go.mod
+++ b/kafkarest/go.mod
@@ -2,7 +2,4 @@ module github.com/confluentinc/ccloud-sdk-go-v2/kafkarest
 
 go 1.13
 
-require (
-	github.com/golang/mock v1.4.4 // indirect
-	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99
-)
+require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/kafkarest/go.sum
+++ b/kafkarest/go.sum
@@ -33,8 +33,6 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
-github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -59,9 +57,7 @@ github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFU
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
-github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
-github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -74,6 +70,7 @@ github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrU
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
+github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -83,6 +80,7 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -152,11 +150,9 @@ golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e h1:bRhVy7zSSasaqNksaRZiA5EEI+Ei4I1nO5Jh72wfHlg=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -180,10 +176,10 @@ golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -269,7 +265,6 @@ golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.0.0-20200825202427-b303f430e36d h1:W07d4xkoAUSNOkOzdzXCdFGxT7o2rW4q8M34tB2i//k=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -293,11 +288,11 @@ google.golang.org/api v0.28.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0M
 google.golang.org/api v0.29.0/go.mod h1:Lcubydp8VUV7KeIHD9z2Bys/sm/vGKnG1UHuDBSrHWM=
 google.golang.org/api v0.30.0/go.mod h1:QGmEvQ87FHZNiUVJkT14jQNYJ4ZJjdRF23ZXz5138Fc=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
-google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -349,6 +344,7 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
+google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/kafkarest/v3/mock/api_aclv3.go
+++ b/kafkarest/v3/mock/api_aclv3.go
@@ -5,31 +5,32 @@
 package mock
 
 import (
-	command_line_arguments "command-line-arguments"
 	context "context"
 	net_http "net/http"
 	sync "sync"
+
+	github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3 "github.com/confluentinc/ccloud-sdk-go-v2/kafkarest/v3"
 )
 
 // ACLV3Api is a mock of ACLV3Api interface
 type ACLV3Api struct {
 	lockCreateKafkaAcls sync.Mutex
-	CreateKafkaAclsFunc func(ctx context.Context, clusterId string) command_line_arguments.ApiCreateKafkaAclsRequest
+	CreateKafkaAclsFunc func(ctx context.Context, clusterId string) github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiCreateKafkaAclsRequest
 
 	lockCreateKafkaAclsExecute sync.Mutex
-	CreateKafkaAclsExecuteFunc func(r command_line_arguments.ApiCreateKafkaAclsRequest) (*net_http.Response, error)
+	CreateKafkaAclsExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiCreateKafkaAclsRequest) (*net_http.Response, error)
 
 	lockDeleteKafkaAcls sync.Mutex
-	DeleteKafkaAclsFunc func(ctx context.Context, clusterId string) command_line_arguments.ApiDeleteKafkaAclsRequest
+	DeleteKafkaAclsFunc func(ctx context.Context, clusterId string) github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiDeleteKafkaAclsRequest
 
 	lockDeleteKafkaAclsExecute sync.Mutex
-	DeleteKafkaAclsExecuteFunc func(r command_line_arguments.ApiDeleteKafkaAclsRequest) (command_line_arguments.InlineResponse200, *net_http.Response, error)
+	DeleteKafkaAclsExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiDeleteKafkaAclsRequest) (github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.InlineResponse200, *net_http.Response, error)
 
 	lockGetKafkaAcls sync.Mutex
-	GetKafkaAclsFunc func(ctx context.Context, clusterId string) command_line_arguments.ApiGetKafkaAclsRequest
+	GetKafkaAclsFunc func(ctx context.Context, clusterId string) github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiGetKafkaAclsRequest
 
 	lockGetKafkaAclsExecute sync.Mutex
-	GetKafkaAclsExecuteFunc func(r command_line_arguments.ApiGetKafkaAclsRequest) (command_line_arguments.AclDataList, *net_http.Response, error)
+	GetKafkaAclsExecuteFunc func(r github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiGetKafkaAclsRequest) (github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.AclDataList, *net_http.Response, error)
 
 	calls struct {
 		CreateKafkaAcls []struct {
@@ -37,27 +38,27 @@ type ACLV3Api struct {
 			ClusterId string
 		}
 		CreateKafkaAclsExecute []struct {
-			R command_line_arguments.ApiCreateKafkaAclsRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiCreateKafkaAclsRequest
 		}
 		DeleteKafkaAcls []struct {
 			Ctx       context.Context
 			ClusterId string
 		}
 		DeleteKafkaAclsExecute []struct {
-			R command_line_arguments.ApiDeleteKafkaAclsRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiDeleteKafkaAclsRequest
 		}
 		GetKafkaAcls []struct {
 			Ctx       context.Context
 			ClusterId string
 		}
 		GetKafkaAclsExecute []struct {
-			R command_line_arguments.ApiGetKafkaAclsRequest
+			R github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiGetKafkaAclsRequest
 		}
 	}
 }
 
 // CreateKafkaAcls mocks base method by wrapping the associated func.
-func (m *ACLV3Api) CreateKafkaAcls(ctx context.Context, clusterId string) command_line_arguments.ApiCreateKafkaAclsRequest {
+func (m *ACLV3Api) CreateKafkaAcls(ctx context.Context, clusterId string) github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiCreateKafkaAclsRequest {
 	m.lockCreateKafkaAcls.Lock()
 	defer m.lockCreateKafkaAcls.Unlock()
 
@@ -98,7 +99,7 @@ func (m *ACLV3Api) CreateKafkaAclsCalls() []struct {
 }
 
 // CreateKafkaAclsExecute mocks base method by wrapping the associated func.
-func (m *ACLV3Api) CreateKafkaAclsExecute(r command_line_arguments.ApiCreateKafkaAclsRequest) (*net_http.Response, error) {
+func (m *ACLV3Api) CreateKafkaAclsExecute(r github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiCreateKafkaAclsRequest) (*net_http.Response, error) {
 	m.lockCreateKafkaAclsExecute.Lock()
 	defer m.lockCreateKafkaAclsExecute.Unlock()
 
@@ -107,7 +108,7 @@ func (m *ACLV3Api) CreateKafkaAclsExecute(r command_line_arguments.ApiCreateKafk
 	}
 
 	call := struct {
-		R command_line_arguments.ApiCreateKafkaAclsRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiCreateKafkaAclsRequest
 	}{
 		R: r,
 	}
@@ -127,7 +128,7 @@ func (m *ACLV3Api) CreateKafkaAclsExecuteCalled() bool {
 
 // CreateKafkaAclsExecuteCalls returns the calls made to CreateKafkaAclsExecute.
 func (m *ACLV3Api) CreateKafkaAclsExecuteCalls() []struct {
-	R command_line_arguments.ApiCreateKafkaAclsRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiCreateKafkaAclsRequest
 } {
 	m.lockCreateKafkaAclsExecute.Lock()
 	defer m.lockCreateKafkaAclsExecute.Unlock()
@@ -136,7 +137,7 @@ func (m *ACLV3Api) CreateKafkaAclsExecuteCalls() []struct {
 }
 
 // DeleteKafkaAcls mocks base method by wrapping the associated func.
-func (m *ACLV3Api) DeleteKafkaAcls(ctx context.Context, clusterId string) command_line_arguments.ApiDeleteKafkaAclsRequest {
+func (m *ACLV3Api) DeleteKafkaAcls(ctx context.Context, clusterId string) github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiDeleteKafkaAclsRequest {
 	m.lockDeleteKafkaAcls.Lock()
 	defer m.lockDeleteKafkaAcls.Unlock()
 
@@ -177,7 +178,7 @@ func (m *ACLV3Api) DeleteKafkaAclsCalls() []struct {
 }
 
 // DeleteKafkaAclsExecute mocks base method by wrapping the associated func.
-func (m *ACLV3Api) DeleteKafkaAclsExecute(r command_line_arguments.ApiDeleteKafkaAclsRequest) (command_line_arguments.InlineResponse200, *net_http.Response, error) {
+func (m *ACLV3Api) DeleteKafkaAclsExecute(r github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiDeleteKafkaAclsRequest) (github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.InlineResponse200, *net_http.Response, error) {
 	m.lockDeleteKafkaAclsExecute.Lock()
 	defer m.lockDeleteKafkaAclsExecute.Unlock()
 
@@ -186,7 +187,7 @@ func (m *ACLV3Api) DeleteKafkaAclsExecute(r command_line_arguments.ApiDeleteKafk
 	}
 
 	call := struct {
-		R command_line_arguments.ApiDeleteKafkaAclsRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiDeleteKafkaAclsRequest
 	}{
 		R: r,
 	}
@@ -206,7 +207,7 @@ func (m *ACLV3Api) DeleteKafkaAclsExecuteCalled() bool {
 
 // DeleteKafkaAclsExecuteCalls returns the calls made to DeleteKafkaAclsExecute.
 func (m *ACLV3Api) DeleteKafkaAclsExecuteCalls() []struct {
-	R command_line_arguments.ApiDeleteKafkaAclsRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiDeleteKafkaAclsRequest
 } {
 	m.lockDeleteKafkaAclsExecute.Lock()
 	defer m.lockDeleteKafkaAclsExecute.Unlock()
@@ -215,7 +216,7 @@ func (m *ACLV3Api) DeleteKafkaAclsExecuteCalls() []struct {
 }
 
 // GetKafkaAcls mocks base method by wrapping the associated func.
-func (m *ACLV3Api) GetKafkaAcls(ctx context.Context, clusterId string) command_line_arguments.ApiGetKafkaAclsRequest {
+func (m *ACLV3Api) GetKafkaAcls(ctx context.Context, clusterId string) github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiGetKafkaAclsRequest {
 	m.lockGetKafkaAcls.Lock()
 	defer m.lockGetKafkaAcls.Unlock()
 
@@ -256,7 +257,7 @@ func (m *ACLV3Api) GetKafkaAclsCalls() []struct {
 }
 
 // GetKafkaAclsExecute mocks base method by wrapping the associated func.
-func (m *ACLV3Api) GetKafkaAclsExecute(r command_line_arguments.ApiGetKafkaAclsRequest) (command_line_arguments.AclDataList, *net_http.Response, error) {
+func (m *ACLV3Api) GetKafkaAclsExecute(r github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiGetKafkaAclsRequest) (github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.AclDataList, *net_http.Response, error) {
 	m.lockGetKafkaAclsExecute.Lock()
 	defer m.lockGetKafkaAclsExecute.Unlock()
 
@@ -265,7 +266,7 @@ func (m *ACLV3Api) GetKafkaAclsExecute(r command_line_arguments.ApiGetKafkaAclsR
 	}
 
 	call := struct {
-		R command_line_arguments.ApiGetKafkaAclsRequest
+		R github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiGetKafkaAclsRequest
 	}{
 		R: r,
 	}
@@ -285,7 +286,7 @@ func (m *ACLV3Api) GetKafkaAclsExecuteCalled() bool {
 
 // GetKafkaAclsExecuteCalls returns the calls made to GetKafkaAclsExecute.
 func (m *ACLV3Api) GetKafkaAclsExecuteCalls() []struct {
-	R command_line_arguments.ApiGetKafkaAclsRequest
+	R github_com_confluentinc_ccloud_sdk_go_v2_kafkarest_v3.ApiGetKafkaAclsRequest
 } {
 	m.lockGetKafkaAclsExecute.Lock()
 	defer m.lockGetKafkaAclsExecute.Unlock()


### PR DESCRIPTION
Previously, `mocker` was giving us a non-existent import:
```
command_line_arguments "command-line-arguments"
```

After the following steps, this has been fixed.
1. Move `go.mod` and `go.sum` into the `v3/` directory.
2. Append `/v3` to the module name in `go.mod`.
3. Run `mocker --prefix "" --dst mock/api_aclv3.go --pkg mock api_aclv3.go ACLV3Api`