### PR TITLE
Update kafkarest

### DIFF
--- a/kafkarest/v3/api/openapi.yaml
+++ b/kafkarest/v3/api/openapi.yaml
@@ -4149,6 +4149,9 @@ paths:
         [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Creates a topic.
+        Also supports a dry-run mode that only validates whether the topic creation would succeed
+        if the ``validate_only`` request property is explicitly specified and set to true. Note that
+        when dry-run mode is being used the response status would be 200 OK instead of 201 Created.
       operationId: createKafkaTopic
       parameters:
       - description: The Kafka cluster ID.
@@ -4163,6 +4166,28 @@ paths:
       requestBody:
         $ref: '#/components/requestBodies/CreateTopicRequest'
       responses:
+        "200":
+          content:
+            application/json:
+              example:
+                kind: KafkaTopic
+                metadata:
+                  self: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-X
+                  resource_name: crn:///kafka=cluster-1/topic=topic-X
+                cluster_id: cluster-1
+                topic_name: topic-X
+                is_internal: false
+                replication_factor: 3
+                partitions_count: 1
+                partitions:
+                  related: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-X/partitions
+                configs:
+                  related: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-X/configs
+                partition_reassignments:
+                  related: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-X/partitions/-/reassignments
+              schema:
+                $ref: '#/components/schemas/TopicData'
+          description: The created topic.
         "201":
           content:
             application/json:
@@ -5108,6 +5133,8 @@ paths:
         [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Updates or deletes a set of topic configs.
+        Also supports a dry-run mode that only validates whether the operation would succeed if the
+        ``validate_only`` request property is explicitly specified and set to true.
       operationId: updateKafkaTopicConfigBatch
       parameters:
       - description: The Kafka cluster ID.
@@ -11565,12 +11592,22 @@ components:
     AlterTopicConfigBatchRequest:
       content:
         application/json:
-          example:
-            data:
-            - name: cleanup.policy
-              operation: DELETE
-            - name: compression.type
-              value: gzip
+          examples:
+            batch_alter_topic_configs:
+              value:
+                data:
+                - name: cleanup.policy
+                  operation: DELETE
+                - name: compression.type
+                  value: gzip
+            validate_only_batch_alter_topic_configs:
+              value:
+                data:
+                - name: cleanup.policy
+                  operation: DELETE
+                - name: compression.type
+                  value: gzip
+                validate_only: true
           schema:
             $ref: '#/components/schemas/AlterConfigBatchRequestData'
       description: The alter topic configuration parameter batch request.
@@ -11624,6 +11661,12 @@ components:
                   value: compact
                 - name: compression.type
                   value: gzip
+            dry_run_create_topic:
+              value:
+                topic_name: topic-Z
+                partitions_count: 64
+                replication_factor: 3
+                validate_only: true
           schema:
             $ref: '#/components/schemas/CreateTopicRequestData'
       description: The topic creation request. Note that Confluent Cloud allows only
@@ -14036,6 +14079,7 @@ components:
       type: string
     AlterConfigBatchRequestData:
       example:
+        validate_only: true
         data:
         - name: name
           value: value
@@ -14048,6 +14092,8 @@ components:
           items:
             $ref: '#/components/schemas/AlterConfigBatchRequestData_data'
           type: array
+        validate_only:
+          type: boolean
       required:
       - data
       type: object
@@ -14156,6 +14202,7 @@ components:
           value: value
         - name: name
           value: value
+        validate_only: true
         replication_factor: 6
         topic_name: topic_name
         partitions_count: 0
@@ -14170,6 +14217,8 @@ components:
           items:
             $ref: '#/components/schemas/CreateTopicRequestData_configs'
           type: array
+        validate_only:
+          type: boolean
       required:
       - topic_name
       type: object

--- a/kafkarest/v3/api_configs_v3.go
+++ b/kafkarest/v3/api_configs_v3.go
@@ -241,6 +241,8 @@ type ConfigsV3Api interface {
 		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 	Updates or deletes a set of topic configs.
+	Also supports a dry-run mode that only validates whether the operation would succeed if the
+	``validate_only`` request property is explicitly specified and set to true.
 
 		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 		 @param clusterId The Kafka cluster ID.
@@ -1959,6 +1961,8 @@ UpdateKafkaTopicConfigBatch Batch Alter Topic Configs
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Updates or deletes a set of topic configs.
+Also supports a dry-run mode that only validates whether the operation would succeed if the
+“validate_only“ request property is explicitly specified and set to true.
 
 	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param clusterId The Kafka cluster ID.

--- a/kafkarest/v3/api_topic_v3.go
+++ b/kafkarest/v3/api_topic_v3.go
@@ -47,6 +47,9 @@ type TopicV3Api interface {
 		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 	Creates a topic.
+	Also supports a dry-run mode that only validates whether the topic creation would succeed
+	if the ``validate_only`` request property is explicitly specified and set to true. Note that
+	when dry-run mode is being used the response status would be 200 OK instead of 201 Created.
 
 		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 		 @param clusterId The Kafka cluster ID.
@@ -137,6 +140,9 @@ CreateKafkaTopic Create Topic
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Creates a topic.
+Also supports a dry-run mode that only validates whether the topic creation would succeed
+if the “validate_only“ request property is explicitly specified and set to true. Note that
+when dry-run mode is being used the response status would be 200 OK instead of 201 Created.
 
 	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param clusterId The Kafka cluster ID.

--- a/kafkarest/v3/docs/AlterConfigBatchRequestData.md
+++ b/kafkarest/v3/docs/AlterConfigBatchRequestData.md
@@ -5,6 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Data** | [**[]AlterConfigBatchRequestDataData**](AlterConfigBatchRequestDataData.md) |  | 
+**ValidateOnly** | Pointer to **bool** |  | [optional] 
 
 ## Methods
 
@@ -44,6 +45,31 @@ and a boolean to check if the value has been set.
 
 SetData sets Data field to given value.
 
+
+### GetValidateOnly
+
+`func (o *AlterConfigBatchRequestData) GetValidateOnly() bool`
+
+GetValidateOnly returns the ValidateOnly field if non-nil, zero value otherwise.
+
+### GetValidateOnlyOk
+
+`func (o *AlterConfigBatchRequestData) GetValidateOnlyOk() (*bool, bool)`
+
+GetValidateOnlyOk returns a tuple with the ValidateOnly field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetValidateOnly
+
+`func (o *AlterConfigBatchRequestData) SetValidateOnly(v bool)`
+
+SetValidateOnly sets ValidateOnly field to given value.
+
+### HasValidateOnly
+
+`func (o *AlterConfigBatchRequestData) HasValidateOnly() bool`
+
+HasValidateOnly returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/kafkarest/v3/docs/CreateTopicRequestData.md
+++ b/kafkarest/v3/docs/CreateTopicRequestData.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 **PartitionsCount** | Pointer to **int32** |  | [optional] 
 **ReplicationFactor** | Pointer to **int32** |  | [optional] 
 **Configs** | Pointer to [**[]CreateTopicRequestDataConfigs**](CreateTopicRequestDataConfigs.md) |  | [optional] 
+**ValidateOnly** | Pointer to **bool** |  | [optional] 
 
 ## Methods
 
@@ -122,6 +123,31 @@ SetConfigs sets Configs field to given value.
 `func (o *CreateTopicRequestData) HasConfigs() bool`
 
 HasConfigs returns a boolean if a field has been set.
+
+### GetValidateOnly
+
+`func (o *CreateTopicRequestData) GetValidateOnly() bool`
+
+GetValidateOnly returns the ValidateOnly field if non-nil, zero value otherwise.
+
+### GetValidateOnlyOk
+
+`func (o *CreateTopicRequestData) GetValidateOnlyOk() (*bool, bool)`
+
+GetValidateOnlyOk returns a tuple with the ValidateOnly field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetValidateOnly
+
+`func (o *CreateTopicRequestData) SetValidateOnly(v bool)`
+
+SetValidateOnly sets ValidateOnly field to given value.
+
+### HasValidateOnly
+
+`func (o *CreateTopicRequestData) HasValidateOnly() bool`
+
+HasValidateOnly returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/kafkarest/v3/model_alter_config_batch_request_data.go
+++ b/kafkarest/v3/model_alter_config_batch_request_data.go
@@ -35,7 +35,8 @@ import (
 
 // AlterConfigBatchRequestData struct for AlterConfigBatchRequestData
 type AlterConfigBatchRequestData struct {
-	Data []AlterConfigBatchRequestDataData `json:"data"`
+	Data         []AlterConfigBatchRequestDataData `json:"data"`
+	ValidateOnly *bool                             `json:"validate_only,omitempty"`
 }
 
 // NewAlterConfigBatchRequestData instantiates a new AlterConfigBatchRequestData object
@@ -80,9 +81,42 @@ func (o *AlterConfigBatchRequestData) SetData(v []AlterConfigBatchRequestDataDat
 	o.Data = v
 }
 
+// GetValidateOnly returns the ValidateOnly field value if set, zero value otherwise.
+func (o *AlterConfigBatchRequestData) GetValidateOnly() bool {
+	if o == nil || o.ValidateOnly == nil {
+		var ret bool
+		return ret
+	}
+	return *o.ValidateOnly
+}
+
+// GetValidateOnlyOk returns a tuple with the ValidateOnly field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *AlterConfigBatchRequestData) GetValidateOnlyOk() (*bool, bool) {
+	if o == nil || o.ValidateOnly == nil {
+		return nil, false
+	}
+	return o.ValidateOnly, true
+}
+
+// HasValidateOnly returns a boolean if a field has been set.
+func (o *AlterConfigBatchRequestData) HasValidateOnly() bool {
+	if o != nil && o.ValidateOnly != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetValidateOnly gets a reference to the given bool and assigns it to the ValidateOnly field.
+func (o *AlterConfigBatchRequestData) SetValidateOnly(v bool) {
+	o.ValidateOnly = &v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *AlterConfigBatchRequestData) Redact() {
 	o.recurseRedact(&o.Data)
+	o.recurseRedact(o.ValidateOnly)
 }
 
 func (o *AlterConfigBatchRequestData) recurseRedact(v interface{}) {
@@ -119,6 +153,9 @@ func (o AlterConfigBatchRequestData) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if true {
 		toSerialize["data"] = o.Data
+	}
+	if o.ValidateOnly != nil {
+		toSerialize["validate_only"] = o.ValidateOnly
 	}
 	return json.Marshal(toSerialize)
 }

--- a/kafkarest/v3/model_create_topic_request_data.go
+++ b/kafkarest/v3/model_create_topic_request_data.go
@@ -39,6 +39,7 @@ type CreateTopicRequestData struct {
 	PartitionsCount   *int32                           `json:"partitions_count,omitempty"`
 	ReplicationFactor *int32                           `json:"replication_factor,omitempty"`
 	Configs           *[]CreateTopicRequestDataConfigs `json:"configs,omitempty"`
+	ValidateOnly      *bool                            `json:"validate_only,omitempty"`
 }
 
 // NewCreateTopicRequestData instantiates a new CreateTopicRequestData object
@@ -179,12 +180,45 @@ func (o *CreateTopicRequestData) SetConfigs(v []CreateTopicRequestDataConfigs) {
 	o.Configs = &v
 }
 
+// GetValidateOnly returns the ValidateOnly field value if set, zero value otherwise.
+func (o *CreateTopicRequestData) GetValidateOnly() bool {
+	if o == nil || o.ValidateOnly == nil {
+		var ret bool
+		return ret
+	}
+	return *o.ValidateOnly
+}
+
+// GetValidateOnlyOk returns a tuple with the ValidateOnly field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *CreateTopicRequestData) GetValidateOnlyOk() (*bool, bool) {
+	if o == nil || o.ValidateOnly == nil {
+		return nil, false
+	}
+	return o.ValidateOnly, true
+}
+
+// HasValidateOnly returns a boolean if a field has been set.
+func (o *CreateTopicRequestData) HasValidateOnly() bool {
+	if o != nil && o.ValidateOnly != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetValidateOnly gets a reference to the given bool and assigns it to the ValidateOnly field.
+func (o *CreateTopicRequestData) SetValidateOnly(v bool) {
+	o.ValidateOnly = &v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *CreateTopicRequestData) Redact() {
 	o.recurseRedact(&o.TopicName)
 	o.recurseRedact(o.PartitionsCount)
 	o.recurseRedact(o.ReplicationFactor)
 	o.recurseRedact(o.Configs)
+	o.recurseRedact(o.ValidateOnly)
 }
 
 func (o *CreateTopicRequestData) recurseRedact(v interface{}) {
@@ -230,6 +264,9 @@ func (o CreateTopicRequestData) MarshalJSON() ([]byte, error) {
 	}
 	if o.Configs != nil {
 		toSerialize["configs"] = o.Configs
+	}
+	if o.ValidateOnly != nil {
+		toSerialize["validate_only"] = o.ValidateOnly
 	}
 	return json.Marshal(toSerialize)
 }


### PR DESCRIPTION
```
internal/unsafeheader
internal/race
internal/goos
internal/goarch
internal/goexperiment
internal/itoa
runtime/internal/math
unicode/utf8
unicode
encoding
crypto/internal/subtle
unicode/utf16
math/bits
runtime/internal/sys
crypto/subtle
vendor/golang.org/x/crypto/cryptobyte/asn1
container/list
internal/nettrace
vendor/golang.org/x/crypto/internal/subtle
runtime/internal/atomic
internal/cpu
internal/abi
sync/atomic
crypto/internal/boring/sig
internal/bytealg
math
runtime
internal/reflectlite
errors
sync
internal/oserror
sort
path
internal/testlog
io
math/rand
vendor/golang.org/x/net/dns/dnsmessage
hash
internal/singleflight
crypto/internal/randutil
bytes
strings
strconv
syscall
crypto/internal/nistec/fiat
hash/crc32
vendor/golang.org/x/text/transform
crypto/rc4
internal/syscall/execenv
crypto
bufio
internal/syscall/unix
net/http/internal/ascii
reflect
internal/fmtsort
time
encoding/binary
regexp/syntax
context
encoding/base64
encoding/pem
crypto/internal/edwards25519/field
io/fs
crypto/md5
crypto/cipher
vendor/golang.org/x/crypto/internal/poly1305
embed
vendor/golang.org/x/crypto/curve25519/internal/field
crypto/internal/edwards25519
regexp
vendor/golang.org/x/crypto/chacha20
crypto/internal/boring
crypto/des
internal/poll
crypto/hmac
crypto/internal/nistec
crypto/sha512
crypto/sha1
crypto/sha256
vendor/golang.org/x/crypto/hkdf
crypto/aes
os
internal/godebug
io/ioutil
path/filepath
vendor/golang.org/x/sys/cpu
internal/intern
fmt
vendor/golang.org/x/net/route
net/netip
crypto/x509/internal/macos
vendor/golang.org/x/crypto/chacha20poly1305
encoding/hex
net/url
encoding/xml
vendor/golang.org/x/crypto/curve25519
log
encoding/json
vendor/golang.org/x/net/http2/hpack
compress/flate
mime
net/http/internal
mime/quotedprintable
compress/gzip
vendor/golang.org/x/text/unicode/norm
math/big
vendor/golang.org/x/text/unicode/bidi
crypto/internal/boring/bbig
crypto/rand
crypto/dsa
crypto/rsa
crypto/elliptic
encoding/asn1
crypto/ed25519
vendor/golang.org/x/crypto/cryptobyte
crypto/x509/pkix
vendor/golang.org/x/text/secure/bidirule
crypto/ecdsa
vendor/golang.org/x/net/idna
runtime/cgo
net
vendor/golang.org/x/net/http/httpproxy
net/textproto
vendor/golang.org/x/net/http/httpguts
mime/multipart
crypto/x509
crypto/tls
net/http/httptrace
net/http
golang.org/x/net/context/ctxhttp
net/http/httputil
golang.org/x/oauth2/internal
golang.org/x/oauth2
github.com/confluentinc/ccloud-sdk-go-v2/kafkarest/v3
```