### PR TITLE
KGLOBAL-2124: Add new link error fields to the cloud Go SDK

### DIFF
--- a/kafkarest/go.mod
+++ b/kafkarest/go.mod
@@ -2,4 +2,6 @@ module github.com/confluentinc/ccloud-sdk-go-v2/kafkarest
 
 go 1.13
 
-require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99
+require (
+	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99
+)

--- a/kafkarest/v3/api/openapi.yaml
+++ b/kafkarest/v3/api/openapi.yaml
@@ -15536,9 +15536,31 @@ components:
           items:
             type: string
           type: array
+        link_error:
+          type: string
+          x-extensible-enum:
+          - UNKNOWN
+          - NO_ERROR
+          - AUTHENTICATION_ERROR
+          - UNRESOLVABLE_BOOTSTRAP_ERROR
+          - INVALID_BOOTSTRAP_INTERNAL_ENDPOINT_ERROR
+          - BOOTSTRAP_TCP_CONNECTION_FAILED_ERROR
+          - TIMEOUT_ERROR
+        link_error_message:
+          type: string
+        link_state:
+          type: string
+          x-extensible-enum:
+          - ACTIVE
+          - FAILED
+          - UNAVAILABLE
+          - PAUSED
       required:
+      - link_error
+      - link_error_message
       - link_id
       - link_name
+      - link_state
       - topic_names
       type: object
     ListLinksResponseDataList_allOf:

--- a/kafkarest/v3/docs/ListLinksResponseData.md
+++ b/kafkarest/v3/docs/ListLinksResponseData.md
@@ -11,12 +11,15 @@ Name | Type | Description | Notes
 **LinkName** | **string** |  | 
 **LinkId** | **string** |  | 
 **TopicsNames** | Pointer to **[]string** |  | [optional] 
+**LinkError** | **string** |  | 
+**LinkErrorMessage** | **string** |  | 
+**LinkState** | **string** |  | 
 
 ## Methods
 
 ### NewListLinksResponseData
 
-`func NewListLinksResponseData(kind string, metadata ResourceMetadata, linkName string, linkId string, ) *ListLinksResponseData`
+`func NewListLinksResponseData(kind string, metadata ResourceMetadata, linkName string, linkId string, linkError string, linkErrorMessage string, linkState string, ) *ListLinksResponseData`
 
 NewListLinksResponseData instantiates a new ListLinksResponseData object
 This constructor will assign default values to properties that have it defined,
@@ -205,6 +208,66 @@ SetTopicsNames sets TopicsNames field to given value.
 `func (o *ListLinksResponseData) HasTopicsNames() bool`
 
 HasTopicsNames returns a boolean if a field has been set.
+
+### GetLinkError
+
+`func (o *ListLinksResponseData) GetLinkError() string`
+
+GetLinkError returns the LinkError field if non-nil, zero value otherwise.
+
+### GetLinkErrorOk
+
+`func (o *ListLinksResponseData) GetLinkErrorOk() (*string, bool)`
+
+GetLinkErrorOk returns a tuple with the LinkError field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetLinkError
+
+`func (o *ListLinksResponseData) SetLinkError(v string)`
+
+SetLinkError sets LinkError field to given value.
+
+
+### GetLinkErrorMessage
+
+`func (o *ListLinksResponseData) GetLinkErrorMessage() string`
+
+GetLinkErrorMessage returns the LinkErrorMessage field if non-nil, zero value otherwise.
+
+### GetLinkErrorMessageOk
+
+`func (o *ListLinksResponseData) GetLinkErrorMessageOk() (*string, bool)`
+
+GetLinkErrorMessageOk returns a tuple with the LinkErrorMessage field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetLinkErrorMessage
+
+`func (o *ListLinksResponseData) SetLinkErrorMessage(v string)`
+
+SetLinkErrorMessage sets LinkErrorMessage field to given value.
+
+
+### GetLinkState
+
+`func (o *ListLinksResponseData) GetLinkState() string`
+
+GetLinkState returns the LinkState field if non-nil, zero value otherwise.
+
+### GetLinkStateOk
+
+`func (o *ListLinksResponseData) GetLinkStateOk() (*string, bool)`
+
+GetLinkStateOk returns a tuple with the LinkState field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetLinkState
+
+`func (o *ListLinksResponseData) SetLinkState(v string)`
+
+SetLinkState sets LinkState field to given value.
+
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/kafkarest/v3/docs/ListLinksResponseDataAllOf.md
+++ b/kafkarest/v3/docs/ListLinksResponseDataAllOf.md
@@ -9,12 +9,15 @@ Name | Type | Description | Notes
 **LinkName** | **string** |  | 
 **LinkId** | **string** |  | 
 **TopicsNames** | Pointer to **[]string** |  | [optional] 
+**LinkError** | **string** |  | 
+**LinkErrorMessage** | **string** |  | 
+**LinkState** | **string** |  | 
 
 ## Methods
 
 ### NewListLinksResponseDataAllOf
 
-`func NewListLinksResponseDataAllOf(linkName string, linkId string, ) *ListLinksResponseDataAllOf`
+`func NewListLinksResponseDataAllOf(linkName string, linkId string, linkError string, linkErrorMessage string, linkState string, ) *ListLinksResponseDataAllOf`
 
 NewListLinksResponseDataAllOf instantiates a new ListLinksResponseDataAllOf object
 This constructor will assign default values to properties that have it defined,
@@ -163,6 +166,66 @@ SetTopicsNames sets TopicsNames field to given value.
 `func (o *ListLinksResponseDataAllOf) HasTopicsNames() bool`
 
 HasTopicsNames returns a boolean if a field has been set.
+
+### GetLinkError
+
+`func (o *ListLinksResponseDataAllOf) GetLinkError() string`
+
+GetLinkError returns the LinkError field if non-nil, zero value otherwise.
+
+### GetLinkErrorOk
+
+`func (o *ListLinksResponseDataAllOf) GetLinkErrorOk() (*string, bool)`
+
+GetLinkErrorOk returns a tuple with the LinkError field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetLinkError
+
+`func (o *ListLinksResponseDataAllOf) SetLinkError(v string)`
+
+SetLinkError sets LinkError field to given value.
+
+
+### GetLinkErrorMessage
+
+`func (o *ListLinksResponseDataAllOf) GetLinkErrorMessage() string`
+
+GetLinkErrorMessage returns the LinkErrorMessage field if non-nil, zero value otherwise.
+
+### GetLinkErrorMessageOk
+
+`func (o *ListLinksResponseDataAllOf) GetLinkErrorMessageOk() (*string, bool)`
+
+GetLinkErrorMessageOk returns a tuple with the LinkErrorMessage field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetLinkErrorMessage
+
+`func (o *ListLinksResponseDataAllOf) SetLinkErrorMessage(v string)`
+
+SetLinkErrorMessage sets LinkErrorMessage field to given value.
+
+
+### GetLinkState
+
+`func (o *ListLinksResponseDataAllOf) GetLinkState() string`
+
+GetLinkState returns the LinkState field if non-nil, zero value otherwise.
+
+### GetLinkStateOk
+
+`func (o *ListLinksResponseDataAllOf) GetLinkStateOk() (*string, bool)`
+
+GetLinkStateOk returns a tuple with the LinkState field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetLinkState
+
+`func (o *ListLinksResponseDataAllOf) SetLinkState(v string)`
+
+SetLinkState sets LinkState field to given value.
+
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/kafkarest/v3/model_list_links_response_data.go
+++ b/kafkarest/v3/model_list_links_response_data.go
@@ -42,18 +42,24 @@ type ListLinksResponseData struct {
 	LinkName             string           `json:"link_name"`
 	LinkId               string           `json:"link_id"`
 	TopicsNames          *[]string        `json:"topics_names,omitempty"`
+	LinkError            string           `json:"link_error"`
+	LinkErrorMessage     string           `json:"link_error_message"`
+	LinkState            string           `json:"link_state"`
 }
 
 // NewListLinksResponseData instantiates a new ListLinksResponseData object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewListLinksResponseData(kind string, metadata ResourceMetadata, linkName string, linkId string) *ListLinksResponseData {
+func NewListLinksResponseData(kind string, metadata ResourceMetadata, linkName string, linkId string, linkError string, linkErrorMessage string, linkState string) *ListLinksResponseData {
 	this := ListLinksResponseData{}
 	this.Kind = kind
 	this.Metadata = metadata
 	this.LinkName = linkName
 	this.LinkId = linkId
+	this.LinkError = linkError
+	this.LinkErrorMessage = linkErrorMessage
+	this.LinkState = linkState
 	return &this
 }
 
@@ -279,6 +285,78 @@ func (o *ListLinksResponseData) SetTopicsNames(v []string) {
 	o.TopicsNames = &v
 }
 
+// GetLinkError returns the LinkError field value
+func (o *ListLinksResponseData) GetLinkError() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.LinkError
+}
+
+// GetLinkErrorOk returns a tuple with the LinkError field value
+// and a boolean to check if the value has been set.
+func (o *ListLinksResponseData) GetLinkErrorOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.LinkError, true
+}
+
+// SetLinkError sets field value
+func (o *ListLinksResponseData) SetLinkError(v string) {
+	o.LinkError = v
+}
+
+// GetLinkErrorMessage returns the LinkErrorMessage field value
+func (o *ListLinksResponseData) GetLinkErrorMessage() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.LinkErrorMessage
+}
+
+// GetLinkErrorMessageOk returns a tuple with the LinkErrorMessage field value
+// and a boolean to check if the value has been set.
+func (o *ListLinksResponseData) GetLinkErrorMessageOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.LinkErrorMessage, true
+}
+
+// SetLinkErrorMessage sets field value
+func (o *ListLinksResponseData) SetLinkErrorMessage(v string) {
+	o.LinkErrorMessage = v
+}
+
+// GetLinkState returns the LinkState field value
+func (o *ListLinksResponseData) GetLinkState() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.LinkState
+}
+
+// GetLinkStateOk returns a tuple with the LinkState field value
+// and a boolean to check if the value has been set.
+func (o *ListLinksResponseData) GetLinkStateOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.LinkState, true
+}
+
+// SetLinkState sets field value
+func (o *ListLinksResponseData) SetLinkState(v string) {
+	o.LinkState = v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *ListLinksResponseData) Redact() {
 	o.recurseRedact(&o.Kind)
@@ -288,6 +366,9 @@ func (o *ListLinksResponseData) Redact() {
 	o.recurseRedact(&o.LinkName)
 	o.recurseRedact(&o.LinkId)
 	o.recurseRedact(o.TopicsNames)
+	o.recurseRedact(&o.LinkError)
+	o.recurseRedact(&o.LinkErrorMessage)
+	o.recurseRedact(&o.LinkState)
 }
 
 func (o *ListLinksResponseData) recurseRedact(v interface{}) {
@@ -342,6 +423,15 @@ func (o ListLinksResponseData) MarshalJSON() ([]byte, error) {
 	}
 	if o.TopicsNames != nil {
 		toSerialize["topics_names"] = o.TopicsNames
+	}
+	if true {
+		toSerialize["link_error"] = o.LinkError
+	}
+	if true {
+		toSerialize["link_error_message"] = o.LinkErrorMessage
+	}
+	if true {
+		toSerialize["link_state"] = o.LinkState
 	}
 	return json.Marshal(toSerialize)
 }

--- a/kafkarest/v3/model_list_links_response_data_all_of.go
+++ b/kafkarest/v3/model_list_links_response_data_all_of.go
@@ -40,16 +40,22 @@ type ListLinksResponseDataAllOf struct {
 	LinkName             string         `json:"link_name"`
 	LinkId               string         `json:"link_id"`
 	TopicsNames          *[]string      `json:"topics_names,omitempty"`
+	LinkError            string         `json:"link_error"`
+	LinkErrorMessage     string         `json:"link_error_message"`
+	LinkState            string         `json:"link_state"`
 }
 
 // NewListLinksResponseDataAllOf instantiates a new ListLinksResponseDataAllOf object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewListLinksResponseDataAllOf(linkName string, linkId string) *ListLinksResponseDataAllOf {
+func NewListLinksResponseDataAllOf(linkName string, linkId string, linkError string, linkErrorMessage string, linkState string) *ListLinksResponseDataAllOf {
 	this := ListLinksResponseDataAllOf{}
 	this.LinkName = linkName
 	this.LinkId = linkId
+	this.LinkError = linkError
+	this.LinkErrorMessage = linkErrorMessage
+	this.LinkState = linkState
 	return &this
 }
 
@@ -227,6 +233,78 @@ func (o *ListLinksResponseDataAllOf) SetTopicsNames(v []string) {
 	o.TopicsNames = &v
 }
 
+// GetLinkError returns the LinkError field value
+func (o *ListLinksResponseDataAllOf) GetLinkError() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.LinkError
+}
+
+// GetLinkErrorOk returns a tuple with the LinkError field value
+// and a boolean to check if the value has been set.
+func (o *ListLinksResponseDataAllOf) GetLinkErrorOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.LinkError, true
+}
+
+// SetLinkError sets field value
+func (o *ListLinksResponseDataAllOf) SetLinkError(v string) {
+	o.LinkError = v
+}
+
+// GetLinkErrorMessage returns the LinkErrorMessage field value
+func (o *ListLinksResponseDataAllOf) GetLinkErrorMessage() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.LinkErrorMessage
+}
+
+// GetLinkErrorMessageOk returns a tuple with the LinkErrorMessage field value
+// and a boolean to check if the value has been set.
+func (o *ListLinksResponseDataAllOf) GetLinkErrorMessageOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.LinkErrorMessage, true
+}
+
+// SetLinkErrorMessage sets field value
+func (o *ListLinksResponseDataAllOf) SetLinkErrorMessage(v string) {
+	o.LinkErrorMessage = v
+}
+
+// GetLinkState returns the LinkState field value
+func (o *ListLinksResponseDataAllOf) GetLinkState() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.LinkState
+}
+
+// GetLinkStateOk returns a tuple with the LinkState field value
+// and a boolean to check if the value has been set.
+func (o *ListLinksResponseDataAllOf) GetLinkStateOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.LinkState, true
+}
+
+// SetLinkState sets field value
+func (o *ListLinksResponseDataAllOf) SetLinkState(v string) {
+	o.LinkState = v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *ListLinksResponseDataAllOf) Redact() {
 	o.recurseRedact(o.SourceClusterId)
@@ -234,6 +312,9 @@ func (o *ListLinksResponseDataAllOf) Redact() {
 	o.recurseRedact(&o.LinkName)
 	o.recurseRedact(&o.LinkId)
 	o.recurseRedact(o.TopicsNames)
+	o.recurseRedact(&o.LinkError)
+	o.recurseRedact(&o.LinkErrorMessage)
+	o.recurseRedact(&o.LinkState)
 }
 
 func (o *ListLinksResponseDataAllOf) recurseRedact(v interface{}) {
@@ -282,6 +363,15 @@ func (o ListLinksResponseDataAllOf) MarshalJSON() ([]byte, error) {
 	}
 	if o.TopicsNames != nil {
 		toSerialize["topics_names"] = o.TopicsNames
+	}
+	if true {
+		toSerialize["link_error"] = o.LinkError
+	}
+	if true {
+		toSerialize["link_error_message"] = o.LinkErrorMessage
+	}
+	if true {
+		toSerialize["link_state"] = o.LinkState
 	}
 	return json.Marshal(toSerialize)
 }


### PR DESCRIPTION
### JIRA

### Details
Copy and pasted the SDK from `ccloud-sdk-go-v2-internal` to here. PR that added the SDK to the internal repo: https://github.com/confluentinc/ccloud-sdk-go-v2-internal/pull/147

### Testing
Ran `go vet -v`