### PR TITLE
update sdk so compute pool display name is editable

### DIFF
--- a/flink/v2/README.md
+++ b/flink/v2/README.md
@@ -118,7 +118,7 @@ Class | Method | HTTP request | Description
 
 
 
-### api-key
+### cloud-api-key
 
 - **Type**: HTTP basic authentication
 

--- a/flink/v2/api/openapi.yaml
+++ b/flink/v2/api/openapi.yaml
@@ -300,7 +300,7 @@ paths:
                 type: string
               style: simple
       security:
-      - api-key: []
+      - cloud-api-key: []
       summary: List of Iam Bindings
       tags:
       - Iam Bindings (fcpm/v2)
@@ -665,7 +665,7 @@ paths:
                 type: string
               style: simple
       security:
-      - api-key: []
+      - cloud-api-key: []
       summary: Create an Iam Binding
       tags:
       - Iam Bindings (fcpm/v2)
@@ -999,7 +999,7 @@ paths:
                 type: string
               style: simple
       security:
-      - api-key: []
+      - cloud-api-key: []
       summary: Delete an Iam Binding
       tags:
       - Iam Bindings (fcpm/v2)
@@ -1335,7 +1335,7 @@ paths:
                 type: string
               style: simple
       security:
-      - api-key: []
+      - cloud-api-key: []
       summary: List of Compute Pools
       tags:
       - Compute Pools (fcpm/v2)
@@ -1723,7 +1723,7 @@ paths:
                 type: string
               style: simple
       security:
-      - api-key: []
+      - cloud-api-key: []
       summary: Create a Compute Pool
       tags:
       - Compute Pools (fcpm/v2)
@@ -2056,7 +2056,7 @@ paths:
                 type: string
               style: simple
       security:
-      - api-key: []
+      - cloud-api-key: []
       summary: Delete a Compute Pool
       tags:
       - Compute Pools (fcpm/v2)
@@ -2392,7 +2392,7 @@ paths:
                 type: string
               style: simple
       security:
-      - api-key: []
+      - cloud-api-key: []
       summary: Read a Compute Pool
       tags:
       - Compute Pools (fcpm/v2)
@@ -2760,7 +2760,7 @@ paths:
                 type: string
               style: simple
       security:
-      - api-key: []
+      - cloud-api-key: []
       summary: Update a Compute Pool
       tags:
       - Compute Pools (fcpm/v2)
@@ -3101,7 +3101,7 @@ paths:
                 type: string
               style: simple
       security:
-      - api-key: []
+      - cloud-api-key: []
       summary: List of Regions
       tags:
       - Regions (fcpm/v2)
@@ -3764,7 +3764,7 @@ components:
           example: flink_compute_pool_0
           pattern: ^(?:[0-9A-Za-z\-])[\w-]{0,31}$
           type: string
-          x-immutable: true
+          x-immutable: false
         cloud:
           description: The cloud service provider that runs the compute pool.
           example: AWS
@@ -4099,6 +4099,12 @@ components:
     fcpm.v2.ComputePoolSpecUpdate:
       description: The desired state of the Compute Pool
       properties:
+        display_name:
+          description: The name of the Flink compute pool.
+          example: flink_compute_pool_0
+          pattern: ^(?:[0-9A-Za-z\-])[\w-]{0,31}$
+          type: string
+          x-immutable: false
         max_cfu:
           description: |
             Maximum number of Confluent Flink Units (CFUs) that the Flink compute pool should auto-scale to.
@@ -4176,8 +4182,8 @@ components:
           type: string
       type: object
   securitySchemes:
-    api-key:
-      description: Authenticate with API Keys using HTTP Basic Auth. Treat the API
-        Key ID as the username and API Key Secret as the password.
+    cloud-api-key:
+      description: Authenticate with Cloud API Keys using HTTP Basic Auth. Treat the
+        Cloud API Key ID as the username and Cloud API Key Secret as the password.
       scheme: basic
       type: http

--- a/flink/v2/api_compute_pools_fcpm_v2.go
+++ b/flink/v2/api_compute_pools_fcpm_v2.go
@@ -149,8 +149,8 @@ CreateFcpmV2ComputePool Create a Compute Pool
 
 Make a request to create a compute pool.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiCreateFcpmV2ComputePoolRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiCreateFcpmV2ComputePoolRequest
 */
 func (a *ComputePoolsFcpmV2ApiService) CreateFcpmV2ComputePool(ctx _context.Context) ApiCreateFcpmV2ComputePoolRequest {
 	return ApiCreateFcpmV2ComputePoolRequest{
@@ -160,7 +160,8 @@ func (a *ComputePoolsFcpmV2ApiService) CreateFcpmV2ComputePool(ctx _context.Cont
 }
 
 // Execute executes the request
-//  @return FcpmV2ComputePool
+//
+//	@return FcpmV2ComputePool
 func (a *ComputePoolsFcpmV2ApiService) CreateFcpmV2ComputePoolExecute(r ApiCreateFcpmV2ComputePoolRequest) (FcpmV2ComputePool, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
@@ -321,9 +322,9 @@ DeleteFcpmV2ComputePool Delete a Compute Pool
 
 Make a request to delete a compute pool.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param id The unique identifier for the compute pool.
- @return ApiDeleteFcpmV2ComputePoolRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param id The unique identifier for the compute pool.
+	@return ApiDeleteFcpmV2ComputePoolRequest
 */
 func (a *ComputePoolsFcpmV2ApiService) DeleteFcpmV2ComputePool(ctx _context.Context, id string) ApiDeleteFcpmV2ComputePoolRequest {
 	return ApiDeleteFcpmV2ComputePoolRequest{
@@ -477,9 +478,9 @@ GetFcpmV2ComputePool Read a Compute Pool
 
 Make a request to read a compute pool.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param id The unique identifier for the compute pool.
- @return ApiGetFcpmV2ComputePoolRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param id The unique identifier for the compute pool.
+	@return ApiGetFcpmV2ComputePoolRequest
 */
 func (a *ComputePoolsFcpmV2ApiService) GetFcpmV2ComputePool(ctx _context.Context, id string) ApiGetFcpmV2ComputePoolRequest {
 	return ApiGetFcpmV2ComputePoolRequest{
@@ -490,7 +491,8 @@ func (a *ComputePoolsFcpmV2ApiService) GetFcpmV2ComputePool(ctx _context.Context
 }
 
 // Execute executes the request
-//  @return FcpmV2ComputePool
+//
+//	@return FcpmV2ComputePool
 func (a *ComputePoolsFcpmV2ApiService) GetFcpmV2ComputePoolExecute(r ApiGetFcpmV2ComputePoolRequest) (FcpmV2ComputePool, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -671,8 +673,8 @@ ListFcpmV2ComputePools List of Compute Pools
 
 Retrieve a sorted, filtered, paginated list of all compute pools.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiListFcpmV2ComputePoolsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiListFcpmV2ComputePoolsRequest
 */
 func (a *ComputePoolsFcpmV2ApiService) ListFcpmV2ComputePools(ctx _context.Context) ApiListFcpmV2ComputePoolsRequest {
 	return ApiListFcpmV2ComputePoolsRequest{
@@ -682,7 +684,8 @@ func (a *ComputePoolsFcpmV2ApiService) ListFcpmV2ComputePools(ctx _context.Conte
 }
 
 // Execute executes the request
-//  @return FcpmV2ComputePoolList
+//
+//	@return FcpmV2ComputePoolList
 func (a *ComputePoolsFcpmV2ApiService) ListFcpmV2ComputePoolsExecute(r ApiListFcpmV2ComputePoolsRequest) (FcpmV2ComputePoolList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -836,9 +839,9 @@ UpdateFcpmV2ComputePool Update a Compute Pool
 
 Make a request to update a compute pool.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param id The unique identifier for the compute pool.
- @return ApiUpdateFcpmV2ComputePoolRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param id The unique identifier for the compute pool.
+	@return ApiUpdateFcpmV2ComputePoolRequest
 */
 func (a *ComputePoolsFcpmV2ApiService) UpdateFcpmV2ComputePool(ctx _context.Context, id string) ApiUpdateFcpmV2ComputePoolRequest {
 	return ApiUpdateFcpmV2ComputePoolRequest{
@@ -849,7 +852,8 @@ func (a *ComputePoolsFcpmV2ApiService) UpdateFcpmV2ComputePool(ctx _context.Cont
 }
 
 // Execute executes the request
-//  @return FcpmV2ComputePool
+//
+//	@return FcpmV2ComputePool
 func (a *ComputePoolsFcpmV2ApiService) UpdateFcpmV2ComputePoolExecute(r ApiUpdateFcpmV2ComputePoolRequest) (FcpmV2ComputePool, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch

--- a/flink/v2/api_iam_bindings_fcpm_v2.go
+++ b/flink/v2/api_iam_bindings_fcpm_v2.go
@@ -115,8 +115,8 @@ CreateFcpmV2IamBinding Create an Iam Binding
 
 Make a request to create an iam binding.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiCreateFcpmV2IamBindingRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiCreateFcpmV2IamBindingRequest
 */
 func (a *IamBindingsFcpmV2ApiService) CreateFcpmV2IamBinding(ctx _context.Context) ApiCreateFcpmV2IamBindingRequest {
 	return ApiCreateFcpmV2IamBindingRequest{
@@ -126,7 +126,8 @@ func (a *IamBindingsFcpmV2ApiService) CreateFcpmV2IamBinding(ctx _context.Contex
 }
 
 // Execute executes the request
-//  @return FcpmV2IamBinding
+//
+//	@return FcpmV2IamBinding
 func (a *IamBindingsFcpmV2ApiService) CreateFcpmV2IamBindingExecute(r ApiCreateFcpmV2IamBindingRequest) (FcpmV2IamBinding, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
@@ -294,9 +295,9 @@ DeleteFcpmV2IamBinding Delete an Iam Binding
 
 Make a request to delete an iam binding.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param id The unique identifier for the iam binding.
- @return ApiDeleteFcpmV2IamBindingRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param id The unique identifier for the iam binding.
+	@return ApiDeleteFcpmV2IamBindingRequest
 */
 func (a *IamBindingsFcpmV2ApiService) DeleteFcpmV2IamBinding(ctx _context.Context, id string) ApiDeleteFcpmV2IamBindingRequest {
 	return ApiDeleteFcpmV2IamBindingRequest{
@@ -487,8 +488,8 @@ ListFcpmV2IamBindings List of Iam Bindings
 
 Retrieve a sorted, filtered, paginated list of all iam bindings.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiListFcpmV2IamBindingsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiListFcpmV2IamBindingsRequest
 */
 func (a *IamBindingsFcpmV2ApiService) ListFcpmV2IamBindings(ctx _context.Context) ApiListFcpmV2IamBindingsRequest {
 	return ApiListFcpmV2IamBindingsRequest{
@@ -498,7 +499,8 @@ func (a *IamBindingsFcpmV2ApiService) ListFcpmV2IamBindings(ctx _context.Context
 }
 
 // Execute executes the request
-//  @return FcpmV2IamBindingList
+//
+//	@return FcpmV2IamBindingList
 func (a *IamBindingsFcpmV2ApiService) ListFcpmV2IamBindingsExecute(r ApiListFcpmV2IamBindingsRequest) (FcpmV2IamBindingList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet

--- a/flink/v2/api_regions_fcpm_v2.go
+++ b/flink/v2/api_regions_fcpm_v2.go
@@ -104,8 +104,8 @@ ListFcpmV2Regions List of Regions
 
 Retrieve a sorted, filtered, paginated list of all regions.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiListFcpmV2RegionsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiListFcpmV2RegionsRequest
 */
 func (a *RegionsFcpmV2ApiService) ListFcpmV2Regions(ctx _context.Context) ApiListFcpmV2RegionsRequest {
 	return ApiListFcpmV2RegionsRequest{
@@ -115,7 +115,8 @@ func (a *RegionsFcpmV2ApiService) ListFcpmV2Regions(ctx _context.Context) ApiLis
 }
 
 // Execute executes the request
-//  @return FcpmV2RegionList
+//
+//	@return FcpmV2RegionList
 func (a *RegionsFcpmV2ApiService) ListFcpmV2RegionsExecute(r ApiListFcpmV2RegionsRequest) (FcpmV2RegionList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet

--- a/flink/v2/docs/ComputePoolsFcpmV2Api.md
+++ b/flink/v2/docs/ComputePoolsFcpmV2Api.md
@@ -66,7 +66,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key)
+[cloud-api-key](../README.md#cloud-api-key)
 
 ### HTTP request headers
 
@@ -136,7 +136,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key)
+[cloud-api-key](../README.md#cloud-api-key)
 
 ### HTTP request headers
 
@@ -208,7 +208,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key)
+[cloud-api-key](../README.md#cloud-api-key)
 
 ### HTTP request headers
 
@@ -282,7 +282,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key)
+[cloud-api-key](../README.md#cloud-api-key)
 
 ### HTTP request headers
 
@@ -354,7 +354,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key)
+[cloud-api-key](../README.md#cloud-api-key)
 
 ### HTTP request headers
 

--- a/flink/v2/docs/FcpmV2ComputePoolSpecUpdate.md
+++ b/flink/v2/docs/FcpmV2ComputePoolSpecUpdate.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**DisplayName** | Pointer to **string** | The name of the Flink compute pool. | [optional] 
 **MaxCfu** | Pointer to **int32** | Maximum number of Confluent Flink Units (CFUs) that the Flink compute pool should auto-scale to.  | [optional] 
 **Environment** | Pointer to [**GlobalObjectReference**](GlobalObjectReference.md) | The environment to which this belongs. | [optional] 
 
@@ -25,6 +26,31 @@ will change when the set of required properties is changed
 NewFcpmV2ComputePoolSpecUpdateWithDefaults instantiates a new FcpmV2ComputePoolSpecUpdate object
 This constructor will only assign default values to properties that have it defined,
 but it doesn't guarantee that properties required by API are set
+
+### GetDisplayName
+
+`func (o *FcpmV2ComputePoolSpecUpdate) GetDisplayName() string`
+
+GetDisplayName returns the DisplayName field if non-nil, zero value otherwise.
+
+### GetDisplayNameOk
+
+`func (o *FcpmV2ComputePoolSpecUpdate) GetDisplayNameOk() (*string, bool)`
+
+GetDisplayNameOk returns a tuple with the DisplayName field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetDisplayName
+
+`func (o *FcpmV2ComputePoolSpecUpdate) SetDisplayName(v string)`
+
+SetDisplayName sets DisplayName field to given value.
+
+### HasDisplayName
+
+`func (o *FcpmV2ComputePoolSpecUpdate) HasDisplayName() bool`
+
+HasDisplayName returns a boolean if a field has been set.
 
 ### GetMaxCfu
 

--- a/flink/v2/docs/IamBindingsFcpmV2Api.md
+++ b/flink/v2/docs/IamBindingsFcpmV2Api.md
@@ -64,7 +64,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key)
+[cloud-api-key](../README.md#cloud-api-key)
 
 ### HTTP request headers
 
@@ -136,7 +136,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key)
+[cloud-api-key](../README.md#cloud-api-key)
 
 ### HTTP request headers
 
@@ -212,7 +212,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key)
+[cloud-api-key](../README.md#cloud-api-key)
 
 ### HTTP request headers
 

--- a/flink/v2/docs/RegionsFcpmV2Api.md
+++ b/flink/v2/docs/RegionsFcpmV2Api.md
@@ -68,7 +68,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key)
+[cloud-api-key](../README.md#cloud-api-key)
 
 ### HTTP request headers
 

--- a/flink/v2/model_fcpm_v2_compute_pool_spec_update.go
+++ b/flink/v2/model_fcpm_v2_compute_pool_spec_update.go
@@ -36,6 +36,8 @@ import (
 
 // FcpmV2ComputePoolSpecUpdate The desired state of the Compute Pool
 type FcpmV2ComputePoolSpecUpdate struct {
+	// The name of the Flink compute pool.
+	DisplayName *string `json:"display_name,omitempty"`
 	// Maximum number of Confluent Flink Units (CFUs) that the Flink compute pool should auto-scale to.
 	MaxCfu *int32 `json:"max_cfu,omitempty"`
 	// The environment to which this belongs.
@@ -57,6 +59,38 @@ func NewFcpmV2ComputePoolSpecUpdate() *FcpmV2ComputePoolSpecUpdate {
 func NewFcpmV2ComputePoolSpecUpdateWithDefaults() *FcpmV2ComputePoolSpecUpdate {
 	this := FcpmV2ComputePoolSpecUpdate{}
 	return &this
+}
+
+// GetDisplayName returns the DisplayName field value if set, zero value otherwise.
+func (o *FcpmV2ComputePoolSpecUpdate) GetDisplayName() string {
+	if o == nil || o.DisplayName == nil {
+		var ret string
+		return ret
+	}
+	return *o.DisplayName
+}
+
+// GetDisplayNameOk returns a tuple with the DisplayName field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *FcpmV2ComputePoolSpecUpdate) GetDisplayNameOk() (*string, bool) {
+	if o == nil || o.DisplayName == nil {
+		return nil, false
+	}
+	return o.DisplayName, true
+}
+
+// HasDisplayName returns a boolean if a field has been set.
+func (o *FcpmV2ComputePoolSpecUpdate) HasDisplayName() bool {
+	if o != nil && o.DisplayName != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetDisplayName gets a reference to the given string and assigns it to the DisplayName field.
+func (o *FcpmV2ComputePoolSpecUpdate) SetDisplayName(v string) {
+	o.DisplayName = &v
 }
 
 // GetMaxCfu returns the MaxCfu field value if set, zero value otherwise.
@@ -125,6 +159,7 @@ func (o *FcpmV2ComputePoolSpecUpdate) SetEnvironment(v GlobalObjectReference) {
 
 // Redact resets all sensitive fields to their zero value.
 func (o *FcpmV2ComputePoolSpecUpdate) Redact() {
+	o.recurseRedact(o.DisplayName)
 	o.recurseRedact(o.MaxCfu)
 	o.recurseRedact(o.Environment)
 }
@@ -161,6 +196,9 @@ func (o FcpmV2ComputePoolSpecUpdate) zeroField(v interface{}) {
 
 func (o FcpmV2ComputePoolSpecUpdate) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
+	if o.DisplayName != nil {
+		toSerialize["display_name"] = o.DisplayName
+	}
 	if o.MaxCfu != nil {
 		toSerialize["max_cfu"] = o.MaxCfu
 	}


### PR DESCRIPTION
go get -v

```
internal/unsafeheader
encoding
math/bits
math
unicode/utf16
crypto/internal/subtle
crypto/subtle
crypto/internal/boring/sig
vendor/golang.org/x/crypto/cryptobyte/asn1
internal/nettrace
container/list
vendor/golang.org/x/crypto/internal/subtle
internal/goos
internal/goarch
internal/race
internal/itoa
internal/cpu
unicode/utf8
internal/goexperiment
runtime/internal/math
unicode
internal/abi
runtime/internal/sys
sync/atomic
runtime/internal/atomic
internal/bytealg
runtime
internal/reflectlite
errors
sync
internal/oserror
path
sort
vendor/golang.org/x/net/dns/dnsmessage
internal/testlog
internal/singleflight
io
hash
math/rand
crypto/internal/randutil
bytes
strconv
strings
crypto/internal/nistec/fiat
vendor/golang.org/x/text/transform
crypto
crypto/rc4
hash/crc32
net/http/internal/ascii
bufio
reflect
regexp/syntax
internal/fmtsort
encoding/binary
syscall
regexp
encoding/base64
vendor/golang.org/x/crypto/internal/poly1305
internal/syscall/execenv
crypto/md5
encoding/pem
crypto/internal/edwards25519/field
vendor/golang.org/x/crypto/curve25519/internal/field
internal/syscall/unix
crypto/cipher
crypto/internal/edwards25519
time
crypto/internal/boring
crypto/des
vendor/golang.org/x/crypto/chacha20
context
crypto/hmac
crypto/sha512
crypto/sha256
crypto/sha1
vendor/golang.org/x/crypto/chacha20poly1305
io/fs
vendor/golang.org/x/crypto/hkdf
crypto/aes
embed
internal/poll
crypto/internal/nistec
os
internal/godebug
io/ioutil
path/filepath
fmt
internal/intern
encoding/hex
net/url
net/netip
crypto/x509/internal/macos
vendor/golang.org/x/crypto/curve25519
encoding/xml
vendor/golang.org/x/net/route
log
compress/flate
mime/quotedprintable
encoding/json
net/http/internal
compress/gzip
mime
vendor/golang.org/x/net/http2/hpack
vendor/golang.org/x/text/unicode/bidi
vendor/golang.org/x/text/unicode/norm
vendor/golang.org/x/text/secure/bidirule
math/big
crypto/internal/boring/bbig
crypto/dsa
crypto/rand
vendor/golang.org/x/net/idna
crypto/elliptic
encoding/asn1
crypto/ed25519
crypto/rsa
vendor/golang.org/x/crypto/cryptobyte
crypto/x509/pkix
crypto/ecdsa
runtime/cgo
net
vendor/golang.org/x/net/http/httpproxy
net/textproto
vendor/golang.org/x/net/http/httpguts
mime/multipart
crypto/x509
crypto/tls
net/http/httptrace
net/http
net/http/httputil
golang.org/x/net/context/ctxhttp
golang.org/x/oauth2/internal
golang.org/x/oauth2
github.com/confluentinc/ccloud-sdk-go-v2
```