### PR TITLE
Update SDK for Flink Gateway API

### DIFF
--- a/flink-gateway/v1alpha1/api/openapi.yaml
+++ b/flink-gateway/v1alpha1/api/openapi.yaml
@@ -612,6 +612,15 @@ paths:
         Make a request to create a statement.
       operationId: createSqlV1alpha1Statement
       parameters:
+      - description: The unique identifier for the organization.
+        explode: false
+        in: header
+        name: Org-Id
+        required: true
+        schema:
+          format: uuid
+          type: string
+        style: simple
       - description: The unique identifier for the environment.
         explode: false
         in: path
@@ -630,6 +639,7 @@ paths:
                   spec:
                     required:
                     - compute_pool_id
+                    - identity_pool_id
                     - statement
                     - statement_name
                     type: object
@@ -840,6 +850,7 @@ paths:
           curl --request POST \
             --url https://flink.region.provider.confluent.cloud/sql/v1alpha1/environments/%7Benvironment_id%7D/statements \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
+            --header 'Org-Id: SOME_STRING_VALUE' \
             --header 'content-type: application/json' \
             --data '{"spec":{"statement_name":"sql123","statement":"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;","properties":{"key1":"value1","key2":"value2"},"compute_pool_id":"fcp-00000","identity_pool_id":"pool-abc123"}}'
       - lang: Java
@@ -852,6 +863,7 @@ paths:
             .url("https://flink.region.provider.confluent.cloud/sql/v1alpha1/environments/%7Benvironment_id%7D/statements")
             .post(body)
             .addHeader("content-type", "application/json")
+            .addHeader("Org-Id", "SOME_STRING_VALUE")
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
             .build();
 
@@ -865,10 +877,10 @@ paths:
           \":\\\"value2\\\"},\\\"compute_pool_id\\\":\\\"fcp-00000\\\",\\\"identity_pool_id\\\
           \":\\\"pool-abc123\\\"}}\")\n\n\treq, _ := http.NewRequest(\"POST\", url,\
           \ payload)\n\n\treq.Header.Add(\"content-type\", \"application/json\")\n\
-          \treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\t\
-          res, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody,\
-          \ _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
-          \n}"
+          \treq.Header.Add(\"Org-Id\", \"SOME_STRING_VALUE\")\n\treq.Header.Add(\"\
+          Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
+          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
+          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
       - lang: Python
         source: |-
           import http.client
@@ -879,6 +891,7 @@ paths:
 
           headers = {
               'content-type': "application/json",
+              'Org-Id': "SOME_STRING_VALUE",
               'Authorization': "Basic REPLACE_BASIC_AUTH"
               }
 
@@ -899,6 +912,7 @@ paths:
             "path": "/sql/v1alpha1/environments/%7Benvironment_id%7D/statements",
             "headers": {
               "content-type": "application/json",
+              "Org-Id": "SOME_STRING_VALUE",
               "Authorization": "Basic REPLACE_BASIC_AUTH"
             }
           };
@@ -935,6 +949,7 @@ paths:
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "content-type: application/json");
+          headers = curl_slist_append(headers, "Org-Id: SOME_STRING_VALUE");
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
@@ -946,6 +961,7 @@ paths:
           var client = new RestClient("https://flink.region.provider.confluent.cloud/sql/v1alpha1/environments/%7Benvironment_id%7D/statements");
           var request = new RestRequest(Method.POST);
           request.AddHeader("content-type", "application/json");
+          request.AddHeader("Org-Id", "SOME_STRING_VALUE");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
           request.AddParameter("application/json", "{\"spec\":{\"statement_name\":\"sql123\",\"statement\":\"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;\",\"properties\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"compute_pool_id\":\"fcp-00000\",\"identity_pool_id\":\"pool-abc123\"}}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
@@ -957,6 +973,15 @@ paths:
         Make a request to delete a statement.
       operationId: deleteSqlV1alpha1Statement
       parameters:
+      - description: The unique identifier for the organization.
+        explode: false
+        in: header
+        name: Org-Id
+        required: true
+        schema:
+          format: uuid
+          type: string
+        style: simple
       - description: The unique identifier for the environment.
         explode: false
         in: path
@@ -1117,7 +1142,8 @@ paths:
         source: |-
           curl --request DELETE \
             --url https://flink.region.provider.confluent.cloud/sql/v1alpha1/environments/%7Benvironment_id%7D/statements/%7Bstatement_name%7D \
-            --header 'Authorization: Basic REPLACE_BASIC_AUTH'
+            --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
+            --header 'Org-Id: SOME_STRING_VALUE'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
@@ -1125,6 +1151,7 @@ paths:
           Request request = new Request.Builder()
             .url("https://flink.region.provider.confluent.cloud/sql/v1alpha1/environments/%7Benvironment_id%7D/statements/%7Bstatement_name%7D")
             .delete(null)
+            .addHeader("Org-Id", "SOME_STRING_VALUE")
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
             .build();
 
@@ -1133,16 +1160,20 @@ paths:
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io/ioutil\"\
           \n)\n\nfunc main() {\n\n\turl := \"https://flink.region.provider.confluent.cloud/sql/v1alpha1/environments/%7Benvironment_id%7D/statements/%7Bstatement_name%7D\"\
           \n\n\treq, _ := http.NewRequest(\"DELETE\", url, nil)\n\n\treq.Header.Add(\"\
-          Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
-          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
-          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          Org-Id\", \"SOME_STRING_VALUE\")\n\treq.Header.Add(\"Authorization\", \"\
+          Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\
+          \tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\
+          \tfmt.Println(string(body))\n\n}"
       - lang: Python
         source: |-
           import http.client
 
           conn = http.client.HTTPSConnection("flink.region.provider.confluent.cloud")
 
-          headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
+          headers = {
+              'Org-Id': "SOME_STRING_VALUE",
+              'Authorization': "Basic REPLACE_BASIC_AUTH"
+              }
 
           conn.request("DELETE", "/sql/v1alpha1/environments/%7Benvironment_id%7D/statements/%7Bstatement_name%7D", headers=headers)
 
@@ -1160,6 +1191,7 @@ paths:
             "port": null,
             "path": "/sql/v1alpha1/environments/%7Benvironment_id%7D/statements/%7Bstatement_name%7D",
             "headers": {
+              "Org-Id": "SOME_STRING_VALUE",
               "Authorization": "Basic REPLACE_BASIC_AUTH"
             }
           };
@@ -1186,6 +1218,7 @@ paths:
           curl_easy_setopt(hnd, CURLOPT_URL, "https://flink.region.provider.confluent.cloud/sql/v1alpha1/environments/%7Benvironment_id%7D/statements/%7Bstatement_name%7D");
 
           struct curl_slist *headers = NULL;
+          headers = curl_slist_append(headers, "Org-Id: SOME_STRING_VALUE");
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
@@ -1194,6 +1227,7 @@ paths:
         source: |-
           var client = new RestClient("https://flink.region.provider.confluent.cloud/sql/v1alpha1/environments/%7Benvironment_id%7D/statements/%7Bstatement_name%7D");
           var request = new RestRequest(Method.DELETE);
+          request.AddHeader("Org-Id", "SOME_STRING_VALUE");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
           IRestResponse response = client.Execute(request);
     get:

--- a/flink-gateway/v1alpha1/api_statements_sql_v1alpha1.go
+++ b/flink-gateway/v1alpha1/api_statements_sql_v1alpha1.go
@@ -113,10 +113,16 @@ type StatementsSqlV1alpha1ApiService service
 type ApiCreateSqlV1alpha1StatementRequest struct {
 	ctx _context.Context
 	ApiService StatementsSqlV1alpha1Api
+	orgId *string
 	environmentId string
 	sqlV1alpha1Statement *SqlV1alpha1Statement
 }
 
+// The unique identifier for the organization.
+func (r ApiCreateSqlV1alpha1StatementRequest) OrgId(orgId string) ApiCreateSqlV1alpha1StatementRequest {
+	r.orgId = &orgId
+	return r
+}
 func (r ApiCreateSqlV1alpha1StatementRequest) SqlV1alpha1Statement(sqlV1alpha1Statement SqlV1alpha1Statement) ApiCreateSqlV1alpha1StatementRequest {
 	r.sqlV1alpha1Statement = &sqlV1alpha1Statement
 	return r
@@ -167,6 +173,9 @@ func (a *StatementsSqlV1alpha1ApiService) CreateSqlV1alpha1StatementExecute(r Ap
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	if r.orgId == nil {
+		return localVarReturnValue, nil, reportError("orgId is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -185,6 +194,7 @@ func (a *StatementsSqlV1alpha1ApiService) CreateSqlV1alpha1StatementExecute(r Ap
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
+	localVarHeaderParams["Org-Id"] = parameterToString(*r.orgId, "")
 	// body params
 	localVarPostBody = r.sqlV1alpha1Statement
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
@@ -286,10 +296,16 @@ func (a *StatementsSqlV1alpha1ApiService) CreateSqlV1alpha1StatementExecute(r Ap
 type ApiDeleteSqlV1alpha1StatementRequest struct {
 	ctx _context.Context
 	ApiService StatementsSqlV1alpha1Api
+	orgId *string
 	environmentId string
 	statementName string
 }
 
+// The unique identifier for the organization.
+func (r ApiDeleteSqlV1alpha1StatementRequest) OrgId(orgId string) ApiDeleteSqlV1alpha1StatementRequest {
+	r.orgId = &orgId
+	return r
+}
 
 func (r ApiDeleteSqlV1alpha1StatementRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.DeleteSqlV1alpha1StatementExecute(r)
@@ -337,6 +353,9 @@ func (a *StatementsSqlV1alpha1ApiService) DeleteSqlV1alpha1StatementExecute(r Ap
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	if r.orgId == nil {
+		return nil, reportError("orgId is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -355,6 +374,7 @@ func (a *StatementsSqlV1alpha1ApiService) DeleteSqlV1alpha1StatementExecute(r Ap
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
+	localVarHeaderParams["Org-Id"] = parameterToString(*r.orgId, "")
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err

--- a/flink-gateway/v1alpha1/docs/StatementsSqlV1alpha1Api.md
+++ b/flink-gateway/v1alpha1/docs/StatementsSqlV1alpha1Api.md
@@ -13,7 +13,7 @@ Method | HTTP request | Description
 
 ## CreateSqlV1alpha1Statement
 
-> SqlV1alpha1Statement CreateSqlV1alpha1Statement(ctx, environmentId).SqlV1alpha1Statement(sqlV1alpha1Statement).Execute()
+> SqlV1alpha1Statement CreateSqlV1alpha1Statement(ctx, environmentId).OrgId(orgId).SqlV1alpha1Statement(sqlV1alpha1Statement).Execute()
 
 Create a Statement
 
@@ -32,12 +32,13 @@ import (
 )
 
 func main() {
+    orgId := TODO // string | The unique identifier for the organization.
     environmentId := "environmentId_example" // string | The unique identifier for the environment.
     sqlV1alpha1Statement := *openapiclient.NewSqlV1alpha1Statement() // SqlV1alpha1Statement |  (optional)
 
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
-    resp, r, err := api_client.StatementsSqlV1alpha1Api.CreateSqlV1alpha1Statement(context.Background(), environmentId).SqlV1alpha1Statement(sqlV1alpha1Statement).Execute()
+    resp, r, err := api_client.StatementsSqlV1alpha1Api.CreateSqlV1alpha1Statement(context.Background(), environmentId).OrgId(orgId).SqlV1alpha1Statement(sqlV1alpha1Statement).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StatementsSqlV1alpha1Api.CreateSqlV1alpha1Statement``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -62,6 +63,7 @@ Other parameters are passed through a pointer to a apiCreateSqlV1alpha1Statement
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **orgId** | [**string**](string.md) | The unique identifier for the organization. | 
 
  **sqlV1alpha1Statement** | [**SqlV1alpha1Statement**](SqlV1alpha1Statement.md) |  | 
 
@@ -85,7 +87,7 @@ Name | Type | Description  | Notes
 
 ## DeleteSqlV1alpha1Statement
 
-> DeleteSqlV1alpha1Statement(ctx, environmentId, statementName).Execute()
+> DeleteSqlV1alpha1Statement(ctx, environmentId, statementName).OrgId(orgId).Execute()
 
 Delete a Statement
 
@@ -104,12 +106,13 @@ import (
 )
 
 func main() {
+    orgId := TODO // string | The unique identifier for the organization.
     environmentId := "environmentId_example" // string | The unique identifier for the environment.
     statementName := "statementName_example" // string | The unique identifier for the statement.
 
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
-    resp, r, err := api_client.StatementsSqlV1alpha1Api.DeleteSqlV1alpha1Statement(context.Background(), environmentId, statementName).Execute()
+    resp, r, err := api_client.StatementsSqlV1alpha1Api.DeleteSqlV1alpha1Statement(context.Background(), environmentId, statementName).OrgId(orgId).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StatementsSqlV1alpha1Api.DeleteSqlV1alpha1Statement``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -133,6 +136,7 @@ Other parameters are passed through a pointer to a apiDeleteSqlV1alpha1Statement
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **orgId** | [**string**](string.md) | The unique identifier for the organization. | 
 
 
 


### PR DESCRIPTION
### What
This PR updates SDK for Flink Gateway API

### Testing
```
➜  v1alpha1 git:(upd123) ✗ go vet -v                                                             
internal/unsafeheader
vendor/golang.org/x/crypto/cryptobyte/asn1
internal/nettrace
container/list
vendor/golang.org/x/crypto/internal/subtle
internal/goarch
math/bits
encoding
unicode/utf16
crypto/internal/subtle
runtime/internal/math
crypto/subtle
internal/goos
internal/itoa
internal/race
unicode/utf8
internal/goexperiment
unicode
runtime/internal/sys
internal/abi
sync/atomic
internal/cpu
runtime/internal/atomic
internal/bytealg
math
runtime
internal/reflectlite
sync
errors
internal/singleflight
internal/testlog
sort
math/rand
internal/oserror
path
io
vendor/golang.org/x/net/dns/dnsmessage
crypto/internal/randutil
hash
crypto/elliptic/internal/fiat
bytes
strconv
strings
crypto/hmac
vendor/golang.org/x/text/transform
crypto/elliptic/internal/nistec
hash/crc32
crypto/rc4
net/http/internal/ascii
crypto
bufio
vendor/golang.org/x/crypto/hkdf
syscall
regexp/syntax
reflect
internal/syscall/execenv
internal/fmtsort
internal/syscall/unix
encoding/binary
regexp
time
encoding/base64
crypto/sha512
crypto/md5
vendor/golang.org/x/crypto/internal/poly1305
crypto/sha256
vendor/golang.org/x/crypto/curve25519/internal/field
context
crypto/sha1
crypto/ed25519/internal/edwards25519/field
encoding/pem
crypto/cipher
io/fs
internal/poll
vendor/golang.org/x/crypto/chacha20
embed
crypto/ed25519/internal/edwards25519
crypto/des
crypto/aes
os
internal/godebug
io/ioutil
path/filepath
vendor/golang.org/x/sys/cpu
fmt
vendor/golang.org/x/net/route
internal/intern
vendor/golang.org/x/crypto/curve25519
net/url
log
crypto/x509/internal/macos
encoding/hex
mime/quotedprintable
vendor/golang.org/x/crypto/chacha20poly1305
net/netip
mime
net/http/internal
encoding/xml
vendor/golang.org/x/net/http2/hpack
encoding/json
compress/flate
vendor/golang.org/x/text/unicode/norm
vendor/golang.org/x/text/unicode/bidi
compress/gzip
math/big
vendor/golang.org/x/text/secure/bidirule
crypto/dsa
crypto/rand
crypto/rsa
encoding/asn1
runtime/cgo
crypto/ed25519
vendor/golang.org/x/net/idna
crypto/elliptic
crypto/x509/pkix
vendor/golang.org/x/crypto/cryptobyte
crypto/ecdsa
net
vendor/golang.org/x/net/http/httpproxy
net/textproto
vendor/golang.org/x/net/http/httpguts
crypto/x509
mime/multipart
crypto/tls
net/http/httptrace
net/http
golang.org/x/net/context/ctxhttp
net/http/httputil
golang.org/x/oauth2/internal
golang.org/x/oauth2
github.com/confluentinc/ccloud-sdk-go-v2
```