### PR TITLE
Update CLI public SDK for panic collection

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,5 +1,5 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/cli
 
-go 1.13
+go 1.16
 
 require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/cli/v1/api/openapi.yaml
+++ b/cli/v1/api/openapi.yaml
@@ -17,6 +17,8 @@ servers:
   url: https://api.confluent.cloud
 tags:
 - description: |-
+    [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
     `Usage` objects represent CLI commands that were run while logged in to Confluent Cloud.
     The API creates usage objects that are collected for CLI analytics.
 
@@ -27,7 +29,10 @@ tags:
 paths:
   /cli/v1/usages:
     post:
-      description: Make a request to create a usage.
+      description: |-
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
+        Make a request to create a usage.
       operationId: createCliV1Usage
       requestBody:
         content:
@@ -216,13 +221,13 @@ paths:
             --url https://api.confluent.cloud/cli/v1/usages \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
             --header 'content-type: application/json' \
-            --data '{"os":"darwin","arch":"amd64","version":"v2.7.0","command":"confluent kafka cluster create","flags":["cloud","region"],"error":true}'
+            --data '{"os":"darwin","arch":"amd64","version":"v2.7.0","command":"confluent kafka cluster create","flags":["cloud","region"],"error":true,"stack_frames":["~/.goenv/versions/1.20.4/src/runtime/panic.go:884","github.com/confluentinc/cli/internal/cmd/command.go:171"]}'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           MediaType mediaType = MediaType.parse("application/json");
-          RequestBody body = RequestBody.create(mediaType, "{\"os\":\"darwin\",\"arch\":\"amd64\",\"version\":\"v2.7.0\",\"command\":\"confluent kafka cluster create\",\"flags\":[\"cloud\",\"region\"],\"error\":true}");
+          RequestBody body = RequestBody.create(mediaType, "{\"os\":\"darwin\",\"arch\":\"amd64\",\"version\":\"v2.7.0\",\"command\":\"confluent kafka cluster create\",\"flags\":[\"cloud\",\"region\"],\"error\":true,\"stack_frames\":[\"~/.goenv/versions/1.20.4/src/runtime/panic.go:884\",\"github.com/confluentinc/cli/internal/cmd/command.go:171\"]}");
           Request request = new Request.Builder()
             .url("https://api.confluent.cloud/cli/v1/usages")
             .post(body)
@@ -237,9 +242,11 @@ paths:
           \n\n\tpayload := strings.NewReader(\"{\\\"os\\\":\\\"darwin\\\",\\\"arch\\\
           \":\\\"amd64\\\",\\\"version\\\":\\\"v2.7.0\\\",\\\"command\\\":\\\"confluent\
           \ kafka cluster create\\\",\\\"flags\\\":[\\\"cloud\\\",\\\"region\\\"],\\\
-          \"error\\\":true}\")\n\n\treq, _ := http.NewRequest(\"POST\", url, payload)\n\
-          \n\treq.Header.Add(\"content-type\", \"application/json\")\n\treq.Header.Add(\"\
-          Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
+          \"error\\\":true,\\\"stack_frames\\\":[\\\"~/.goenv/versions/1.20.4/src/runtime/panic.go:884\\\
+          \",\\\"github.com/confluentinc/cli/internal/cmd/command.go:171\\\"]}\")\n\
+          \n\treq, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"\
+          content-type\", \"application/json\")\n\treq.Header.Add(\"Authorization\"\
+          , \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
           \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
           fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
       - lang: Python
@@ -248,7 +255,7 @@ paths:
 
           conn = http.client.HTTPSConnection("api.confluent.cloud")
 
-          payload = "{\"os\":\"darwin\",\"arch\":\"amd64\",\"version\":\"v2.7.0\",\"command\":\"confluent kafka cluster create\",\"flags\":[\"cloud\",\"region\"],\"error\":true}"
+          payload = "{\"os\":\"darwin\",\"arch\":\"amd64\",\"version\":\"v2.7.0\",\"command\":\"confluent kafka cluster create\",\"flags\":[\"cloud\",\"region\"],\"error\":true,\"stack_frames\":[\"~/.goenv/versions/1.20.4/src/runtime/panic.go:884\",\"github.com/confluentinc/cli/internal/cmd/command.go:171\"]}"
 
           headers = {
               'content-type': "application/json",
@@ -295,7 +302,11 @@ paths:
             version: 'v2.7.0',
             command: 'confluent kafka cluster create',
             flags: ['cloud', 'region'],
-            error: true
+            error: true,
+            stack_frames: [
+              '~/.goenv/versions/1.20.4/src/runtime/panic.go:884',
+              'github.com/confluentinc/cli/internal/cmd/command.go:171'
+            ]
           }));
           req.end();
       - lang: C
@@ -310,7 +321,7 @@ paths:
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"os\":\"darwin\",\"arch\":\"amd64\",\"version\":\"v2.7.0\",\"command\":\"confluent kafka cluster create\",\"flags\":[\"cloud\",\"region\"],\"error\":true}");
+          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"os\":\"darwin\",\"arch\":\"amd64\",\"version\":\"v2.7.0\",\"command\":\"confluent kafka cluster create\",\"flags\":[\"cloud\",\"region\"],\"error\":true,\"stack_frames\":[\"~/.goenv/versions/1.20.4/src/runtime/panic.go:884\",\"github.com/confluentinc/cli/internal/cmd/command.go:171\"]}");
 
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
@@ -319,7 +330,7 @@ paths:
           var request = new RestRequest(Method.POST);
           request.AddHeader("content-type", "application/json");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("application/json", "{\"os\":\"darwin\",\"arch\":\"amd64\",\"version\":\"v2.7.0\",\"command\":\"confluent kafka cluster create\",\"flags\":[\"cloud\",\"region\"],\"error\":true}", ParameterType.RequestBody);
+          request.AddParameter("application/json", "{\"os\":\"darwin\",\"arch\":\"amd64\",\"version\":\"v2.7.0\",\"command\":\"confluent kafka cluster create\",\"flags\":[\"cloud\",\"region\"],\"error\":true,\"stack_frames\":[\"~/.goenv/versions/1.20.4/src/runtime/panic.go:884\",\"github.com/confluentinc/cli/internal/cmd/command.go:171\"]}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
 components:
   responses:
@@ -586,6 +597,14 @@ components:
           description: If an error occurred while running the CLI command
           example: true
           type: boolean
+        stack_frames:
+          description: Line numbers of the stack trace from a panic
+          example:
+          - ~/.goenv/versions/1.20.4/src/runtime/panic.go:884
+          - github.com/confluentinc/cli/internal/cmd/command.go:171
+          items:
+            type: string
+          type: array
       type: object
     ObjectMeta:
       description: ObjectMeta is metadata that all persisted resources must have,

--- a/cli/v1/api_usages_cli_v1.go
+++ b/cli/v1/api_usages_cli_v1.go
@@ -43,7 +43,9 @@ type UsagesCliV1Api interface {
 	/*
 	CreateCliV1Usage Create a Usage
 
-	Make a request to create a usage.
+	[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
+Make a request to create a usage.
 
 	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 @return ApiCreateCliV1UsageRequest
@@ -74,6 +76,8 @@ func (r ApiCreateCliV1UsageRequest) Execute() (*_nethttp.Response, error) {
 
 /*
 CreateCliV1Usage Create a Usage
+
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to create a usage.
 

--- a/cli/v1/docs/CliV1Usage.md
+++ b/cli/v1/docs/CliV1Usage.md
@@ -14,6 +14,7 @@ Name | Type | Description | Notes
 **Command** | Pointer to **string** | CLI command that was run | [optional] 
 **Flags** | Pointer to **[]string** | Names of the flags passed with the CLI command | [optional] 
 **Error** | Pointer to **bool** | If an error occurred while running the CLI command | [optional] 
+**StackFrames** | Pointer to **[]string** | Line numbers of the stack trace from a panic | [optional] 
 
 ## Methods
 
@@ -283,6 +284,31 @@ SetError sets Error field to given value.
 `func (o *CliV1Usage) HasError() bool`
 
 HasError returns a boolean if a field has been set.
+
+### GetStackFrames
+
+`func (o *CliV1Usage) GetStackFrames() []string`
+
+GetStackFrames returns the StackFrames field if non-nil, zero value otherwise.
+
+### GetStackFramesOk
+
+`func (o *CliV1Usage) GetStackFramesOk() (*[]string, bool)`
+
+GetStackFramesOk returns a tuple with the StackFrames field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetStackFrames
+
+`func (o *CliV1Usage) SetStackFrames(v []string)`
+
+SetStackFrames sets StackFrames field to given value.
+
+### HasStackFrames
+
+`func (o *CliV1Usage) HasStackFrames() bool`
+
+HasStackFrames returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/cli/v1/model_cli_v1_usage.go
+++ b/cli/v1/model_cli_v1_usage.go
@@ -26,6 +26,7 @@ Contact: cli-team@confluent.io
 package v1
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -54,6 +55,8 @@ type CliV1Usage struct {
 	Flags *[]string `json:"flags,omitempty"`
 	// If an error occurred while running the CLI command
 	Error *bool `json:"error,omitempty"`
+	// Line numbers of the stack trace from a panic
+	StackFrames *[]string `json:"stack_frames,omitempty"`
 }
 
 // NewCliV1Usage instantiates a new CliV1Usage object
@@ -393,6 +396,38 @@ func (o *CliV1Usage) SetError(v bool) {
 	o.Error = &v
 }
 
+// GetStackFrames returns the StackFrames field value if set, zero value otherwise.
+func (o *CliV1Usage) GetStackFrames() []string {
+	if o == nil || o.StackFrames == nil {
+		var ret []string
+		return ret
+	}
+	return *o.StackFrames
+}
+
+// GetStackFramesOk returns a tuple with the StackFrames field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *CliV1Usage) GetStackFramesOk() (*[]string, bool) {
+	if o == nil || o.StackFrames == nil {
+		return nil, false
+	}
+	return o.StackFrames, true
+}
+
+// HasStackFrames returns a boolean if a field has been set.
+func (o *CliV1Usage) HasStackFrames() bool {
+	if o != nil && o.StackFrames != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetStackFrames gets a reference to the given []string and assigns it to the StackFrames field.
+func (o *CliV1Usage) SetStackFrames(v []string) {
+	o.StackFrames = &v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *CliV1Usage) Redact() {
     o.recurseRedact(o.ApiVersion)
@@ -405,6 +440,7 @@ func (o *CliV1Usage) Redact() {
     o.recurseRedact(o.Command)
     o.recurseRedact(o.Flags)
     o.recurseRedact(o.Error)
+    o.recurseRedact(o.StackFrames)
 }
 
 func (o *CliV1Usage) recurseRedact(v interface{}) {
@@ -469,7 +505,14 @@ func (o CliV1Usage) MarshalJSON() ([]byte, error) {
 	if o.Error != nil {
 		toSerialize["error"] = o.Error
 	}
-	return json.Marshal(toSerialize)
+	if o.StackFrames != nil {
+		toSerialize["stack_frames"] = o.StackFrames
+	}
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(toSerialize)
+	return buffer.Bytes(), err
 }
 
 type NullableCliV1Usage struct {
@@ -500,7 +543,11 @@ func NewNullableCliV1Usage(val *CliV1Usage) *NullableCliV1Usage {
 }
 
 func (v NullableCliV1Usage) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.value)
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(v.value)
+	return buffer.Bytes(), err
 }
 
 func (v *NullableCliV1Usage) UnmarshalJSON(src []byte) error {

--- a/cli/v1/model_error.go
+++ b/cli/v1/model_error.go
@@ -26,6 +26,7 @@ Contact: cli-team@confluent.io
 package v1
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -317,7 +318,11 @@ func (o Error) MarshalJSON() ([]byte, error) {
 	if o.Source != nil {
 		toSerialize["source"] = o.Source
 	}
-	return json.Marshal(toSerialize)
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(toSerialize)
+	return buffer.Bytes(), err
 }
 
 type NullableError struct {
@@ -348,7 +353,11 @@ func NewNullableError(val *Error) *NullableError {
 }
 
 func (v NullableError) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.value)
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(v.value)
+	return buffer.Bytes(), err
 }
 
 func (v *NullableError) UnmarshalJSON(src []byte) error {

--- a/cli/v1/model_error_source.go
+++ b/cli/v1/model_error_source.go
@@ -26,6 +26,7 @@ Contact: cli-team@confluent.io
 package v1
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -166,7 +167,11 @@ func (o ErrorSource) MarshalJSON() ([]byte, error) {
 	if o.Parameter != nil {
 		toSerialize["parameter"] = o.Parameter
 	}
-	return json.Marshal(toSerialize)
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(toSerialize)
+	return buffer.Bytes(), err
 }
 
 type NullableErrorSource struct {
@@ -197,7 +202,11 @@ func NewNullableErrorSource(val *ErrorSource) *NullableErrorSource {
 }
 
 func (v NullableErrorSource) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.value)
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(v.value)
+	return buffer.Bytes(), err
 }
 
 func (v *NullableErrorSource) UnmarshalJSON(src []byte) error {

--- a/cli/v1/model_failure.go
+++ b/cli/v1/model_failure.go
@@ -26,6 +26,7 @@ Contact: cli-team@confluent.io
 package v1
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -36,7 +37,7 @@ import (
 // Failure Provides information about problems encountered while performing an operation.
 type Failure struct {
 	// List of errors which caused this operation to fail
-	Errors []Error `json:"errors"`
+	Errors []Error `json:"errors,omitempty"`
 }
 
 // NewFailure instantiates a new Failure object
@@ -121,7 +122,11 @@ func (o Failure) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["errors"] = o.Errors
 	}
-	return json.Marshal(toSerialize)
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(toSerialize)
+	return buffer.Bytes(), err
 }
 
 type NullableFailure struct {
@@ -152,7 +157,11 @@ func NewNullableFailure(val *Failure) *NullableFailure {
 }
 
 func (v NullableFailure) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.value)
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(v.value)
+	return buffer.Bytes(), err
 }
 
 func (v *NullableFailure) UnmarshalJSON(src []byte) error {

--- a/cli/v1/model_list_meta.go
+++ b/cli/v1/model_list_meta.go
@@ -26,6 +26,7 @@ Contact: cli-team@confluent.io
 package v1
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -320,7 +321,11 @@ func (o ListMeta) MarshalJSON() ([]byte, error) {
 	if o.TotalSize != nil {
 		toSerialize["total_size"] = o.TotalSize
 	}
-	return json.Marshal(toSerialize)
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(toSerialize)
+	return buffer.Bytes(), err
 }
 
 type NullableListMeta struct {
@@ -351,7 +356,11 @@ func NewNullableListMeta(val *ListMeta) *NullableListMeta {
 }
 
 func (v NullableListMeta) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.value)
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(v.value)
+	return buffer.Bytes(), err
 }
 
 func (v *NullableListMeta) UnmarshalJSON(src []byte) error {

--- a/cli/v1/model_object_meta.go
+++ b/cli/v1/model_object_meta.go
@@ -26,6 +26,7 @@ Contact: cli-team@confluent.io
 package v1
 
 import (
+	"bytes"
 	"encoding/json"
 	"time"
 )
@@ -37,7 +38,7 @@ import (
 // ObjectMeta ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.
 type ObjectMeta struct {
 	// Self is a Uniform Resource Locator (URL) at which an object can be addressed. This URL encodes the service location, API version, and other particulars necessary to locate the resource at a point in time
-	Self string `json:"self"`
+	Self string `json:"self,omitempty"`
 	// Resource Name is a Uniform Resource Identifier (URI) that is globally unique across space and time. It is represented as a Confluent Resource Name
 	ResourceName *string `json:"resource_name,omitempty"`
 	// The date and time at which this object was created. It is represented in RFC3339 format and is in UTC.
@@ -274,7 +275,11 @@ func (o ObjectMeta) MarshalJSON() ([]byte, error) {
 	if o.DeletedAt != nil {
 		toSerialize["deleted_at"] = o.DeletedAt
 	}
-	return json.Marshal(toSerialize)
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(toSerialize)
+	return buffer.Bytes(), err
 }
 
 type NullableObjectMeta struct {
@@ -305,7 +310,11 @@ func NewNullableObjectMeta(val *ObjectMeta) *NullableObjectMeta {
 }
 
 func (v NullableObjectMeta) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.value)
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(v.value)
+	return buffer.Bytes(), err
 }
 
 func (v *NullableObjectMeta) UnmarshalJSON(src []byte) error {

--- a/cli/v1/model_object_reference.go
+++ b/cli/v1/model_object_reference.go
@@ -26,6 +26,7 @@ Contact: cli-team@confluent.io
 package v1
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -36,13 +37,13 @@ import (
 // ObjectReference ObjectReference provides information for you to locate the referred object
 type ObjectReference struct {
 	// ID of the referred resource
-	Id string `json:"id"`
+	Id string `json:"id,omitempty"`
 	// Environment of the referred resource, if env-scoped
 	Environment *string `json:"environment,omitempty"`
 	// API URL for accessing or modifying the referred object
-	Related string `json:"related"`
+	Related string `json:"related,omitempty"`
 	// CRN reference to the referred resource
-	ResourceName string `json:"resource_name"`
+	ResourceName string `json:"resource_name,omitempty"`
 	// API group and version of the referred resource
 	ApiVersion *string `json:"api_version,omitempty"`
 	// Kind of the referred resource
@@ -297,7 +298,11 @@ func (o ObjectReference) MarshalJSON() ([]byte, error) {
 	if o.Kind != nil {
 		toSerialize["kind"] = o.Kind
 	}
-	return json.Marshal(toSerialize)
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(toSerialize)
+	return buffer.Bytes(), err
 }
 
 type NullableObjectReference struct {
@@ -328,7 +333,11 @@ func NewNullableObjectReference(val *ObjectReference) *NullableObjectReference {
 }
 
 func (v NullableObjectReference) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.value)
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(v.value)
+	return buffer.Bytes(), err
 }
 
 func (v *NullableObjectReference) UnmarshalJSON(src []byte) error {

--- a/cli/v1/utils.go
+++ b/cli/v1/utils.go
@@ -26,6 +26,7 @@ Contact: cli-team@confluent.io
 package v1
 
 import (
+	"bytes"
 	"encoding/json"
 	"time"
 )
@@ -298,7 +299,11 @@ func NewNullableString(val *string) *NullableString {
 }
 
 func (v NullableString) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.value)
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(v.value)
+	return buffer.Bytes(), err
 }
 
 func (v *NullableString) UnmarshalJSON(src []byte) error {


### PR DESCRIPTION
Test

```
go vet -v
internal/unsafeheader
sync/atomic
unicode
unicode/utf8
internal/itoa
encoding
math/bits
unicode/utf16
crypto/internal/alias
crypto/subtle
crypto/internal/boring/sig
vendor/golang.org/x/crypto/cryptobyte/asn1
internal/nettrace
internal/goarch
container/list
internal/abi
runtime/internal/math
vendor/golang.org/x/crypto/internal/alias
internal/cpu
internal/race
internal/coverage/rtcov
internal/goos
runtime/internal/atomic
internal/goexperiment
runtime/internal/sys
internal/bytealg
math
runtime
internal/reflectlite
sync
internal/singleflight
internal/testlog
internal/godebug
errors
sort
internal/oserror
internal/safefilepath
path
vendor/golang.org/x/net/dns/dnsmessage
io
math/rand
internal/intern
hash
crypto/internal/randutil
bytes
strconv
strings
crypto/internal/nistec/fiat
crypto
vendor/golang.org/x/text/transform
net/http/internal/ascii
hash/crc32
bufio
crypto/rc4
net/netip
reflect
regexp/syntax
syscall
encoding/binary
internal/fmtsort
internal/syscall/execenv
regexp
internal/syscall/unix
encoding/base64
time
crypto/md5
crypto/internal/edwards25519/field
vendor/golang.org/x/crypto/internal/poly1305
crypto/cipher
encoding/pem
context
crypto/des
crypto/x509/internal/macos
io/fs
crypto/internal/boring
vendor/golang.org/x/crypto/chacha20
crypto/internal/edwards25519
embed
crypto/hmac
internal/poll
crypto/sha512
crypto/sha1
crypto/sha256
crypto/aes
vendor/golang.org/x/crypto/hkdf
crypto/internal/nistec
crypto/ecdh
os
io/ioutil
vendor/golang.org/x/sys/cpu
path/filepath
fmt
vendor/golang.org/x/net/route
encoding/hex
net/url
vendor/golang.org/x/crypto/chacha20poly1305
encoding/xml
compress/flate
encoding/json
log
compress/gzip
mime/quotedprintable
mime
vendor/golang.org/x/net/http2/hpack
net/http/internal
vendor/golang.org/x/text/unicode/bidi
math/big
vendor/golang.org/x/text/unicode/norm
vendor/golang.org/x/text/secure/bidirule
crypto/internal/bigmod
crypto/internal/boring/bbig
crypto/dsa
crypto/rand
crypto/elliptic
encoding/asn1
crypto/x509/pkix
crypto/rsa
crypto/ed25519
vendor/golang.org/x/crypto/cryptobyte
vendor/golang.org/x/net/idna
net
crypto/ecdsa
vendor/golang.org/x/net/http/httpproxy
net/textproto
vendor/golang.org/x/net/http/httpguts
crypto/x509
mime/multipart
crypto/tls
net/http/httptrace
net/http
golang.org/x/net/context/ctxhttp
net/http/httputil
golang.org/x/oauth2/internal
golang.org/x/oauth2
github.com/confluentinc/ccloud-sdk-go-v2/cli/v1
```