### PR TITLE
Regenerate Kafka REST SDK to include updates to MirrorTopicStatus

### DIFF
--- a/kafkarest/v3/README.md
+++ b/kafkarest/v3/README.md
@@ -277,22 +277,7 @@ Class | Method | HTTP request | Description
 
 
 
-### api-key
-
-- **Type**: HTTP basic authentication
-
-Example
-
-```golang
-auth := context.WithValue(context.Background(), sw.ContextBasicAuth, sw.BasicAuth{
-    UserName: "username",
-    Password: "password",
-})
-r, err := client.Service.Operation(auth, args)
-```
-
-
-### confluent-sts-access-token
+### external-access-token
 
 
 - **Type**: OAuth
@@ -316,6 +301,21 @@ import "golang.org/x/oauth2"
 
 tokenSource := oauth2cfg.TokenSource(createContext(httpClient), &token)
 auth := context.WithValue(oauth2.NoContext, sw.ContextOAuth2, tokenSource)
+r, err := client.Service.Operation(auth, args)
+```
+
+
+### resource-api-key
+
+- **Type**: HTTP basic authentication
+
+Example
+
+```golang
+auth := context.WithValue(context.Background(), sw.ContextBasicAuth, sw.BasicAuth{
+    UserName: "username",
+    Password: "password",
+})
 r, err := client.Service.Operation(auth, args)
 ```
 

--- a/kafkarest/v3/api/openapi.yaml
+++ b/kafkarest/v3/api/openapi.yaml
@@ -156,8 +156,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Get Cluster
       tags:
       - Cluster (v3)
@@ -339,8 +339,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Batch Create ACLs
       tags:
       - ACL (v3)
@@ -350,6 +350,7 @@ paths:
           curl --request POST \
             --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls:batch \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
+            --header 'content-type: application/json' \
             --data '{"data":[{"resource_type":"UNKNOWN","resource_name":"string","pattern_type":"string","principal":"string","host":"string","operation":"string","permission":"string"}]}'
       - lang: Java
         source: |-
@@ -361,6 +362,7 @@ paths:
             .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls:batch")
             .post(body)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
+            .addHeader("content-type", "application/json")
             .build();
 
           Response response = client.newCall(request).execute();
@@ -372,9 +374,10 @@ paths:
           \":\\\"string\\\",\\\"principal\\\":\\\"string\\\",\\\"host\\\":\\\"string\\\
           \",\\\"operation\\\":\\\"string\\\",\\\"permission\\\":\\\"string\\\"}]}\"\
           )\n\n\treq, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"\
-          Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
-          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
-          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\treq.Header.Add(\"content-type\"\
+          , \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\t\
+          defer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\
+          \tfmt.Println(string(body))\n\n}"
       - lang: Python
         source: |-
           import http.client
@@ -383,7 +386,10 @@ paths:
 
           payload = "{\"data\":[{\"resource_type\":\"UNKNOWN\",\"resource_name\":\"string\",\"pattern_type\":\"string\",\"principal\":\"string\",\"host\":\"string\",\"operation\":\"string\",\"permission\":\"string\"}]}"
 
-          headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
+          headers = {
+              'Authorization': "Basic REPLACE_BASIC_AUTH",
+              'content-type': "application/json"
+              }
 
           conn.request("POST", "/kafka/v3/clusters/cluster-1/acls:batch", payload, headers)
 
@@ -401,7 +407,8 @@ paths:
             "port": null,
             "path": "/kafka/v3/clusters/cluster-1/acls:batch",
             "headers": {
-              "Authorization": "Basic REPLACE_BASIC_AUTH"
+              "Authorization": "Basic REPLACE_BASIC_AUTH",
+              "content-type": "application/json"
             }
           };
 
@@ -441,6 +448,7 @@ paths:
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
+          headers = curl_slist_append(headers, "content-type: application/json");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
           curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"data\":[{\"resource_type\":\"UNKNOWN\",\"resource_name\":\"string\",\"pattern_type\":\"string\",\"principal\":\"string\",\"host\":\"string\",\"operation\":\"string\",\"permission\":\"string\"}]}");
@@ -451,7 +459,8 @@ paths:
           var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls:batch");
           var request = new RestRequest(Method.POST);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("undefined", "{\"data\":[{\"resource_type\":\"UNKNOWN\",\"resource_name\":\"string\",\"pattern_type\":\"string\",\"principal\":\"string\",\"host\":\"string\",\"operation\":\"string\",\"permission\":\"string\"}]}", ParameterType.RequestBody);
+          request.AddHeader("content-type", "application/json");
+          request.AddParameter("application/json", "{\"data\":[{\"resource_type\":\"UNKNOWN\",\"resource_name\":\"string\",\"pattern_type\":\"string\",\"principal\":\"string\",\"host\":\"string\",\"operation\":\"string\",\"permission\":\"string\"}]}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /kafka/v3/clusters/{cluster_id}/acls:
     delete:
@@ -629,8 +638,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Delete ACLs
       tags:
       - ACL (v3)
@@ -638,14 +647,14 @@ paths:
       - lang: Shell
         source: |-
           curl --request DELETE \
-            --url 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE' \
+            --url 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&resource_name=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&principal=SOME_STRING_VALUE&host=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           Request request = new Request.Builder()
-            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE")
+            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&resource_name=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&principal=SOME_STRING_VALUE&host=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE")
             .delete(null)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
             .build();
@@ -653,7 +662,7 @@ paths:
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io/ioutil\"\
-          \n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE\"\
+          \n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&resource_name=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&principal=SOME_STRING_VALUE&host=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE\"\
           \n\n\treq, _ := http.NewRequest(\"DELETE\", url, nil)\n\n\treq.Header.Add(\"\
           Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
           \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
@@ -666,7 +675,7 @@ paths:
 
           headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
 
-          conn.request("DELETE", "/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE", headers=headers)
+          conn.request("DELETE", "/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&resource_name=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&principal=SOME_STRING_VALUE&host=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE", headers=headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -680,7 +689,7 @@ paths:
             "method": "DELETE",
             "hostname": "pkc-00000.region.provider.confluent.cloud",
             "port": null,
-            "path": "/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE",
+            "path": "/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&resource_name=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&principal=SOME_STRING_VALUE&host=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE",
             "headers": {
               "Authorization": "Basic REPLACE_BASIC_AUTH"
             }
@@ -705,7 +714,7 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "DELETE");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&resource_name=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&principal=SOME_STRING_VALUE&host=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
@@ -714,7 +723,7 @@ paths:
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE");
+          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&resource_name=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&principal=SOME_STRING_VALUE&host=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE");
           var request = new RestRequest(Method.DELETE);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
           IRestResponse response = client.Execute(request);
@@ -904,8 +913,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: List ACLs
       tags:
       - ACL (v3)
@@ -913,14 +922,14 @@ paths:
       - lang: Shell
         source: |-
           curl --request GET \
-            --url 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE' \
+            --url 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&resource_name=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&principal=SOME_STRING_VALUE&host=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           Request request = new Request.Builder()
-            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE")
+            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&resource_name=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&principal=SOME_STRING_VALUE&host=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE")
             .get()
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
             .build();
@@ -928,7 +937,7 @@ paths:
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io/ioutil\"\
-          \n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE\"\
+          \n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&resource_name=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&principal=SOME_STRING_VALUE&host=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE\"\
           \n\n\treq, _ := http.NewRequest(\"GET\", url, nil)\n\n\treq.Header.Add(\"\
           Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
           \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
@@ -941,7 +950,7 @@ paths:
 
           headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
 
-          conn.request("GET", "/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE", headers=headers)
+          conn.request("GET", "/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&resource_name=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&principal=SOME_STRING_VALUE&host=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE", headers=headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -955,7 +964,7 @@ paths:
             "method": "GET",
             "hostname": "pkc-00000.region.provider.confluent.cloud",
             "port": null,
-            "path": "/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE",
+            "path": "/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&resource_name=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&principal=SOME_STRING_VALUE&host=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE",
             "headers": {
               "Authorization": "Basic REPLACE_BASIC_AUTH"
             }
@@ -980,7 +989,7 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "GET");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&resource_name=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&principal=SOME_STRING_VALUE&host=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
@@ -989,7 +998,7 @@ paths:
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE");
+          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls?resource_type=SOME_STRING_VALUE&resource_name=SOME_STRING_VALUE&pattern_type=SOME_STRING_VALUE&principal=SOME_STRING_VALUE&host=SOME_STRING_VALUE&operation=SOME_STRING_VALUE&permission=SOME_STRING_VALUE");
           var request = new RestRequest(Method.GET);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
           IRestResponse response = client.Execute(request);
@@ -1086,8 +1095,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Create an ACL
       tags:
       - ACL (v3)
@@ -1097,6 +1106,7 @@ paths:
           curl --request POST \
             --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
+            --header 'content-type: application/json' \
             --data '{"resource_type":"UNKNOWN","resource_name":"string","pattern_type":"string","principal":"string","host":"string","operation":"string","permission":"string"}'
       - lang: Java
         source: |-
@@ -1108,6 +1118,7 @@ paths:
             .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls")
             .post(body)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
+            .addHeader("content-type", "application/json")
             .build();
 
           Response response = client.newCall(request).execute();
@@ -1119,8 +1130,9 @@ paths:
           \",\\\"principal\\\":\\\"string\\\",\\\"host\\\":\\\"string\\\",\\\"operation\\\
           \":\\\"string\\\",\\\"permission\\\":\\\"string\\\"}\")\n\n\treq, _ := http.NewRequest(\"\
           POST\", url, payload)\n\n\treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\"\
-          )\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\
-          \tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
+          )\n\treq.Header.Add(\"content-type\", \"application/json\")\n\n\tres, _\
+          \ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ :=\
+          \ ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
           \n}"
       - lang: Python
         source: |-
@@ -1130,7 +1142,10 @@ paths:
 
           payload = "{\"resource_type\":\"UNKNOWN\",\"resource_name\":\"string\",\"pattern_type\":\"string\",\"principal\":\"string\",\"host\":\"string\",\"operation\":\"string\",\"permission\":\"string\"}"
 
-          headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
+          headers = {
+              'Authorization': "Basic REPLACE_BASIC_AUTH",
+              'content-type': "application/json"
+              }
 
           conn.request("POST", "/kafka/v3/clusters/cluster-1/acls", payload, headers)
 
@@ -1148,7 +1163,8 @@ paths:
             "port": null,
             "path": "/kafka/v3/clusters/cluster-1/acls",
             "headers": {
-              "Authorization": "Basic REPLACE_BASIC_AUTH"
+              "Authorization": "Basic REPLACE_BASIC_AUTH",
+              "content-type": "application/json"
             }
           };
 
@@ -1184,6 +1200,7 @@ paths:
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
+          headers = curl_slist_append(headers, "content-type: application/json");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
           curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"resource_type\":\"UNKNOWN\",\"resource_name\":\"string\",\"pattern_type\":\"string\",\"principal\":\"string\",\"host\":\"string\",\"operation\":\"string\",\"permission\":\"string\"}");
@@ -1194,7 +1211,8 @@ paths:
           var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/acls");
           var request = new RestRequest(Method.POST);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("undefined", "{\"resource_type\":\"UNKNOWN\",\"resource_name\":\"string\",\"pattern_type\":\"string\",\"principal\":\"string\",\"host\":\"string\",\"operation\":\"string\",\"permission\":\"string\"}", ParameterType.RequestBody);
+          request.AddHeader("content-type", "application/json");
+          request.AddParameter("application/json", "{\"resource_type\":\"UNKNOWN\",\"resource_name\":\"string\",\"pattern_type\":\"string\",\"principal\":\"string\",\"host\":\"string\",\"operation\":\"string\",\"permission\":\"string\"}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /kafka/v3/clusters/{cluster_id}/broker-configs:
     get:
@@ -1345,8 +1363,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: List Dynamic Broker Configs
       tags:
       - Configs (v3)
@@ -1536,8 +1554,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Batch Alter Dynamic Broker Configs
       tags:
       - Configs (v3)
@@ -1547,6 +1565,7 @@ paths:
           curl --request POST \
             --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs:alter \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
+            --header 'content-type: application/json' \
             --data '{"data":[{"name":"string","value":"string","operation":"string"}],"validate_only":true}'
       - lang: Java
         source: |-
@@ -1558,6 +1577,7 @@ paths:
             .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs:alter")
             .post(body)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
+            .addHeader("content-type", "application/json")
             .build();
 
           Response response = client.newCall(request).execute();
@@ -1568,8 +1588,9 @@ paths:
           \",\\\"value\\\":\\\"string\\\",\\\"operation\\\":\\\"string\\\"}],\\\"\
           validate_only\\\":true}\")\n\n\treq, _ := http.NewRequest(\"POST\", url,\
           \ payload)\n\n\treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\"\
-          )\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\
-          \tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
+          )\n\treq.Header.Add(\"content-type\", \"application/json\")\n\n\tres, _\
+          \ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ :=\
+          \ ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
           \n}"
       - lang: Python
         source: |-
@@ -1579,7 +1600,10 @@ paths:
 
           payload = "{\"data\":[{\"name\":\"string\",\"value\":\"string\",\"operation\":\"string\"}],\"validate_only\":true}"
 
-          headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
+          headers = {
+              'Authorization': "Basic REPLACE_BASIC_AUTH",
+              'content-type': "application/json"
+              }
 
           conn.request("POST", "/kafka/v3/clusters/cluster-1/broker-configs:alter", payload, headers)
 
@@ -1597,7 +1621,8 @@ paths:
             "port": null,
             "path": "/kafka/v3/clusters/cluster-1/broker-configs:alter",
             "headers": {
-              "Authorization": "Basic REPLACE_BASIC_AUTH"
+              "Authorization": "Basic REPLACE_BASIC_AUTH",
+              "content-type": "application/json"
             }
           };
 
@@ -1628,6 +1653,7 @@ paths:
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
+          headers = curl_slist_append(headers, "content-type: application/json");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
           curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"data\":[{\"name\":\"string\",\"value\":\"string\",\"operation\":\"string\"}],\"validate_only\":true}");
@@ -1638,7 +1664,8 @@ paths:
           var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs:alter");
           var request = new RestRequest(Method.POST);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("undefined", "{\"data\":[{\"name\":\"string\",\"value\":\"string\",\"operation\":\"string\"}],\"validate_only\":true}", ParameterType.RequestBody);
+          request.AddHeader("content-type", "application/json");
+          request.AddParameter("application/json", "{\"data\":[{\"name\":\"string\",\"value\":\"string\",\"operation\":\"string\"}],\"validate_only\":true}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /kafka/v3/clusters/{cluster_id}/broker-configs/{name}:
     delete:
@@ -1750,8 +1777,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Reset Dynamic Broker Config
       tags:
       - Configs (v3)
@@ -1971,8 +1998,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Get Dynamic Broker Config
       tags:
       - Configs (v3)
@@ -2170,8 +2197,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Update Dynamic Broker Config
       tags:
       - Configs (v3)
@@ -2181,6 +2208,7 @@ paths:
           curl --request PUT \
             --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs/compression.type \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
+            --header 'content-type: application/json' \
             --data '{"value":"string"}'
       - lang: Java
         source: |-
@@ -2192,6 +2220,7 @@ paths:
             .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs/compression.type")
             .put(body)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
+            .addHeader("content-type", "application/json")
             .build();
 
           Response response = client.newCall(request).execute();
@@ -2200,9 +2229,10 @@ paths:
           \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs/compression.type\"\
           \n\n\tpayload := strings.NewReader(\"{\\\"value\\\":\\\"string\\\"}\")\n\
           \n\treq, _ := http.NewRequest(\"PUT\", url, payload)\n\n\treq.Header.Add(\"\
-          Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
-          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
-          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\treq.Header.Add(\"content-type\"\
+          , \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\t\
+          defer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\
+          \tfmt.Println(string(body))\n\n}"
       - lang: Python
         source: |-
           import http.client
@@ -2211,7 +2241,10 @@ paths:
 
           payload = "{\"value\":\"string\"}"
 
-          headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
+          headers = {
+              'Authorization': "Basic REPLACE_BASIC_AUTH",
+              'content-type': "application/json"
+              }
 
           conn.request("PUT", "/kafka/v3/clusters/cluster-1/broker-configs/compression.type", payload, headers)
 
@@ -2229,7 +2262,8 @@ paths:
             "port": null,
             "path": "/kafka/v3/clusters/cluster-1/broker-configs/compression.type",
             "headers": {
-              "Authorization": "Basic REPLACE_BASIC_AUTH"
+              "Authorization": "Basic REPLACE_BASIC_AUTH",
+              "content-type": "application/json"
             }
           };
 
@@ -2257,6 +2291,7 @@ paths:
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
+          headers = curl_slist_append(headers, "content-type: application/json");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
           curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"value\":\"string\"}");
@@ -2267,7 +2302,8 @@ paths:
           var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/broker-configs/compression.type");
           var request = new RestRequest(Method.PUT);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("undefined", "{\"value\":\"string\"}", ParameterType.RequestBody);
+          request.AddHeader("content-type", "application/json");
+          request.AddParameter("application/json", "{\"value\":\"string\"}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /kafka/v3/clusters/{cluster_id}/consumer-groups:
     get:
@@ -2425,8 +2461,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: List Consumer Groups
       tags:
       - Consumer Group (v3)
@@ -2643,8 +2679,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Get Consumer Group
       tags:
       - Consumer Group (v3)
@@ -2885,8 +2921,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: List Consumers
       tags:
       - Consumer Group (v3)
@@ -3106,8 +3142,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Get Consumer Group Lag Summary
       tags:
       - Consumer Group (v3)
@@ -3357,8 +3393,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: List Consumer Lags
       tags:
       - Consumer Group (v3)
@@ -3592,8 +3628,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Get Consumer Lag
       tags:
       - Consumer Group (v3)
@@ -3815,8 +3851,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Get Consumer
       tags:
       - Consumer Group (v3)
@@ -4059,8 +4095,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: List Topics
       tags:
       - Topic (v3)
@@ -4293,8 +4329,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Create Topic
       tags:
       - Topic (v3)
@@ -4304,6 +4340,7 @@ paths:
           curl --request POST \
             --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
+            --header 'content-type: application/json' \
             --data '{"topic_name":"string","partitions_count":0,"replication_factor":0,"configs":[{"name":"string","value":"string"}],"validate_only":true}'
       - lang: Java
         source: |-
@@ -4315,6 +4352,7 @@ paths:
             .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics")
             .post(body)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
+            .addHeader("content-type", "application/json")
             .build();
 
           Response response = client.newCall(request).execute();
@@ -4325,10 +4363,10 @@ paths:
           ,\\\"partitions_count\\\":0,\\\"replication_factor\\\":0,\\\"configs\\\"\
           :[{\\\"name\\\":\\\"string\\\",\\\"value\\\":\\\"string\\\"}],\\\"validate_only\\\
           \":true}\")\n\n\treq, _ := http.NewRequest(\"POST\", url, payload)\n\n\t\
-          req.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres,\
-          \ _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _\
-          \ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
-          \n}"
+          req.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\treq.Header.Add(\"\
+          content-type\", \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
+          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
+          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
       - lang: Python
         source: |-
           import http.client
@@ -4337,7 +4375,10 @@ paths:
 
           payload = "{\"topic_name\":\"string\",\"partitions_count\":0,\"replication_factor\":0,\"configs\":[{\"name\":\"string\",\"value\":\"string\"}],\"validate_only\":true}"
 
-          headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
+          headers = {
+              'Authorization': "Basic REPLACE_BASIC_AUTH",
+              'content-type': "application/json"
+              }
 
           conn.request("POST", "/kafka/v3/clusters/cluster-1/topics", payload, headers)
 
@@ -4355,7 +4396,8 @@ paths:
             "port": null,
             "path": "/kafka/v3/clusters/cluster-1/topics",
             "headers": {
-              "Authorization": "Basic REPLACE_BASIC_AUTH"
+              "Authorization": "Basic REPLACE_BASIC_AUTH",
+              "content-type": "application/json"
             }
           };
 
@@ -4389,6 +4431,7 @@ paths:
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
+          headers = curl_slist_append(headers, "content-type: application/json");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
           curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"topic_name\":\"string\",\"partitions_count\":0,\"replication_factor\":0,\"configs\":[{\"name\":\"string\",\"value\":\"string\"}],\"validate_only\":true}");
@@ -4399,7 +4442,8 @@ paths:
           var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics");
           var request = new RestRequest(Method.POST);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("undefined", "{\"topic_name\":\"string\",\"partitions_count\":0,\"replication_factor\":0,\"configs\":[{\"name\":\"string\",\"value\":\"string\"}],\"validate_only\":true}", ParameterType.RequestBody);
+          request.AddHeader("content-type", "application/json");
+          request.AddParameter("application/json", "{\"topic_name\":\"string\",\"partitions_count\":0,\"replication_factor\":0,\"configs\":[{\"name\":\"string\",\"value\":\"string\"}],\"validate_only\":true}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /kafka/v3/clusters/{cluster_id}/topics/{topic_name}:
     delete:
@@ -4535,8 +4579,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Delete Topic
       tags:
       - Topic (v3)
@@ -4785,8 +4829,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Get Topic
       tags:
       - Topic (v3)
@@ -4794,14 +4838,14 @@ paths:
       - lang: Shell
         source: |-
           curl --request GET \
-            --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1 \
+            --url 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1?include_authorized_operations=SOME_BOOLEAN_VALUE' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           Request request = new Request.Builder()
-            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1")
+            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1?include_authorized_operations=SOME_BOOLEAN_VALUE")
             .get()
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
             .build();
@@ -4809,7 +4853,7 @@ paths:
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io/ioutil\"\
-          \n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1\"\
+          \n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1?include_authorized_operations=SOME_BOOLEAN_VALUE\"\
           \n\n\treq, _ := http.NewRequest(\"GET\", url, nil)\n\n\treq.Header.Add(\"\
           Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
           \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
@@ -4822,7 +4866,7 @@ paths:
 
           headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
 
-          conn.request("GET", "/kafka/v3/clusters/cluster-1/topics/topic-1", headers=headers)
+          conn.request("GET", "/kafka/v3/clusters/cluster-1/topics/topic-1?include_authorized_operations=SOME_BOOLEAN_VALUE", headers=headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -4836,7 +4880,7 @@ paths:
             "method": "GET",
             "hostname": "pkc-00000.region.provider.confluent.cloud",
             "port": null,
-            "path": "/kafka/v3/clusters/cluster-1/topics/topic-1",
+            "path": "/kafka/v3/clusters/cluster-1/topics/topic-1?include_authorized_operations=SOME_BOOLEAN_VALUE",
             "headers": {
               "Authorization": "Basic REPLACE_BASIC_AUTH"
             }
@@ -4861,7 +4905,7 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "GET");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1?include_authorized_operations=SOME_BOOLEAN_VALUE");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
@@ -4870,7 +4914,7 @@ paths:
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1");
+          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1?include_authorized_operations=SOME_BOOLEAN_VALUE");
           var request = new RestRequest(Method.GET);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
           IRestResponse response = client.Execute(request);
@@ -4999,8 +5043,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Update Partition Count
       tags:
       - Topic (v3)
@@ -5021,8 +5065,8 @@ paths:
           Request request = new Request.Builder()
             .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1")
             .patch(body)
-            .addHeader("content-type", "application/json")
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
+            .addHeader("content-type", "application/json")
             .build();
 
           Response response = client.newCall(request).execute();
@@ -5031,10 +5075,10 @@ paths:
           \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1\"\
           \n\n\tpayload := strings.NewReader(\"{\\\"partitions_count\\\":0}\")\n\n\
           \treq, _ := http.NewRequest(\"PATCH\", url, payload)\n\n\treq.Header.Add(\"\
-          content-type\", \"application/json\")\n\treq.Header.Add(\"Authorization\"\
-          , \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
-          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
-          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\treq.Header.Add(\"content-type\"\
+          , \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\t\
+          defer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\
+          \tfmt.Println(string(body))\n\n}"
       - lang: Python
         source: |-
           import http.client
@@ -5044,8 +5088,8 @@ paths:
           payload = "{\"partitions_count\":0}"
 
           headers = {
-              'content-type': "application/json",
-              'Authorization': "Basic REPLACE_BASIC_AUTH"
+              'Authorization': "Basic REPLACE_BASIC_AUTH",
+              'content-type': "application/json"
               }
 
           conn.request("PATCH", "/kafka/v3/clusters/cluster-1/topics/topic-1", payload, headers)
@@ -5064,8 +5108,8 @@ paths:
             "port": null,
             "path": "/kafka/v3/clusters/cluster-1/topics/topic-1",
             "headers": {
-              "content-type": "application/json",
-              "Authorization": "Basic REPLACE_BASIC_AUTH"
+              "Authorization": "Basic REPLACE_BASIC_AUTH",
+              "content-type": "application/json"
             }
           };
 
@@ -5092,8 +5136,8 @@ paths:
           curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1");
 
           struct curl_slist *headers = NULL;
-          headers = curl_slist_append(headers, "content-type: application/json");
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
+          headers = curl_slist_append(headers, "content-type: application/json");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
           curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"partitions_count\":0}");
@@ -5103,8 +5147,8 @@ paths:
         source: |-
           var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1");
           var request = new RestRequest(Method.PATCH);
-          request.AddHeader("content-type", "application/json");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
+          request.AddHeader("content-type", "application/json");
           request.AddParameter("application/json", "{\"partitions_count\":0}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/configs:
@@ -5289,8 +5333,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: List Topic Configs
       tags:
       - Configs (v3)
@@ -5516,8 +5560,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Batch Alter Topic Configs
       tags:
       - Configs (v3)
@@ -5527,6 +5571,7 @@ paths:
           curl --request POST \
             --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs:alter \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
+            --header 'content-type: application/json' \
             --data '{"data":[{"name":"string","value":"string","operation":"string"}],"validate_only":true}'
       - lang: Java
         source: |-
@@ -5538,6 +5583,7 @@ paths:
             .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs:alter")
             .post(body)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
+            .addHeader("content-type", "application/json")
             .build();
 
           Response response = client.newCall(request).execute();
@@ -5548,8 +5594,9 @@ paths:
           \",\\\"value\\\":\\\"string\\\",\\\"operation\\\":\\\"string\\\"}],\\\"\
           validate_only\\\":true}\")\n\n\treq, _ := http.NewRequest(\"POST\", url,\
           \ payload)\n\n\treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\"\
-          )\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\
-          \tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
+          )\n\treq.Header.Add(\"content-type\", \"application/json\")\n\n\tres, _\
+          \ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ :=\
+          \ ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
           \n}"
       - lang: Python
         source: |-
@@ -5559,7 +5606,10 @@ paths:
 
           payload = "{\"data\":[{\"name\":\"string\",\"value\":\"string\",\"operation\":\"string\"}],\"validate_only\":true}"
 
-          headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
+          headers = {
+              'Authorization': "Basic REPLACE_BASIC_AUTH",
+              'content-type': "application/json"
+              }
 
           conn.request("POST", "/kafka/v3/clusters/cluster-1/topics/topic-1/configs:alter", payload, headers)
 
@@ -5577,7 +5627,8 @@ paths:
             "port": null,
             "path": "/kafka/v3/clusters/cluster-1/topics/topic-1/configs:alter",
             "headers": {
-              "Authorization": "Basic REPLACE_BASIC_AUTH"
+              "Authorization": "Basic REPLACE_BASIC_AUTH",
+              "content-type": "application/json"
             }
           };
 
@@ -5608,6 +5659,7 @@ paths:
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
+          headers = curl_slist_append(headers, "content-type: application/json");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
           curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"data\":[{\"name\":\"string\",\"value\":\"string\",\"operation\":\"string\"}],\"validate_only\":true}");
@@ -5618,7 +5670,8 @@ paths:
           var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs:alter");
           var request = new RestRequest(Method.POST);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("undefined", "{\"data\":[{\"name\":\"string\",\"value\":\"string\",\"operation\":\"string\"}],\"validate_only\":true}", ParameterType.RequestBody);
+          request.AddHeader("content-type", "application/json");
+          request.AddParameter("application/json", "{\"data\":[{\"name\":\"string\",\"value\":\"string\",\"operation\":\"string\"}],\"validate_only\":true}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/configs/{name}:
     delete:
@@ -5763,8 +5816,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Reset Topic Config
       tags:
       - Configs (v3)
@@ -6018,8 +6071,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Get Topic Config
       tags:
       - Configs (v3)
@@ -6251,8 +6304,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Update Topic Config
       tags:
       - Configs (v3)
@@ -6262,6 +6315,7 @@ paths:
           curl --request PUT \
             --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs/compression.type \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
+            --header 'content-type: application/json' \
             --data '{"value":"string"}'
       - lang: Java
         source: |-
@@ -6273,6 +6327,7 @@ paths:
             .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs/compression.type")
             .put(body)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
+            .addHeader("content-type", "application/json")
             .build();
 
           Response response = client.newCall(request).execute();
@@ -6281,9 +6336,10 @@ paths:
           \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs/compression.type\"\
           \n\n\tpayload := strings.NewReader(\"{\\\"value\\\":\\\"string\\\"}\")\n\
           \n\treq, _ := http.NewRequest(\"PUT\", url, payload)\n\n\treq.Header.Add(\"\
-          Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
-          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
-          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\treq.Header.Add(\"content-type\"\
+          , \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\t\
+          defer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\
+          \tfmt.Println(string(body))\n\n}"
       - lang: Python
         source: |-
           import http.client
@@ -6292,7 +6348,10 @@ paths:
 
           payload = "{\"value\":\"string\"}"
 
-          headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
+          headers = {
+              'Authorization': "Basic REPLACE_BASIC_AUTH",
+              'content-type': "application/json"
+              }
 
           conn.request("PUT", "/kafka/v3/clusters/cluster-1/topics/topic-1/configs/compression.type", payload, headers)
 
@@ -6310,7 +6369,8 @@ paths:
             "port": null,
             "path": "/kafka/v3/clusters/cluster-1/topics/topic-1/configs/compression.type",
             "headers": {
-              "Authorization": "Basic REPLACE_BASIC_AUTH"
+              "Authorization": "Basic REPLACE_BASIC_AUTH",
+              "content-type": "application/json"
             }
           };
 
@@ -6338,6 +6398,7 @@ paths:
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
+          headers = curl_slist_append(headers, "content-type: application/json");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
           curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"value\":\"string\"}");
@@ -6348,7 +6409,8 @@ paths:
           var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/configs/compression.type");
           var request = new RestRequest(Method.PUT);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("undefined", "{\"value\":\"string\"}", ParameterType.RequestBody);
+          request.AddHeader("content-type", "application/json");
+          request.AddParameter("application/json", "{\"value\":\"string\"}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/partitions:
     get:
@@ -6533,8 +6595,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: List Partitions
       tags:
       - Partition (v3)
@@ -6783,8 +6845,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Get Partition
       tags:
       - Partition (v3)
@@ -7021,8 +7083,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: List All Topic Configs
       tags:
       - Configs (v3)
@@ -7112,18 +7174,23 @@ paths:
           IRestResponse response = client.Execute(request);
   /kafka/v3/clusters/{cluster_id}/topics/{topic_name}/records:
     post:
-      description: "[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)\n\
-        \nProduce records to the given topic, returning delivery reports for each\n\
-        \            record produced. This API can be used in streaming mode by setting\
-        \ \"Transfer-Encoding:\n            chunked\" header. For as long as the connection\
-        \ is kept open, the server will\n            keep accepting records. Records\
-        \ are streamed to and from the server as Concatenated \n            JSON.\
-        \ For each record sent to the server, the server will\n            asynchronously\
-        \ send back a delivery report, in the same order, each with its own\n    \
-        \        error_code. An error_code of 200 indicates success. The HTTP status\
-        \ code will be HTTP \n            200 OK as long as the connection is successfully\
-        \ established. To identify records\n            that have encountered an error,\
-        \ check the error_code of each delivery report."
+      description: |-
+        [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
+        Produce records to the given topic, returning delivery reports for each
+        record produced. This API can be used in streaming mode by setting
+        "Transfer-Encoding: chunked" header. For as long as the connection is
+        kept open, the server will keep accepting records. Records are streamed
+        to and from the server as Concatenated JSON. For each record sent to the
+        server, the server will asynchronously send back a delivery report, in
+        the same order, each with its own error_code. An error_code of 200
+        indicates success. The HTTP status code will be HTTP 200 OK as long as
+        the connection is successfully established. To identify records that
+        have encountered an error, check the error_code of each delivery report.
+
+        This API currently does not support Schema Registry integration. Sending
+        schemas is not supported. Only BINARY, JSON, and STRING formats are
+        supported.
       operationId: produceRecord
       parameters:
       - description: The Kafka cluster ID.
@@ -7274,8 +7341,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Produce Records
       tags:
       - Records (v3)
@@ -7285,6 +7352,7 @@ paths:
           curl --request POST \
             --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/records \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
+            --header 'content-type: application/json' \
             --data '{"partition_id":0,"headers":[{"name":"string","value":"string"}],"key":{"type":"string","data":null},"value":{"type":"string","data":null},"timestamp":"2019-08-24T14:15:22Z"}'
       - lang: Java
         source: |-
@@ -7296,6 +7364,7 @@ paths:
             .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/records")
             .post(body)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
+            .addHeader("content-type", "application/json")
             .build();
 
           Response response = client.newCall(request).execute();
@@ -7307,9 +7376,10 @@ paths:
           \":{\\\"type\\\":\\\"string\\\",\\\"data\\\":null},\\\"value\\\":{\\\"type\\\
           \":\\\"string\\\",\\\"data\\\":null},\\\"timestamp\\\":\\\"2019-08-24T14:15:22Z\\\
           \"}\")\n\n\treq, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"\
-          Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
-          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
-          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\treq.Header.Add(\"content-type\"\
+          , \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\t\
+          defer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\
+          \tfmt.Println(string(body))\n\n}"
       - lang: Python
         source: |-
           import http.client
@@ -7318,7 +7388,10 @@ paths:
 
           payload = "{\"partition_id\":0,\"headers\":[{\"name\":\"string\",\"value\":\"string\"}],\"key\":{\"type\":\"string\",\"data\":null},\"value\":{\"type\":\"string\",\"data\":null},\"timestamp\":\"2019-08-24T14:15:22Z\"}"
 
-          headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
+          headers = {
+              'Authorization': "Basic REPLACE_BASIC_AUTH",
+              'content-type': "application/json"
+              }
 
           conn.request("POST", "/kafka/v3/clusters/cluster-1/topics/topic-1/records", payload, headers)
 
@@ -7336,7 +7409,8 @@ paths:
             "port": null,
             "path": "/kafka/v3/clusters/cluster-1/topics/topic-1/records",
             "headers": {
-              "Authorization": "Basic REPLACE_BASIC_AUTH"
+              "Authorization": "Basic REPLACE_BASIC_AUTH",
+              "content-type": "application/json"
             }
           };
 
@@ -7370,6 +7444,7 @@ paths:
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
+          headers = curl_slist_append(headers, "content-type: application/json");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
           curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"partition_id\":0,\"headers\":[{\"name\":\"string\",\"value\":\"string\"}],\"key\":{\"type\":\"string\",\"data\":null},\"value\":{\"type\":\"string\",\"data\":null},\"timestamp\":\"2019-08-24T14:15:22Z\"}");
@@ -7380,7 +7455,8 @@ paths:
           var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/topics/topic-1/records");
           var request = new RestRequest(Method.POST);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("undefined", "{\"partition_id\":0,\"headers\":[{\"name\":\"string\",\"value\":\"string\"}],\"key\":{\"type\":\"string\",\"data\":null},\"value\":{\"type\":\"string\",\"data\":null},\"timestamp\":\"2019-08-24T14:15:22Z\"}", ParameterType.RequestBody);
+          request.AddHeader("content-type", "application/json");
+          request.AddParameter("application/json", "{\"partition_id\":0,\"headers\":[{\"name\":\"string\",\"value\":\"string\"}],\"key\":{\"type\":\"string\",\"data\":null},\"value\":{\"type\":\"string\",\"data\":null},\"timestamp\":\"2019-08-24T14:15:22Z\"}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /kafka/v3/clusters/{cluster_id}/links:
     get:
@@ -7413,8 +7489,7 @@ paths:
                   metadata:
                     self: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/CIL-69l7S1CwoVNAhoQLug/links/my-new-link-1
                     resource_name: null
-                  remote_cluster_id: src-cluster-id
-                  destination_cluster_id: null
+                  source_cluster_id: src-cluster-id
                   link_name: my-new-link-1
                   link_id: 7840644d-f7d8-4844-a577-a10ef3df31df
                   cluster_link_id: eEBkTffYSESld6EO898x3w
@@ -7427,7 +7502,6 @@ paths:
                     self: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/CIL-69l7S1CwoVNAhoQLug/links/my-new-link-2
                     resource_name: null
                   remote_cluster_id: src-cluster-id
-                  destination_cluster_id: null
                   link_name: my-new-link-2
                   link_id: f749116e-f847-4bd2-b1f6-5c4e518a0678
                   cluster_link_id: 90kRbvhHS9Kx9lxOUYoGeA
@@ -7441,7 +7515,6 @@ paths:
                   metadata:
                     self: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/CIL-69l7S1CwoVNAhoQLug/links/my-new-link-3
                     resource_name: null
-                  remote_cluster_id: null
                   destination_cluster_id: dest-cluster-id
                   link_name: my-new-link-3
                   link_id: 9cd1711e-a4ef-4390-a35e-dfd758d97a82
@@ -7517,8 +7590,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: List all cluster links in the dest cluster
       tags:
       - Cluster Linking (v3)
@@ -7720,8 +7793,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Create a cluster link
       tags:
       - Cluster Linking (v3)
@@ -7729,8 +7802,9 @@ paths:
       - lang: Shell
         source: |-
           curl --request POST \
-            --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links \
+            --url 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links?link_name=link-sb1&validate_only=false&validate_link=false' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
+            --header 'content-type: application/json' \
             --data '{"source_cluster_id":"string","destination_cluster_id":"string","remote_cluster_id":"string","cluster_link_id":"string","configs":[{"name":"name","value":"value"}]}'
       - lang: Java
         source: |-
@@ -7739,23 +7813,25 @@ paths:
           MediaType mediaType = MediaType.parse("application/json");
           RequestBody body = RequestBody.create(mediaType, "{\"source_cluster_id\":\"string\",\"destination_cluster_id\":\"string\",\"remote_cluster_id\":\"string\",\"cluster_link_id\":\"string\",\"configs\":[{\"name\":\"name\",\"value\":\"value\"}]}");
           Request request = new Request.Builder()
-            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links")
+            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links?link_name=link-sb1&validate_only=false&validate_link=false")
             .post(body)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
+            .addHeader("content-type", "application/json")
             .build();
 
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\
-          \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links\"\
+          \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links?link_name=link-sb1&validate_only=false&validate_link=false\"\
           \n\n\tpayload := strings.NewReader(\"{\\\"source_cluster_id\\\":\\\"string\\\
           \",\\\"destination_cluster_id\\\":\\\"string\\\",\\\"remote_cluster_id\\\
           \":\\\"string\\\",\\\"cluster_link_id\\\":\\\"string\\\",\\\"configs\\\"\
           :[{\\\"name\\\":\\\"name\\\",\\\"value\\\":\\\"value\\\"}]}\")\n\n\treq,\
           \ _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"Authorization\"\
-          , \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
-          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
-          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          , \"Basic REPLACE_BASIC_AUTH\")\n\treq.Header.Add(\"content-type\", \"application/json\"\
+          )\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\
+          \tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
+          \n}"
       - lang: Python
         source: |-
           import http.client
@@ -7764,9 +7840,12 @@ paths:
 
           payload = "{\"source_cluster_id\":\"string\",\"destination_cluster_id\":\"string\",\"remote_cluster_id\":\"string\",\"cluster_link_id\":\"string\",\"configs\":[{\"name\":\"name\",\"value\":\"value\"}]}"
 
-          headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
+          headers = {
+              'Authorization': "Basic REPLACE_BASIC_AUTH",
+              'content-type': "application/json"
+              }
 
-          conn.request("POST", "/kafka/v3/clusters/cluster-1/links", payload, headers)
+          conn.request("POST", "/kafka/v3/clusters/cluster-1/links?link_name=link-sb1&validate_only=false&validate_link=false", payload, headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -7780,9 +7859,10 @@ paths:
             "method": "POST",
             "hostname": "pkc-00000.region.provider.confluent.cloud",
             "port": null,
-            "path": "/kafka/v3/clusters/cluster-1/links",
+            "path": "/kafka/v3/clusters/cluster-1/links?link_name=link-sb1&validate_only=false&validate_link=false",
             "headers": {
-              "Authorization": "Basic REPLACE_BASIC_AUTH"
+              "Authorization": "Basic REPLACE_BASIC_AUTH",
+              "content-type": "application/json"
             }
           };
 
@@ -7812,10 +7892,11 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "POST");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links?link_name=link-sb1&validate_only=false&validate_link=false");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
+          headers = curl_slist_append(headers, "content-type: application/json");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
           curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"source_cluster_id\":\"string\",\"destination_cluster_id\":\"string\",\"remote_cluster_id\":\"string\",\"cluster_link_id\":\"string\",\"configs\":[{\"name\":\"name\",\"value\":\"value\"}]}");
@@ -7823,10 +7904,11 @@ paths:
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links");
+          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links?link_name=link-sb1&validate_only=false&validate_link=false");
           var request = new RestRequest(Method.POST);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("undefined", "{\"source_cluster_id\":\"string\",\"destination_cluster_id\":\"string\",\"remote_cluster_id\":\"string\",\"cluster_link_id\":\"string\",\"configs\":[{\"name\":\"name\",\"value\":\"value\"}]}", ParameterType.RequestBody);
+          request.AddHeader("content-type", "application/json");
+          request.AddParameter("application/json", "{\"source_cluster_id\":\"string\",\"destination_cluster_id\":\"string\",\"remote_cluster_id\":\"string\",\"cluster_link_id\":\"string\",\"configs\":[{\"name\":\"name\",\"value\":\"value\"}]}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /kafka/v3/clusters/{cluster_id}/links/{link_name}:
     delete:
@@ -7939,8 +8021,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Delete the cluster link
       tags:
       - Cluster Linking (v3)
@@ -7948,14 +8030,14 @@ paths:
       - lang: Shell
         source: |-
           curl --request DELETE \
-            --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1 \
+            --url 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1?force=false&validate_only=false' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           Request request = new Request.Builder()
-            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1")
+            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1?force=false&validate_only=false")
             .delete(null)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
             .build();
@@ -7963,7 +8045,7 @@ paths:
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io/ioutil\"\
-          \n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1\"\
+          \n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1?force=false&validate_only=false\"\
           \n\n\treq, _ := http.NewRequest(\"DELETE\", url, nil)\n\n\treq.Header.Add(\"\
           Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
           \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
@@ -7976,7 +8058,7 @@ paths:
 
           headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
 
-          conn.request("DELETE", "/kafka/v3/clusters/cluster-1/links/link-sb1", headers=headers)
+          conn.request("DELETE", "/kafka/v3/clusters/cluster-1/links/link-sb1?force=false&validate_only=false", headers=headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -7990,7 +8072,7 @@ paths:
             "method": "DELETE",
             "hostname": "pkc-00000.region.provider.confluent.cloud",
             "port": null,
-            "path": "/kafka/v3/clusters/cluster-1/links/link-sb1",
+            "path": "/kafka/v3/clusters/cluster-1/links/link-sb1?force=false&validate_only=false",
             "headers": {
               "Authorization": "Basic REPLACE_BASIC_AUTH"
             }
@@ -8015,7 +8097,7 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "DELETE");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1?force=false&validate_only=false");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
@@ -8024,7 +8106,7 @@ paths:
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1");
+          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1?force=false&validate_only=false");
           var request = new RestRequest(Method.DELETE);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
           IRestResponse response = client.Execute(request);
@@ -8065,8 +8147,7 @@ paths:
                     metadata:
                       self: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/Fds7TcT9TTqEXsoRLEKMcQ/links/my-new-link-1
                     resource_name: null
-                    remote_cluster_id: src-cluster-id
-                    destination_cluster_id: null
+                    source_cluster_id: src-cluster-id
                     link_name: my-new-link-1
                     link_id: 7840644d-f7d8-4844-a577-a10ef3df31df
                     cluster_link_id: eEBkTffYSESld6EO898x3w
@@ -8080,7 +8161,6 @@ paths:
                     metadata:
                       self: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/Fds7TcT9TTqEXsoRLEKMcQ/links/my-new-link-1
                     resource_name: null
-                    remote_cluster_id: null
                     destination_cluster_id: dst-cluster-id
                     link_name: my-new-link-1
                     link_id: 7840644d-f7d8-4844-a577-a10ef3df31df
@@ -8155,8 +8235,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Describe the cluster link
       tags:
       - Cluster Linking (v3)
@@ -8412,8 +8492,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: List New Topic Default Configs
       tags:
       - Configs (v3)
@@ -8633,8 +8713,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: List all configs of the cluster link
       tags:
       - Cluster Linking (v3)
@@ -8823,8 +8903,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Reset the given config to default value
       tags:
       - Cluster Linking (v3)
@@ -9035,8 +9115,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Describe the config under the cluster link
       tags:
       - Cluster Linking (v3)
@@ -9226,8 +9306,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Alter the config under the cluster link
       tags:
       - Cluster Linking (v3)
@@ -9237,6 +9317,7 @@ paths:
           curl --request PUT \
             --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/configs/consumer.offset.sync.enable \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
+            --header 'content-type: application/json' \
             --data '{"value":"string"}'
       - lang: Java
         source: |-
@@ -9248,6 +9329,7 @@ paths:
             .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/configs/consumer.offset.sync.enable")
             .put(body)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
+            .addHeader("content-type", "application/json")
             .build();
 
           Response response = client.newCall(request).execute();
@@ -9256,9 +9338,10 @@ paths:
           \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/configs/consumer.offset.sync.enable\"\
           \n\n\tpayload := strings.NewReader(\"{\\\"value\\\":\\\"string\\\"}\")\n\
           \n\treq, _ := http.NewRequest(\"PUT\", url, payload)\n\n\treq.Header.Add(\"\
-          Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
-          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
-          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\treq.Header.Add(\"content-type\"\
+          , \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\t\
+          defer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\
+          \tfmt.Println(string(body))\n\n}"
       - lang: Python
         source: |-
           import http.client
@@ -9267,7 +9350,10 @@ paths:
 
           payload = "{\"value\":\"string\"}"
 
-          headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
+          headers = {
+              'Authorization': "Basic REPLACE_BASIC_AUTH",
+              'content-type': "application/json"
+              }
 
           conn.request("PUT", "/kafka/v3/clusters/cluster-1/links/link-sb1/configs/consumer.offset.sync.enable", payload, headers)
 
@@ -9285,7 +9371,8 @@ paths:
             "port": null,
             "path": "/kafka/v3/clusters/cluster-1/links/link-sb1/configs/consumer.offset.sync.enable",
             "headers": {
-              "Authorization": "Basic REPLACE_BASIC_AUTH"
+              "Authorization": "Basic REPLACE_BASIC_AUTH",
+              "content-type": "application/json"
             }
           };
 
@@ -9313,6 +9400,7 @@ paths:
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
+          headers = curl_slist_append(headers, "content-type: application/json");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
           curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"value\":\"string\"}");
@@ -9323,7 +9411,8 @@ paths:
           var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/configs/consumer.offset.sync.enable");
           var request = new RestRequest(Method.PUT);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("undefined", "{\"value\":\"string\"}", ParameterType.RequestBody);
+          request.AddHeader("content-type", "application/json");
+          request.AddParameter("application/json", "{\"value\":\"string\"}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /kafka/v3/clusters/{cluster_id}/links/{link_name}/configs:alter:
     put:
@@ -9432,8 +9521,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Batch Alter Cluster Link Configs
       tags:
       - Cluster Linking (v3)
@@ -9441,8 +9530,9 @@ paths:
       - lang: Shell
         source: |-
           curl --request PUT \
-            --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/configs:alter \
+            --url 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/configs:alter?validate_only=false' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
+            --header 'content-type: application/json' \
             --data '{"data":[{"name":"string","value":"string","operation":"string"}],"validate_only":true}'
       - lang: Java
         source: |-
@@ -9451,21 +9541,23 @@ paths:
           MediaType mediaType = MediaType.parse("application/json");
           RequestBody body = RequestBody.create(mediaType, "{\"data\":[{\"name\":\"string\",\"value\":\"string\",\"operation\":\"string\"}],\"validate_only\":true}");
           Request request = new Request.Builder()
-            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/configs:alter")
+            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/configs:alter?validate_only=false")
             .put(body)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
+            .addHeader("content-type", "application/json")
             .build();
 
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\
-          \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/configs:alter\"\
+          \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/configs:alter?validate_only=false\"\
           \n\n\tpayload := strings.NewReader(\"{\\\"data\\\":[{\\\"name\\\":\\\"string\\\
           \",\\\"value\\\":\\\"string\\\",\\\"operation\\\":\\\"string\\\"}],\\\"\
           validate_only\\\":true}\")\n\n\treq, _ := http.NewRequest(\"PUT\", url,\
           \ payload)\n\n\treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\"\
-          )\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\
-          \tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
+          )\n\treq.Header.Add(\"content-type\", \"application/json\")\n\n\tres, _\
+          \ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ :=\
+          \ ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
           \n}"
       - lang: Python
         source: |-
@@ -9475,9 +9567,12 @@ paths:
 
           payload = "{\"data\":[{\"name\":\"string\",\"value\":\"string\",\"operation\":\"string\"}],\"validate_only\":true}"
 
-          headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
+          headers = {
+              'Authorization': "Basic REPLACE_BASIC_AUTH",
+              'content-type': "application/json"
+              }
 
-          conn.request("PUT", "/kafka/v3/clusters/cluster-1/links/link-sb1/configs:alter", payload, headers)
+          conn.request("PUT", "/kafka/v3/clusters/cluster-1/links/link-sb1/configs:alter?validate_only=false", payload, headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -9491,9 +9586,10 @@ paths:
             "method": "PUT",
             "hostname": "pkc-00000.region.provider.confluent.cloud",
             "port": null,
-            "path": "/kafka/v3/clusters/cluster-1/links/link-sb1/configs:alter",
+            "path": "/kafka/v3/clusters/cluster-1/links/link-sb1/configs:alter?validate_only=false",
             "headers": {
-              "Authorization": "Basic REPLACE_BASIC_AUTH"
+              "Authorization": "Basic REPLACE_BASIC_AUTH",
+              "content-type": "application/json"
             }
           };
 
@@ -9520,10 +9616,11 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "PUT");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/configs:alter");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/configs:alter?validate_only=false");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
+          headers = curl_slist_append(headers, "content-type: application/json");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
           curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"data\":[{\"name\":\"string\",\"value\":\"string\",\"operation\":\"string\"}],\"validate_only\":true}");
@@ -9531,10 +9628,11 @@ paths:
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/configs:alter");
+          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/configs:alter?validate_only=false");
           var request = new RestRequest(Method.PUT);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("undefined", "{\"data\":[{\"name\":\"string\",\"value\":\"string\",\"operation\":\"string\"}],\"validate_only\":true}", ParameterType.RequestBody);
+          request.AddHeader("content-type", "application/json");
+          request.AddParameter("application/json", "{\"data\":[{\"name\":\"string\",\"value\":\"string\",\"operation\":\"string\"}],\"validate_only\":true}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /kafka/v3/clusters/{cluster_id}/links/{link_name}/mirrors:
     get:
@@ -9694,8 +9792,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: List mirror topics
       tags:
       - Cluster Linking (v3)
@@ -9880,8 +9978,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Create a mirror topic
       tags:
       - Cluster Linking (v3)
@@ -9891,6 +9989,7 @@ paths:
           curl --request POST \
             --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
+            --header 'content-type: application/json' \
             --data '{"source_topic_name":"string","mirror_topic_name":"string","replication_factor":0,"configs":[{"name":"name","value":"value"}]}'
       - lang: Java
         source: |-
@@ -9902,6 +10001,7 @@ paths:
             .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors")
             .post(body)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
+            .addHeader("content-type", "application/json")
             .build();
 
           Response response = client.newCall(request).execute();
@@ -9912,9 +10012,10 @@ paths:
           \",\\\"mirror_topic_name\\\":\\\"string\\\",\\\"replication_factor\\\":0,\\\
           \"configs\\\":[{\\\"name\\\":\\\"name\\\",\\\"value\\\":\\\"value\\\"}]}\"\
           )\n\n\treq, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"\
-          Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
-          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
-          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\treq.Header.Add(\"content-type\"\
+          , \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\t\
+          defer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\
+          \tfmt.Println(string(body))\n\n}"
       - lang: Python
         source: |-
           import http.client
@@ -9923,7 +10024,10 @@ paths:
 
           payload = "{\"source_topic_name\":\"string\",\"mirror_topic_name\":\"string\",\"replication_factor\":0,\"configs\":[{\"name\":\"name\",\"value\":\"value\"}]}"
 
-          headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
+          headers = {
+              'Authorization': "Basic REPLACE_BASIC_AUTH",
+              'content-type': "application/json"
+              }
 
           conn.request("POST", "/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors", payload, headers)
 
@@ -9941,7 +10045,8 @@ paths:
             "port": null,
             "path": "/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors",
             "headers": {
-              "Authorization": "Basic REPLACE_BASIC_AUTH"
+              "Authorization": "Basic REPLACE_BASIC_AUTH",
+              "content-type": "application/json"
             }
           };
 
@@ -9974,6 +10079,7 @@ paths:
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
+          headers = curl_slist_append(headers, "content-type: application/json");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
           curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"source_topic_name\":\"string\",\"mirror_topic_name\":\"string\",\"replication_factor\":0,\"configs\":[{\"name\":\"name\",\"value\":\"value\"}]}");
@@ -9984,7 +10090,8 @@ paths:
           var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors");
           var request = new RestRequest(Method.POST);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("undefined", "{\"source_topic_name\":\"string\",\"mirror_topic_name\":\"string\",\"replication_factor\":0,\"configs\":[{\"name\":\"name\",\"value\":\"value\"}]}", ParameterType.RequestBody);
+          request.AddHeader("content-type", "application/json");
+          request.AddParameter("application/json", "{\"source_topic_name\":\"string\",\"mirror_topic_name\":\"string\",\"replication_factor\":0,\"configs\":[{\"name\":\"name\",\"value\":\"value\"}]}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /kafka/v3/clusters/{cluster_id}/links/-/mirrors:
     get:
@@ -10135,8 +10242,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: List mirror topics
       tags:
       - Cluster Linking (v3)
@@ -10144,14 +10251,14 @@ paths:
       - lang: Shell
         source: |-
           curl --request GET \
-            --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/-/mirrors \
+            --url 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/-/mirrors?mirror_status=ACTIVE' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           Request request = new Request.Builder()
-            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/-/mirrors")
+            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/-/mirrors?mirror_status=ACTIVE")
             .get()
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
             .build();
@@ -10159,7 +10266,7 @@ paths:
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io/ioutil\"\
-          \n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/-/mirrors\"\
+          \n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/-/mirrors?mirror_status=ACTIVE\"\
           \n\n\treq, _ := http.NewRequest(\"GET\", url, nil)\n\n\treq.Header.Add(\"\
           Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
           \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
@@ -10172,7 +10279,7 @@ paths:
 
           headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
 
-          conn.request("GET", "/kafka/v3/clusters/cluster-1/links/-/mirrors", headers=headers)
+          conn.request("GET", "/kafka/v3/clusters/cluster-1/links/-/mirrors?mirror_status=ACTIVE", headers=headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -10186,7 +10293,7 @@ paths:
             "method": "GET",
             "hostname": "pkc-00000.region.provider.confluent.cloud",
             "port": null,
-            "path": "/kafka/v3/clusters/cluster-1/links/-/mirrors",
+            "path": "/kafka/v3/clusters/cluster-1/links/-/mirrors?mirror_status=ACTIVE",
             "headers": {
               "Authorization": "Basic REPLACE_BASIC_AUTH"
             }
@@ -10211,7 +10318,7 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "GET");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/-/mirrors");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/-/mirrors?mirror_status=ACTIVE");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
@@ -10220,7 +10327,7 @@ paths:
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/-/mirrors");
+          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/-/mirrors?mirror_status=ACTIVE");
           var request = new RestRequest(Method.GET);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
           IRestResponse response = client.Execute(request);
@@ -10350,8 +10457,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Describe the mirror topic
       tags:
       - Cluster Linking (v3)
@@ -10588,8 +10695,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Promote the mirror topics
       tags:
       - Cluster Linking (v3)
@@ -10597,8 +10704,9 @@ paths:
       - lang: Shell
         source: |-
           curl --request POST \
-            --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:promote \
+            --url 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:promote?validate_only=false' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
+            --header 'content-type: application/json' \
             --data '{"mirror_topic_names":["string"],"mirror_topic_name_pattern":"string"}'
       - lang: Java
         source: |-
@@ -10607,21 +10715,23 @@ paths:
           MediaType mediaType = MediaType.parse("application/json");
           RequestBody body = RequestBody.create(mediaType, "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}");
           Request request = new Request.Builder()
-            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:promote")
+            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:promote?validate_only=false")
             .post(body)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
+            .addHeader("content-type", "application/json")
             .build();
 
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\
-          \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:promote\"\
+          \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:promote?validate_only=false\"\
           \n\n\tpayload := strings.NewReader(\"{\\\"mirror_topic_names\\\":[\\\"string\\\
           \"],\\\"mirror_topic_name_pattern\\\":\\\"string\\\"}\")\n\n\treq, _ :=\
           \ http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"Authorization\"\
-          , \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
-          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
-          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          , \"Basic REPLACE_BASIC_AUTH\")\n\treq.Header.Add(\"content-type\", \"application/json\"\
+          )\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\
+          \tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
+          \n}"
       - lang: Python
         source: |-
           import http.client
@@ -10630,9 +10740,12 @@ paths:
 
           payload = "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}"
 
-          headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
+          headers = {
+              'Authorization': "Basic REPLACE_BASIC_AUTH",
+              'content-type': "application/json"
+              }
 
-          conn.request("POST", "/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:promote", payload, headers)
+          conn.request("POST", "/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:promote?validate_only=false", payload, headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -10646,9 +10759,10 @@ paths:
             "method": "POST",
             "hostname": "pkc-00000.region.provider.confluent.cloud",
             "port": null,
-            "path": "/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:promote",
+            "path": "/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:promote?validate_only=false",
             "headers": {
-              "Authorization": "Basic REPLACE_BASIC_AUTH"
+              "Authorization": "Basic REPLACE_BASIC_AUTH",
+              "content-type": "application/json"
             }
           };
 
@@ -10672,10 +10786,11 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "POST");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:promote");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:promote?validate_only=false");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
+          headers = curl_slist_append(headers, "content-type: application/json");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
           curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}");
@@ -10683,10 +10798,11 @@ paths:
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:promote");
+          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:promote?validate_only=false");
           var request = new RestRequest(Method.POST);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("undefined", "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}", ParameterType.RequestBody);
+          request.AddHeader("content-type", "application/json");
+          request.AddParameter("application/json", "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /kafka/v3/clusters/{cluster_id}/links/{link_name}/mirrors:failover:
     post:
@@ -10837,8 +10953,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Failover the mirror topics
       tags:
       - Cluster Linking (v3)
@@ -10846,8 +10962,9 @@ paths:
       - lang: Shell
         source: |-
           curl --request POST \
-            --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:failover \
+            --url 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:failover?validate_only=false' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
+            --header 'content-type: application/json' \
             --data '{"mirror_topic_names":["string"],"mirror_topic_name_pattern":"string"}'
       - lang: Java
         source: |-
@@ -10856,21 +10973,23 @@ paths:
           MediaType mediaType = MediaType.parse("application/json");
           RequestBody body = RequestBody.create(mediaType, "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}");
           Request request = new Request.Builder()
-            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:failover")
+            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:failover?validate_only=false")
             .post(body)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
+            .addHeader("content-type", "application/json")
             .build();
 
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\
-          \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:failover\"\
+          \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:failover?validate_only=false\"\
           \n\n\tpayload := strings.NewReader(\"{\\\"mirror_topic_names\\\":[\\\"string\\\
           \"],\\\"mirror_topic_name_pattern\\\":\\\"string\\\"}\")\n\n\treq, _ :=\
           \ http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"Authorization\"\
-          , \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
-          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
-          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          , \"Basic REPLACE_BASIC_AUTH\")\n\treq.Header.Add(\"content-type\", \"application/json\"\
+          )\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\
+          \tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
+          \n}"
       - lang: Python
         source: |-
           import http.client
@@ -10879,9 +10998,12 @@ paths:
 
           payload = "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}"
 
-          headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
+          headers = {
+              'Authorization': "Basic REPLACE_BASIC_AUTH",
+              'content-type': "application/json"
+              }
 
-          conn.request("POST", "/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:failover", payload, headers)
+          conn.request("POST", "/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:failover?validate_only=false", payload, headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -10895,9 +11017,10 @@ paths:
             "method": "POST",
             "hostname": "pkc-00000.region.provider.confluent.cloud",
             "port": null,
-            "path": "/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:failover",
+            "path": "/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:failover?validate_only=false",
             "headers": {
-              "Authorization": "Basic REPLACE_BASIC_AUTH"
+              "Authorization": "Basic REPLACE_BASIC_AUTH",
+              "content-type": "application/json"
             }
           };
 
@@ -10921,10 +11044,11 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "POST");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:failover");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:failover?validate_only=false");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
+          headers = curl_slist_append(headers, "content-type: application/json");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
           curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}");
@@ -10932,10 +11056,11 @@ paths:
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:failover");
+          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:failover?validate_only=false");
           var request = new RestRequest(Method.POST);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("undefined", "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}", ParameterType.RequestBody);
+          request.AddHeader("content-type", "application/json");
+          request.AddParameter("application/json", "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /kafka/v3/clusters/{cluster_id}/links/{link_name}/mirrors:pause:
     post:
@@ -11086,8 +11211,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Pause the mirror topics
       tags:
       - Cluster Linking (v3)
@@ -11095,8 +11220,9 @@ paths:
       - lang: Shell
         source: |-
           curl --request POST \
-            --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:pause \
+            --url 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:pause?validate_only=false' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
+            --header 'content-type: application/json' \
             --data '{"mirror_topic_names":["string"],"mirror_topic_name_pattern":"string"}'
       - lang: Java
         source: |-
@@ -11105,21 +11231,23 @@ paths:
           MediaType mediaType = MediaType.parse("application/json");
           RequestBody body = RequestBody.create(mediaType, "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}");
           Request request = new Request.Builder()
-            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:pause")
+            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:pause?validate_only=false")
             .post(body)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
+            .addHeader("content-type", "application/json")
             .build();
 
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\
-          \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:pause\"\
+          \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:pause?validate_only=false\"\
           \n\n\tpayload := strings.NewReader(\"{\\\"mirror_topic_names\\\":[\\\"string\\\
           \"],\\\"mirror_topic_name_pattern\\\":\\\"string\\\"}\")\n\n\treq, _ :=\
           \ http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"Authorization\"\
-          , \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
-          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
-          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          , \"Basic REPLACE_BASIC_AUTH\")\n\treq.Header.Add(\"content-type\", \"application/json\"\
+          )\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\
+          \tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
+          \n}"
       - lang: Python
         source: |-
           import http.client
@@ -11128,9 +11256,12 @@ paths:
 
           payload = "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}"
 
-          headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
+          headers = {
+              'Authorization': "Basic REPLACE_BASIC_AUTH",
+              'content-type': "application/json"
+              }
 
-          conn.request("POST", "/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:pause", payload, headers)
+          conn.request("POST", "/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:pause?validate_only=false", payload, headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -11144,9 +11275,10 @@ paths:
             "method": "POST",
             "hostname": "pkc-00000.region.provider.confluent.cloud",
             "port": null,
-            "path": "/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:pause",
+            "path": "/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:pause?validate_only=false",
             "headers": {
-              "Authorization": "Basic REPLACE_BASIC_AUTH"
+              "Authorization": "Basic REPLACE_BASIC_AUTH",
+              "content-type": "application/json"
             }
           };
 
@@ -11170,10 +11302,11 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "POST");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:pause");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:pause?validate_only=false");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
+          headers = curl_slist_append(headers, "content-type: application/json");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
           curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}");
@@ -11181,10 +11314,11 @@ paths:
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:pause");
+          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:pause?validate_only=false");
           var request = new RestRequest(Method.POST);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("undefined", "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}", ParameterType.RequestBody);
+          request.AddHeader("content-type", "application/json");
+          request.AddParameter("application/json", "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /kafka/v3/clusters/{cluster_id}/links/{link_name}/mirrors:resume:
     post:
@@ -11335,8 +11469,8 @@ paths:
             client side. Retriable Kafka errors will contain error code 50003 in the
             response body.
       security:
-      - api-key: []
-      - confluent-sts-access-token: []
+      - resource-api-key: []
+      - external-access-token: []
       summary: Resume the mirror topics
       tags:
       - Cluster Linking (v3)
@@ -11344,8 +11478,9 @@ paths:
       - lang: Shell
         source: |-
           curl --request POST \
-            --url https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:resume \
+            --url 'https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:resume?validate_only=false' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
+            --header 'content-type: application/json' \
             --data '{"mirror_topic_names":["string"],"mirror_topic_name_pattern":"string"}'
       - lang: Java
         source: |-
@@ -11354,21 +11489,23 @@ paths:
           MediaType mediaType = MediaType.parse("application/json");
           RequestBody body = RequestBody.create(mediaType, "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}");
           Request request = new Request.Builder()
-            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:resume")
+            .url("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:resume?validate_only=false")
             .post(body)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
+            .addHeader("content-type", "application/json")
             .build();
 
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\
-          \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:resume\"\
+          \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:resume?validate_only=false\"\
           \n\n\tpayload := strings.NewReader(\"{\\\"mirror_topic_names\\\":[\\\"string\\\
           \"],\\\"mirror_topic_name_pattern\\\":\\\"string\\\"}\")\n\n\treq, _ :=\
           \ http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"Authorization\"\
-          , \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
-          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
-          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          , \"Basic REPLACE_BASIC_AUTH\")\n\treq.Header.Add(\"content-type\", \"application/json\"\
+          )\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\
+          \tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
+          \n}"
       - lang: Python
         source: |-
           import http.client
@@ -11377,9 +11514,12 @@ paths:
 
           payload = "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}"
 
-          headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
+          headers = {
+              'Authorization': "Basic REPLACE_BASIC_AUTH",
+              'content-type': "application/json"
+              }
 
-          conn.request("POST", "/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:resume", payload, headers)
+          conn.request("POST", "/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:resume?validate_only=false", payload, headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -11393,9 +11533,10 @@ paths:
             "method": "POST",
             "hostname": "pkc-00000.region.provider.confluent.cloud",
             "port": null,
-            "path": "/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:resume",
+            "path": "/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:resume?validate_only=false",
             "headers": {
-              "Authorization": "Basic REPLACE_BASIC_AUTH"
+              "Authorization": "Basic REPLACE_BASIC_AUTH",
+              "content-type": "application/json"
             }
           };
 
@@ -11419,10 +11560,11 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "POST");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:resume");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:resume?validate_only=false");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
+          headers = curl_slist_append(headers, "content-type: application/json");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
           curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}");
@@ -11430,10 +11572,11 @@ paths:
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:resume");
+          var client = new RestClient("https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/links/link-sb1/mirrors:resume?validate_only=false");
           var request = new RestRequest(Method.POST);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("undefined", "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}", ParameterType.RequestBody);
+          request.AddHeader("content-type", "application/json");
+          request.AddParameter("application/json", "{\"mirror_topic_names\":[\"string\"],\"mirror_topic_name_pattern\":\"string\"}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
 components:
   parameters:
@@ -11896,7 +12039,7 @@ components:
             destination_initiated_link:
               description: Create a destination initiated cluster link
               value:
-                remote_cluster_id: cluster-1
+                source_cluster_id: cluster-1
                 configs:
                 - name: bootstrap.servers
                   value: cluster-1-bootstrap-server
@@ -11916,7 +12059,7 @@ components:
             source_initiated_link_at_destination_cluster:
               description: Create a source initiated cluster link at destination cluster
               value:
-                remote_cluster_id: cluster-1
+                destination_cluster_id: cluster-1
                 configs:
                 - name: bootstrap.servers
                   value: cluster-1-bootstrap-server
@@ -13919,8 +14062,7 @@ components:
               metadata:
                 self: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/CIL-69l7S1CwoVNAhoQLug/links/my-new-link-1
                 resource_name: null
-              remote_cluster_id: src-cluster-id
-              destination_cluster_id: null
+              source_cluster_id: src-cluster-id
               link_name: my-new-link-1
               link_id: 7840644d-f7d8-4844-a577-a10ef3df31df
               cluster_link_id: eEBkTffYSESld6EO898x3w
@@ -13933,7 +14075,6 @@ components:
                 self: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/CIL-69l7S1CwoVNAhoQLug/links/my-new-link-2
                 resource_name: null
               remote_cluster_id: src-cluster-id
-              destination_cluster_id: null
               link_name: my-new-link-2
               link_id: f749116e-f847-4bd2-b1f6-5c4e518a0678
               cluster_link_id: 90kRbvhHS9Kx9lxOUYoGeA
@@ -13947,7 +14088,6 @@ components:
               metadata:
                 self: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/CIL-69l7S1CwoVNAhoQLug/links/my-new-link-3
                 resource_name: null
-              remote_cluster_id: null
               destination_cluster_id: dest-cluster-id
               link_name: my-new-link-3
               link_id: 9cd1711e-a4ef-4390-a35e-dfd758d97a82
@@ -13968,8 +14108,7 @@ components:
                 metadata:
                   self: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/Fds7TcT9TTqEXsoRLEKMcQ/links/my-new-link-1
                 resource_name: null
-                remote_cluster_id: src-cluster-id
-                destination_cluster_id: null
+                source_cluster_id: src-cluster-id
                 link_name: my-new-link-1
                 link_id: 7840644d-f7d8-4844-a577-a10ef3df31df
                 cluster_link_id: eEBkTffYSESld6EO898x3w
@@ -13983,7 +14122,6 @@ components:
                 metadata:
                   self: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/Fds7TcT9TTqEXsoRLEKMcQ/links/my-new-link-1
                 resource_name: null
-                remote_cluster_id: null
                 destination_cluster_id: dst-cluster-id
                 link_name: my-new-link-1
                 link_id: 7840644d-f7d8-4844-a577-a10ef3df31df
@@ -14929,10 +15067,8 @@ components:
         source_cluster_id: source_cluster_id
       properties:
         source_cluster_id:
-          deprecated: true
           type: string
         destination_cluster_id:
-          deprecated: true
           type: string
         remote_cluster_id:
           description: The expected remote cluster ID.
@@ -15078,9 +15214,12 @@ components:
       enum:
       - ACTIVE
       - FAILED
+      - LINK_FAILED
+      - LINK_PAUSED
       - PAUSED
-      - STOPPED
       - PENDING_STOPPED
+      - SOURCE_UNAVAILABLE
+      - STOPPED
       type: string
     AnyUnevenLoadStatus:
       type: string
@@ -16101,11 +16240,9 @@ components:
     ListLinksResponseData_allOf:
       properties:
         source_cluster_id:
-          deprecated: true
           nullable: true
           type: string
         destination_cluster_id:
-          deprecated: true
           nullable: true
           type: string
         remote_cluster_id:
@@ -16262,14 +16399,14 @@ components:
       - data
       type: object
   securitySchemes:
-    api-key:
-      description: Authenticate with API Keys using HTTP Basic Auth. Treat the API
-        Key ID as the username and API Key Secret as the password.
+    resource-api-key:
+      description: "Authenticate with resource-specific API Keys using HTTP Basic\
+        \ Auth. Treat the resource-specific API Key ID \nas the username and resource-specific\
+        \ API Key Secret as the password.\n"
       scheme: basic
       type: http
-    confluent-sts-access-token:
-      description: Authenticate with Confluent API using this credentials (JSON Web
-        Tokens) following OAuth 2.0.
+    external-access-token:
+      description: Authenticate with OAuth 2.0.
       flows:
         clientCredentials:
           scopes: {}

--- a/kafkarest/v3/api_aclv3.go
+++ b/kafkarest/v3/api_aclv3.go
@@ -135,9 +135,9 @@ BatchCreateKafkaAcls Batch Create ACLs
 
 Create ACLs.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiBatchCreateKafkaAclsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiBatchCreateKafkaAclsRequest
 */
 func (a *ACLV3ApiService) BatchCreateKafkaAcls(ctx _context.Context, clusterId string) ApiBatchCreateKafkaAclsRequest {
 	return ApiBatchCreateKafkaAclsRequest{
@@ -289,9 +289,9 @@ CreateKafkaAcls Create an ACL
 
 Create an ACL.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiCreateKafkaAclsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiCreateKafkaAclsRequest
 */
 func (a *ACLV3ApiService) CreateKafkaAcls(ctx _context.Context, clusterId string) ApiCreateKafkaAclsRequest {
 	return ApiCreateKafkaAclsRequest{
@@ -485,9 +485,9 @@ DeleteKafkaAcls Delete ACLs
 
 Delete the ACLs that match the search criteria.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiDeleteKafkaAclsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiDeleteKafkaAclsRequest
 */
 func (a *ACLV3ApiService) DeleteKafkaAcls(ctx _context.Context, clusterId string) ApiDeleteKafkaAclsRequest {
 	return ApiDeleteKafkaAclsRequest{
@@ -498,7 +498,8 @@ func (a *ACLV3ApiService) DeleteKafkaAcls(ctx _context.Context, clusterId string
 }
 
 // Execute executes the request
-//  @return InlineResponse200
+//
+//	@return InlineResponse200
 func (a *ACLV3ApiService) DeleteKafkaAclsExecute(r ApiDeleteKafkaAclsRequest) (InlineResponse200, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
@@ -715,9 +716,9 @@ GetKafkaAcls List ACLs
 
 Return a list of ACLs that match the search criteria.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiGetKafkaAclsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiGetKafkaAclsRequest
 */
 func (a *ACLV3ApiService) GetKafkaAcls(ctx _context.Context, clusterId string) ApiGetKafkaAclsRequest {
 	return ApiGetKafkaAclsRequest{
@@ -728,7 +729,8 @@ func (a *ACLV3ApiService) GetKafkaAcls(ctx _context.Context, clusterId string) A
 }
 
 // Execute executes the request
-//  @return AclDataList
+//
+//	@return AclDataList
 func (a *ACLV3ApiService) GetKafkaAclsExecute(r ApiGetKafkaAclsRequest) (AclDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet

--- a/kafkarest/v3/api_aclv3.go
+++ b/kafkarest/v3/api_aclv3.go
@@ -42,15 +42,15 @@ var (
 type ACLV3Api interface {
 
 	/*
-		BatchCreateKafkaAcls Batch Create ACLs
+			BatchCreateKafkaAcls Batch Create ACLs
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Create ACLs.
+		Create ACLs.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @return ApiBatchCreateKafkaAclsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiBatchCreateKafkaAclsRequest
 	*/
 	BatchCreateKafkaAcls(ctx _context.Context, clusterId string) ApiBatchCreateKafkaAclsRequest
 
@@ -58,15 +58,15 @@ type ACLV3Api interface {
 	BatchCreateKafkaAclsExecute(r ApiBatchCreateKafkaAclsRequest) (*_nethttp.Response, error)
 
 	/*
-		CreateKafkaAcls Create an ACL
+			CreateKafkaAcls Create an ACL
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Create an ACL.
+		Create an ACL.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @return ApiCreateKafkaAclsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiCreateKafkaAclsRequest
 	*/
 	CreateKafkaAcls(ctx _context.Context, clusterId string) ApiCreateKafkaAclsRequest
 
@@ -74,15 +74,15 @@ type ACLV3Api interface {
 	CreateKafkaAclsExecute(r ApiCreateKafkaAclsRequest) (*_nethttp.Response, error)
 
 	/*
-		DeleteKafkaAcls Delete ACLs
+			DeleteKafkaAcls Delete ACLs
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Delete the ACLs that match the search criteria.
+		Delete the ACLs that match the search criteria.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @return ApiDeleteKafkaAclsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiDeleteKafkaAclsRequest
 	*/
 	DeleteKafkaAcls(ctx _context.Context, clusterId string) ApiDeleteKafkaAclsRequest
 
@@ -91,15 +91,15 @@ type ACLV3Api interface {
 	DeleteKafkaAclsExecute(r ApiDeleteKafkaAclsRequest) (InlineResponse200, *_nethttp.Response, error)
 
 	/*
-		GetKafkaAcls List ACLs
+			GetKafkaAcls List ACLs
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Return a list of ACLs that match the search criteria.
+		Return a list of ACLs that match the search criteria.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @return ApiGetKafkaAclsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiGetKafkaAclsRequest
 	*/
 	GetKafkaAcls(ctx _context.Context, clusterId string) ApiGetKafkaAclsRequest
 

--- a/kafkarest/v3/api_cluster_linking_v3.go
+++ b/kafkarest/v3/api_cluster_linking_v3.go
@@ -368,9 +368,9 @@ CreateKafkaLink Create a cluster link
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiCreateKafkaLinkRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiCreateKafkaLinkRequest
 */
 func (a *ClusterLinkingV3ApiService) CreateKafkaLink(ctx _context.Context, clusterId string) ApiCreateKafkaLinkRequest {
 	return ApiCreateKafkaLinkRequest{
@@ -524,10 +524,10 @@ CreateKafkaMirrorTopic Create a mirror topic
 Create a topic in the destination cluster mirroring a topic in
 the source cluster
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiCreateKafkaMirrorTopicRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiCreateKafkaMirrorTopicRequest
 */
 func (a *ClusterLinkingV3ApiService) CreateKafkaMirrorTopic(ctx _context.Context, clusterId string, linkName string) ApiCreateKafkaMirrorTopicRequest {
 	return ApiCreateKafkaMirrorTopicRequest{
@@ -677,10 +677,10 @@ DeleteKafkaLink Delete the cluster link
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiDeleteKafkaLinkRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiDeleteKafkaLinkRequest
 */
 func (a *ClusterLinkingV3ApiService) DeleteKafkaLink(ctx _context.Context, clusterId string, linkName string) ApiDeleteKafkaLinkRequest {
 	return ApiDeleteKafkaLinkRequest{
@@ -821,11 +821,11 @@ DeleteKafkaLinkConfig Reset the given config to default value
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @param configName The link config name
- @return ApiDeleteKafkaLinkConfigRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@param configName The link config name
+	@return ApiDeleteKafkaLinkConfigRequest
 */
 func (a *ClusterLinkingV3ApiService) DeleteKafkaLinkConfig(ctx _context.Context, clusterId string, linkName string, configName string) ApiDeleteKafkaLinkConfigRequest {
 	return ApiDeleteKafkaLinkConfigRequest{
@@ -961,12 +961,12 @@ GetKafkaLink Describe the cluster link
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-``link_id`` in ``ListLinksResponseData`` is deprecated and may be removed in a future release. Use the new ``cluster_link_id`` instead.
+“link_id“ in “ListLinksResponseData“ is deprecated and may be removed in a future release. Use the new “cluster_link_id“ instead.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiGetKafkaLinkRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiGetKafkaLinkRequest
 */
 func (a *ClusterLinkingV3ApiService) GetKafkaLink(ctx _context.Context, clusterId string, linkName string) ApiGetKafkaLinkRequest {
 	return ApiGetKafkaLinkRequest{
@@ -978,7 +978,8 @@ func (a *ClusterLinkingV3ApiService) GetKafkaLink(ctx _context.Context, clusterI
 }
 
 // Execute executes the request
-//  @return ListLinksResponseData
+//
+//	@return ListLinksResponseData
 func (a *ClusterLinkingV3ApiService) GetKafkaLinkExecute(r ApiGetKafkaLinkRequest) (ListLinksResponseData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1112,11 +1113,11 @@ GetKafkaLinkConfigs Describe the config under the cluster link
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @param configName The link config name
- @return ApiGetKafkaLinkConfigsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@param configName The link config name
+	@return ApiGetKafkaLinkConfigsRequest
 */
 func (a *ClusterLinkingV3ApiService) GetKafkaLinkConfigs(ctx _context.Context, clusterId string, linkName string, configName string) ApiGetKafkaLinkConfigsRequest {
 	return ApiGetKafkaLinkConfigsRequest{
@@ -1129,7 +1130,8 @@ func (a *ClusterLinkingV3ApiService) GetKafkaLinkConfigs(ctx _context.Context, c
 }
 
 // Execute executes the request
-//  @return ListLinkConfigsResponseData
+//
+//	@return ListLinkConfigsResponseData
 func (a *ClusterLinkingV3ApiService) GetKafkaLinkConfigsExecute(r ApiGetKafkaLinkConfigsRequest) (ListLinkConfigsResponseData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1263,10 +1265,10 @@ ListKafkaLinkConfigs List all configs of the cluster link
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiListKafkaLinkConfigsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiListKafkaLinkConfigsRequest
 */
 func (a *ClusterLinkingV3ApiService) ListKafkaLinkConfigs(ctx _context.Context, clusterId string, linkName string) ApiListKafkaLinkConfigsRequest {
 	return ApiListKafkaLinkConfigsRequest{
@@ -1278,7 +1280,8 @@ func (a *ClusterLinkingV3ApiService) ListKafkaLinkConfigs(ctx _context.Context, 
 }
 
 // Execute executes the request
-//  @return ListLinkConfigsResponseDataList
+//
+//	@return ListLinkConfigsResponseDataList
 func (a *ClusterLinkingV3ApiService) ListKafkaLinkConfigsExecute(r ApiListKafkaLinkConfigsRequest) (ListLinkConfigsResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1410,11 +1413,11 @@ ListKafkaLinks List all cluster links in the dest cluster
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-``link_id`` in ``ListLinksResponseData`` is deprecated and may be removed in a future release. Use the new ``cluster_link_id`` instead.
+“link_id“ in “ListLinksResponseData“ is deprecated and may be removed in a future release. Use the new “cluster_link_id“ instead.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiListKafkaLinksRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiListKafkaLinksRequest
 */
 func (a *ClusterLinkingV3ApiService) ListKafkaLinks(ctx _context.Context, clusterId string) ApiListKafkaLinksRequest {
 	return ApiListKafkaLinksRequest{
@@ -1425,7 +1428,8 @@ func (a *ClusterLinkingV3ApiService) ListKafkaLinks(ctx _context.Context, cluste
 }
 
 // Execute executes the request
-//  @return ListLinksResponseDataList
+//
+//	@return ListLinksResponseDataList
 func (a *ClusterLinkingV3ApiService) ListKafkaLinksExecute(r ApiListKafkaLinksRequest) (ListLinksResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1565,9 +1569,9 @@ ListKafkaMirrorTopics List mirror topics
 
 List all mirror topics in the cluster
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiListKafkaMirrorTopicsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiListKafkaMirrorTopicsRequest
 */
 func (a *ClusterLinkingV3ApiService) ListKafkaMirrorTopics(ctx _context.Context, clusterId string) ApiListKafkaMirrorTopicsRequest {
 	return ApiListKafkaMirrorTopicsRequest{
@@ -1578,7 +1582,8 @@ func (a *ClusterLinkingV3ApiService) ListKafkaMirrorTopics(ctx _context.Context,
 }
 
 // Execute executes the request
-//  @return ListMirrorTopicsResponseDataList
+//
+//	@return ListMirrorTopicsResponseDataList
 func (a *ClusterLinkingV3ApiService) ListKafkaMirrorTopicsExecute(r ApiListKafkaMirrorTopicsRequest) (ListMirrorTopicsResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1722,10 +1727,10 @@ ListKafkaMirrorTopicsUnderLink List mirror topics
 
 List all mirror topics under the link
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiListKafkaMirrorTopicsUnderLinkRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiListKafkaMirrorTopicsUnderLinkRequest
 */
 func (a *ClusterLinkingV3ApiService) ListKafkaMirrorTopicsUnderLink(ctx _context.Context, clusterId string, linkName string) ApiListKafkaMirrorTopicsUnderLinkRequest {
 	return ApiListKafkaMirrorTopicsUnderLinkRequest{
@@ -1737,7 +1742,8 @@ func (a *ClusterLinkingV3ApiService) ListKafkaMirrorTopicsUnderLink(ctx _context
 }
 
 // Execute executes the request
-//  @return ListMirrorTopicsResponseDataList
+//
+//	@return ListMirrorTopicsResponseDataList
 func (a *ClusterLinkingV3ApiService) ListKafkaMirrorTopicsUnderLinkExecute(r ApiListKafkaMirrorTopicsUnderLinkRequest) (ListMirrorTopicsResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1874,11 +1880,11 @@ ReadKafkaMirrorTopic Describe the mirror topic
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @param mirrorTopicName Cluster Linking mirror topic name
- @return ApiReadKafkaMirrorTopicRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@param mirrorTopicName Cluster Linking mirror topic name
+	@return ApiReadKafkaMirrorTopicRequest
 */
 func (a *ClusterLinkingV3ApiService) ReadKafkaMirrorTopic(ctx _context.Context, clusterId string, linkName string, mirrorTopicName string) ApiReadKafkaMirrorTopicRequest {
 	return ApiReadKafkaMirrorTopicRequest{
@@ -1891,7 +1897,8 @@ func (a *ClusterLinkingV3ApiService) ReadKafkaMirrorTopic(ctx _context.Context, 
 }
 
 // Execute executes the request
-//  @return ListMirrorTopicsResponseData
+//
+//	@return ListMirrorTopicsResponseData
 func (a *ClusterLinkingV3ApiService) ReadKafkaMirrorTopicExecute(r ApiReadKafkaMirrorTopicRequest) (ListMirrorTopicsResponseData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -2033,11 +2040,11 @@ UpdateKafkaLinkConfig Alter the config under the cluster link
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @param configName The link config name
- @return ApiUpdateKafkaLinkConfigRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@param configName The link config name
+	@return ApiUpdateKafkaLinkConfigRequest
 */
 func (a *ClusterLinkingV3ApiService) UpdateKafkaLinkConfig(ctx _context.Context, clusterId string, linkName string, configName string) ApiUpdateKafkaLinkConfigRequest {
 	return ApiUpdateKafkaLinkConfigRequest{
@@ -2189,10 +2196,10 @@ UpdateKafkaLinkConfigBatch Batch Alter Cluster Link Configs
 
 Batch Alter Cluster Link Configs
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiUpdateKafkaLinkConfigBatchRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiUpdateKafkaLinkConfigBatchRequest
 */
 func (a *ClusterLinkingV3ApiService) UpdateKafkaLinkConfigBatch(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaLinkConfigBatchRequest {
 	return ApiUpdateKafkaLinkConfigBatchRequest{
@@ -2345,10 +2352,10 @@ UpdateKafkaMirrorTopicsFailover Failover the mirror topics
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiUpdateKafkaMirrorTopicsFailoverRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiUpdateKafkaMirrorTopicsFailoverRequest
 */
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsFailover(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaMirrorTopicsFailoverRequest {
 	return ApiUpdateKafkaMirrorTopicsFailoverRequest{
@@ -2360,7 +2367,8 @@ func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsFailover(ctx _contex
 }
 
 // Execute executes the request
-//  @return AlterMirrorStatusResponseDataList
+//
+//	@return AlterMirrorStatusResponseDataList
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsFailoverExecute(r ApiUpdateKafkaMirrorTopicsFailoverRequest) (AlterMirrorStatusResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
@@ -2512,10 +2520,10 @@ UpdateKafkaMirrorTopicsPause Pause the mirror topics
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiUpdateKafkaMirrorTopicsPauseRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiUpdateKafkaMirrorTopicsPauseRequest
 */
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsPause(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaMirrorTopicsPauseRequest {
 	return ApiUpdateKafkaMirrorTopicsPauseRequest{
@@ -2527,7 +2535,8 @@ func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsPause(ctx _context.C
 }
 
 // Execute executes the request
-//  @return AlterMirrorStatusResponseDataList
+//
+//	@return AlterMirrorStatusResponseDataList
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsPauseExecute(r ApiUpdateKafkaMirrorTopicsPauseRequest) (AlterMirrorStatusResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
@@ -2679,10 +2688,10 @@ UpdateKafkaMirrorTopicsPromote Promote the mirror topics
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiUpdateKafkaMirrorTopicsPromoteRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiUpdateKafkaMirrorTopicsPromoteRequest
 */
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsPromote(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaMirrorTopicsPromoteRequest {
 	return ApiUpdateKafkaMirrorTopicsPromoteRequest{
@@ -2694,7 +2703,8 @@ func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsPromote(ctx _context
 }
 
 // Execute executes the request
-//  @return AlterMirrorStatusResponseDataList
+//
+//	@return AlterMirrorStatusResponseDataList
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsPromoteExecute(r ApiUpdateKafkaMirrorTopicsPromoteRequest) (AlterMirrorStatusResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
@@ -2846,10 +2856,10 @@ UpdateKafkaMirrorTopicsResume Resume the mirror topics
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiUpdateKafkaMirrorTopicsResumeRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiUpdateKafkaMirrorTopicsResumeRequest
 */
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsResume(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaMirrorTopicsResumeRequest {
 	return ApiUpdateKafkaMirrorTopicsResumeRequest{
@@ -2861,7 +2871,8 @@ func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsResume(ctx _context.
 }
 
 // Execute executes the request
-//  @return AlterMirrorStatusResponseDataList
+//
+//	@return AlterMirrorStatusResponseDataList
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsResumeExecute(r ApiUpdateKafkaMirrorTopicsResumeRequest) (AlterMirrorStatusResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost

--- a/kafkarest/v3/api_cluster_linking_v3.go
+++ b/kafkarest/v3/api_cluster_linking_v3.go
@@ -56,17 +56,17 @@ type ClusterLinkingV3Api interface {
 	CreateKafkaLinkExecute(r ApiCreateKafkaLinkRequest) (*_nethttp.Response, error)
 
 	/*
-		CreateKafkaMirrorTopic Create a mirror topic
+			CreateKafkaMirrorTopic Create a mirror topic
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Create a topic in the destination cluster mirroring a topic in
-	the source cluster
+		Create a topic in the destination cluster mirroring a topic in
+		the source cluster
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param linkName The link name
-		 @return ApiCreateKafkaMirrorTopicRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param linkName The link name
+			 @return ApiCreateKafkaMirrorTopicRequest
 	*/
 	CreateKafkaMirrorTopic(ctx _context.Context, clusterId string, linkName string) ApiCreateKafkaMirrorTopicRequest
 
@@ -105,16 +105,16 @@ type ClusterLinkingV3Api interface {
 	DeleteKafkaLinkConfigExecute(r ApiDeleteKafkaLinkConfigRequest) (*_nethttp.Response, error)
 
 	/*
-		GetKafkaLink Describe the cluster link
+			GetKafkaLink Describe the cluster link
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	``link_id`` in ``ListLinksResponseData`` is deprecated and may be removed in a future release. Use the new ``cluster_link_id`` instead.
+		``link_id`` in ``ListLinksResponseData`` is deprecated and may be removed in a future release. Use the new ``cluster_link_id`` instead.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param linkName The link name
-		 @return ApiGetKafkaLinkRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param linkName The link name
+			 @return ApiGetKafkaLinkRequest
 	*/
 	GetKafkaLink(ctx _context.Context, clusterId string, linkName string) ApiGetKafkaLinkRequest
 
@@ -156,15 +156,15 @@ type ClusterLinkingV3Api interface {
 	ListKafkaLinkConfigsExecute(r ApiListKafkaLinkConfigsRequest) (ListLinkConfigsResponseDataList, *_nethttp.Response, error)
 
 	/*
-		ListKafkaLinks List all cluster links in the dest cluster
+			ListKafkaLinks List all cluster links in the dest cluster
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	``link_id`` in ``ListLinksResponseData`` is deprecated and may be removed in a future release. Use the new ``cluster_link_id`` instead.
+		``link_id`` in ``ListLinksResponseData`` is deprecated and may be removed in a future release. Use the new ``cluster_link_id`` instead.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @return ApiListKafkaLinksRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiListKafkaLinksRequest
 	*/
 	ListKafkaLinks(ctx _context.Context, clusterId string) ApiListKafkaLinksRequest
 
@@ -173,15 +173,15 @@ type ClusterLinkingV3Api interface {
 	ListKafkaLinksExecute(r ApiListKafkaLinksRequest) (ListLinksResponseDataList, *_nethttp.Response, error)
 
 	/*
-		ListKafkaMirrorTopics List mirror topics
+			ListKafkaMirrorTopics List mirror topics
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	List all mirror topics in the cluster
+		List all mirror topics in the cluster
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @return ApiListKafkaMirrorTopicsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiListKafkaMirrorTopicsRequest
 	*/
 	ListKafkaMirrorTopics(ctx _context.Context, clusterId string) ApiListKafkaMirrorTopicsRequest
 
@@ -190,16 +190,16 @@ type ClusterLinkingV3Api interface {
 	ListKafkaMirrorTopicsExecute(r ApiListKafkaMirrorTopicsRequest) (ListMirrorTopicsResponseDataList, *_nethttp.Response, error)
 
 	/*
-		ListKafkaMirrorTopicsUnderLink List mirror topics
+			ListKafkaMirrorTopicsUnderLink List mirror topics
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	List all mirror topics under the link
+		List all mirror topics under the link
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param linkName The link name
-		 @return ApiListKafkaMirrorTopicsUnderLinkRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param linkName The link name
+			 @return ApiListKafkaMirrorTopicsUnderLinkRequest
 	*/
 	ListKafkaMirrorTopicsUnderLink(ctx _context.Context, clusterId string, linkName string) ApiListKafkaMirrorTopicsUnderLinkRequest
 
@@ -241,16 +241,16 @@ type ClusterLinkingV3Api interface {
 	UpdateKafkaLinkConfigExecute(r ApiUpdateKafkaLinkConfigRequest) (*_nethttp.Response, error)
 
 	/*
-		UpdateKafkaLinkConfigBatch Batch Alter Cluster Link Configs
+			UpdateKafkaLinkConfigBatch Batch Alter Cluster Link Configs
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Batch Alter Cluster Link Configs
+		Batch Alter Cluster Link Configs
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param linkName The link name
-		 @return ApiUpdateKafkaLinkConfigBatchRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param linkName The link name
+			 @return ApiUpdateKafkaLinkConfigBatchRequest
 	*/
 	UpdateKafkaLinkConfigBatch(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaLinkConfigBatchRequest
 

--- a/kafkarest/v3/api_cluster_v3.go
+++ b/kafkarest/v3/api_cluster_v3.go
@@ -77,11 +77,11 @@ GetKafkaCluster Get Cluster
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the Kafka cluster with the specified ``cluster_id``.
+Return the Kafka cluster with the specified “cluster_id“.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiGetKafkaClusterRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiGetKafkaClusterRequest
 */
 func (a *ClusterV3ApiService) GetKafkaCluster(ctx _context.Context, clusterId string) ApiGetKafkaClusterRequest {
 	return ApiGetKafkaClusterRequest{
@@ -92,7 +92,8 @@ func (a *ClusterV3ApiService) GetKafkaCluster(ctx _context.Context, clusterId st
 }
 
 // Execute executes the request
-//  @return ClusterData
+//
+//	@return ClusterData
 func (a *ClusterV3ApiService) GetKafkaClusterExecute(r ApiGetKafkaClusterRequest) (ClusterData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet

--- a/kafkarest/v3/api_cluster_v3.go
+++ b/kafkarest/v3/api_cluster_v3.go
@@ -42,15 +42,15 @@ var (
 type ClusterV3Api interface {
 
 	/*
-		GetKafkaCluster Get Cluster
+			GetKafkaCluster Get Cluster
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Return the Kafka cluster with the specified ``cluster_id``.
+		Return the Kafka cluster with the specified ``cluster_id``.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @return ApiGetKafkaClusterRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiGetKafkaClusterRequest
 	*/
 	GetKafkaCluster(ctx _context.Context, clusterId string) ApiGetKafkaClusterRequest
 

--- a/kafkarest/v3/api_configs_v3.go
+++ b/kafkarest/v3/api_configs_v3.go
@@ -42,17 +42,17 @@ var (
 type ConfigsV3Api interface {
 
 	/*
-		DeleteKafkaClusterConfig Reset Dynamic Broker Config
+			DeleteKafkaClusterConfig Reset Dynamic Broker Config
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Reset the configuration parameter specified by ``name`` to its
-	default value by deleting a dynamic cluster-wide configuration.
+		Reset the configuration parameter specified by ``name`` to its
+		default value by deleting a dynamic cluster-wide configuration.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param name The configuration parameter name.
-		 @return ApiDeleteKafkaClusterConfigRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param name The configuration parameter name.
+			 @return ApiDeleteKafkaClusterConfigRequest
 	*/
 	DeleteKafkaClusterConfig(ctx _context.Context, clusterId string, name string) ApiDeleteKafkaClusterConfigRequest
 
@@ -60,17 +60,17 @@ type ConfigsV3Api interface {
 	DeleteKafkaClusterConfigExecute(r ApiDeleteKafkaClusterConfigRequest) (*_nethttp.Response, error)
 
 	/*
-		DeleteKafkaTopicConfig Reset Topic Config
+			DeleteKafkaTopicConfig Reset Topic Config
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Reset the configuration parameter with given `name` to its default value.
+		Reset the configuration parameter with given `name` to its default value.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param topicName The topic name.
-		 @param name The configuration parameter name.
-		 @return ApiDeleteKafkaTopicConfigRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @param name The configuration parameter name.
+			 @return ApiDeleteKafkaTopicConfigRequest
 	*/
 	DeleteKafkaTopicConfig(ctx _context.Context, clusterId string, topicName string, name string) ApiDeleteKafkaTopicConfigRequest
 
@@ -78,16 +78,16 @@ type ConfigsV3Api interface {
 	DeleteKafkaTopicConfigExecute(r ApiDeleteKafkaTopicConfigRequest) (*_nethttp.Response, error)
 
 	/*
-		GetKafkaClusterConfig Get Dynamic Broker Config
+			GetKafkaClusterConfig Get Dynamic Broker Config
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Return the dynamic cluster-wide broker configuration parameter specified by ``name``.
+		Return the dynamic cluster-wide broker configuration parameter specified by ``name``.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param name The configuration parameter name.
-		 @return ApiGetKafkaClusterConfigRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param name The configuration parameter name.
+			 @return ApiGetKafkaClusterConfigRequest
 	*/
 	GetKafkaClusterConfig(ctx _context.Context, clusterId string, name string) ApiGetKafkaClusterConfigRequest
 
@@ -96,17 +96,17 @@ type ConfigsV3Api interface {
 	GetKafkaClusterConfigExecute(r ApiGetKafkaClusterConfigRequest) (ClusterConfigData, *_nethttp.Response, error)
 
 	/*
-		GetKafkaTopicConfig Get Topic Config
+			GetKafkaTopicConfig Get Topic Config
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Return the configuration parameter with the given `name`.
+		Return the configuration parameter with the given `name`.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param topicName The topic name.
-		 @param name The configuration parameter name.
-		 @return ApiGetKafkaTopicConfigRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @param name The configuration parameter name.
+			 @return ApiGetKafkaTopicConfigRequest
 	*/
 	GetKafkaTopicConfig(ctx _context.Context, clusterId string, topicName string, name string) ApiGetKafkaTopicConfigRequest
 
@@ -115,16 +115,16 @@ type ConfigsV3Api interface {
 	GetKafkaTopicConfigExecute(r ApiGetKafkaTopicConfigRequest) (TopicConfigData, *_nethttp.Response, error)
 
 	/*
-		ListKafkaAllTopicConfigs List All Topic Configs
+			ListKafkaAllTopicConfigs List All Topic Configs
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Return the list of configuration parameters for all topics hosted by the specified
-	cluster.
+		Return the list of configuration parameters for all topics hosted by the specified
+		cluster.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @return ApiListKafkaAllTopicConfigsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiListKafkaAllTopicConfigsRequest
 	*/
 	ListKafkaAllTopicConfigs(ctx _context.Context, clusterId string) ApiListKafkaAllTopicConfigsRequest
 
@@ -133,16 +133,16 @@ type ConfigsV3Api interface {
 	ListKafkaAllTopicConfigsExecute(r ApiListKafkaAllTopicConfigsRequest) (TopicConfigDataList, *_nethttp.Response, error)
 
 	/*
-		ListKafkaClusterConfigs List Dynamic Broker Configs
+			ListKafkaClusterConfigs List Dynamic Broker Configs
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Return a list of dynamic cluster-wide broker configuration parameters for the specified Kafka
-	cluster. Returns an empty list if there are no dynamic cluster-wide broker configuration parameters.
+		Return a list of dynamic cluster-wide broker configuration parameters for the specified Kafka
+		cluster. Returns an empty list if there are no dynamic cluster-wide broker configuration parameters.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @return ApiListKafkaClusterConfigsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiListKafkaClusterConfigsRequest
 	*/
 	ListKafkaClusterConfigs(ctx _context.Context, clusterId string) ApiListKafkaClusterConfigsRequest
 
@@ -151,16 +151,16 @@ type ConfigsV3Api interface {
 	ListKafkaClusterConfigsExecute(r ApiListKafkaClusterConfigsRequest) (ClusterConfigDataList, *_nethttp.Response, error)
 
 	/*
-		ListKafkaDefaultTopicConfigs List New Topic Default Configs
+			ListKafkaDefaultTopicConfigs List New Topic Default Configs
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	List the default configuration parameters used if the topic were to be newly created.
+		List the default configuration parameters used if the topic were to be newly created.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param topicName The topic name.
-		 @return ApiListKafkaDefaultTopicConfigsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @return ApiListKafkaDefaultTopicConfigsRequest
 	*/
 	ListKafkaDefaultTopicConfigs(ctx _context.Context, clusterId string, topicName string) ApiListKafkaDefaultTopicConfigsRequest
 
@@ -169,16 +169,16 @@ type ConfigsV3Api interface {
 	ListKafkaDefaultTopicConfigsExecute(r ApiListKafkaDefaultTopicConfigsRequest) (TopicConfigDataList, *_nethttp.Response, error)
 
 	/*
-		ListKafkaTopicConfigs List Topic Configs
+			ListKafkaTopicConfigs List Topic Configs
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Return the list of configuration parameters that belong to the specified topic.
+		Return the list of configuration parameters that belong to the specified topic.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param topicName The topic name.
-		 @return ApiListKafkaTopicConfigsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @return ApiListKafkaTopicConfigsRequest
 	*/
 	ListKafkaTopicConfigs(ctx _context.Context, clusterId string, topicName string) ApiListKafkaTopicConfigsRequest
 
@@ -187,16 +187,16 @@ type ConfigsV3Api interface {
 	ListKafkaTopicConfigsExecute(r ApiListKafkaTopicConfigsRequest) (TopicConfigDataList, *_nethttp.Response, error)
 
 	/*
-		UpdateKafkaClusterConfig Update Dynamic Broker Config
+			UpdateKafkaClusterConfig Update Dynamic Broker Config
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Update the dynamic cluster-wide broker configuration parameter specified by ``name``.
+		Update the dynamic cluster-wide broker configuration parameter specified by ``name``.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param name The configuration parameter name.
-		 @return ApiUpdateKafkaClusterConfigRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param name The configuration parameter name.
+			 @return ApiUpdateKafkaClusterConfigRequest
 	*/
 	UpdateKafkaClusterConfig(ctx _context.Context, clusterId string, name string) ApiUpdateKafkaClusterConfigRequest
 
@@ -204,15 +204,15 @@ type ConfigsV3Api interface {
 	UpdateKafkaClusterConfigExecute(r ApiUpdateKafkaClusterConfigRequest) (*_nethttp.Response, error)
 
 	/*
-		UpdateKafkaClusterConfigs Batch Alter Dynamic Broker Configs
+			UpdateKafkaClusterConfigs Batch Alter Dynamic Broker Configs
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Update or delete a set of dynamic cluster-wide broker configuration parameters.
+		Update or delete a set of dynamic cluster-wide broker configuration parameters.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @return ApiUpdateKafkaClusterConfigsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiUpdateKafkaClusterConfigsRequest
 	*/
 	UpdateKafkaClusterConfigs(ctx _context.Context, clusterId string) ApiUpdateKafkaClusterConfigsRequest
 
@@ -220,17 +220,17 @@ type ConfigsV3Api interface {
 	UpdateKafkaClusterConfigsExecute(r ApiUpdateKafkaClusterConfigsRequest) (*_nethttp.Response, error)
 
 	/*
-		UpdateKafkaTopicConfig Update Topic Config
+			UpdateKafkaTopicConfig Update Topic Config
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Update the configuration parameter with given `name`.
+		Update the configuration parameter with given `name`.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param topicName The topic name.
-		 @param name The configuration parameter name.
-		 @return ApiUpdateKafkaTopicConfigRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @param name The configuration parameter name.
+			 @return ApiUpdateKafkaTopicConfigRequest
 	*/
 	UpdateKafkaTopicConfig(ctx _context.Context, clusterId string, topicName string, name string) ApiUpdateKafkaTopicConfigRequest
 
@@ -238,18 +238,18 @@ type ConfigsV3Api interface {
 	UpdateKafkaTopicConfigExecute(r ApiUpdateKafkaTopicConfigRequest) (*_nethttp.Response, error)
 
 	/*
-		UpdateKafkaTopicConfigBatch Batch Alter Topic Configs
+			UpdateKafkaTopicConfigBatch Batch Alter Topic Configs
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Update or delete a set of topic configuration parameters.
-	Also supports a dry-run mode that only validates whether the operation would succeed if the
-	``validate_only`` request property is explicitly specified and set to true.
+		Update or delete a set of topic configuration parameters.
+		Also supports a dry-run mode that only validates whether the operation would succeed if the
+		``validate_only`` request property is explicitly specified and set to true.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param topicName The topic name.
-		 @return ApiUpdateKafkaTopicConfigBatchRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @return ApiUpdateKafkaTopicConfigBatchRequest
 	*/
 	UpdateKafkaTopicConfigBatch(ctx _context.Context, clusterId string, topicName string) ApiUpdateKafkaTopicConfigBatchRequest
 

--- a/kafkarest/v3/api_configs_v3.go
+++ b/kafkarest/v3/api_configs_v3.go
@@ -276,13 +276,13 @@ DeleteKafkaClusterConfig Reset Dynamic Broker Config
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Reset the configuration parameter specified by ``name`` to its
+Reset the configuration parameter specified by “name“ to its
 default value by deleting a dynamic cluster-wide configuration.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param name The configuration parameter name.
- @return ApiDeleteKafkaClusterConfigRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param name The configuration parameter name.
+	@return ApiDeleteKafkaClusterConfigRequest
 */
 func (a *ConfigsV3ApiService) DeleteKafkaClusterConfig(ctx _context.Context, clusterId string, name string) ApiDeleteKafkaClusterConfigRequest {
 	return ApiDeleteKafkaClusterConfigRequest{
@@ -429,11 +429,11 @@ DeleteKafkaTopicConfig Reset Topic Config
 
 Reset the configuration parameter with given `name` to its default value.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @param name The configuration parameter name.
- @return ApiDeleteKafkaTopicConfigRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@param name The configuration parameter name.
+	@return ApiDeleteKafkaTopicConfigRequest
 */
 func (a *ConfigsV3ApiService) DeleteKafkaTopicConfig(ctx _context.Context, clusterId string, topicName string, name string) ApiDeleteKafkaTopicConfigRequest {
 	return ApiDeleteKafkaTopicConfigRequest{
@@ -589,12 +589,12 @@ GetKafkaClusterConfig Get Dynamic Broker Config
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the dynamic cluster-wide broker configuration parameter specified by ``name``.
+Return the dynamic cluster-wide broker configuration parameter specified by “name“.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param name The configuration parameter name.
- @return ApiGetKafkaClusterConfigRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param name The configuration parameter name.
+	@return ApiGetKafkaClusterConfigRequest
 */
 func (a *ConfigsV3ApiService) GetKafkaClusterConfig(ctx _context.Context, clusterId string, name string) ApiGetKafkaClusterConfigRequest {
 	return ApiGetKafkaClusterConfigRequest{
@@ -606,7 +606,8 @@ func (a *ConfigsV3ApiService) GetKafkaClusterConfig(ctx _context.Context, cluste
 }
 
 // Execute executes the request
-//  @return ClusterConfigData
+//
+//	@return ClusterConfigData
 func (a *ConfigsV3ApiService) GetKafkaClusterConfigExecute(r ApiGetKafkaClusterConfigRequest) (ClusterConfigData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -752,11 +753,11 @@ GetKafkaTopicConfig Get Topic Config
 
 Return the configuration parameter with the given `name`.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @param name The configuration parameter name.
- @return ApiGetKafkaTopicConfigRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@param name The configuration parameter name.
+	@return ApiGetKafkaTopicConfigRequest
 */
 func (a *ConfigsV3ApiService) GetKafkaTopicConfig(ctx _context.Context, clusterId string, topicName string, name string) ApiGetKafkaTopicConfigRequest {
 	return ApiGetKafkaTopicConfigRequest{
@@ -769,7 +770,8 @@ func (a *ConfigsV3ApiService) GetKafkaTopicConfig(ctx _context.Context, clusterI
 }
 
 // Execute executes the request
-//  @return TopicConfigData
+//
+//	@return TopicConfigData
 func (a *ConfigsV3ApiService) GetKafkaTopicConfigExecute(r ApiGetKafkaTopicConfigRequest) (TopicConfigData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -925,9 +927,9 @@ ListKafkaAllTopicConfigs List All Topic Configs
 Return the list of configuration parameters for all topics hosted by the specified
 cluster.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiListKafkaAllTopicConfigsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiListKafkaAllTopicConfigsRequest
 */
 func (a *ConfigsV3ApiService) ListKafkaAllTopicConfigs(ctx _context.Context, clusterId string) ApiListKafkaAllTopicConfigsRequest {
 	return ApiListKafkaAllTopicConfigsRequest{
@@ -938,7 +940,8 @@ func (a *ConfigsV3ApiService) ListKafkaAllTopicConfigs(ctx _context.Context, clu
 }
 
 // Execute executes the request
-//  @return TopicConfigDataList
+//
+//	@return TopicConfigDataList
 func (a *ConfigsV3ApiService) ListKafkaAllTopicConfigsExecute(r ApiListKafkaAllTopicConfigsRequest) (TopicConfigDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1082,9 +1085,9 @@ ListKafkaClusterConfigs List Dynamic Broker Configs
 Return a list of dynamic cluster-wide broker configuration parameters for the specified Kafka
 cluster. Returns an empty list if there are no dynamic cluster-wide broker configuration parameters.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiListKafkaClusterConfigsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiListKafkaClusterConfigsRequest
 */
 func (a *ConfigsV3ApiService) ListKafkaClusterConfigs(ctx _context.Context, clusterId string) ApiListKafkaClusterConfigsRequest {
 	return ApiListKafkaClusterConfigsRequest{
@@ -1095,7 +1098,8 @@ func (a *ConfigsV3ApiService) ListKafkaClusterConfigs(ctx _context.Context, clus
 }
 
 // Execute executes the request
-//  @return ClusterConfigDataList
+//
+//	@return ClusterConfigDataList
 func (a *ConfigsV3ApiService) ListKafkaClusterConfigsExecute(r ApiListKafkaClusterConfigsRequest) (ClusterConfigDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1239,10 +1243,10 @@ ListKafkaDefaultTopicConfigs List New Topic Default Configs
 
 List the default configuration parameters used if the topic were to be newly created.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @return ApiListKafkaDefaultTopicConfigsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@return ApiListKafkaDefaultTopicConfigsRequest
 */
 func (a *ConfigsV3ApiService) ListKafkaDefaultTopicConfigs(ctx _context.Context, clusterId string, topicName string) ApiListKafkaDefaultTopicConfigsRequest {
 	return ApiListKafkaDefaultTopicConfigsRequest{
@@ -1254,7 +1258,8 @@ func (a *ConfigsV3ApiService) ListKafkaDefaultTopicConfigs(ctx _context.Context,
 }
 
 // Execute executes the request
-//  @return TopicConfigDataList
+//
+//	@return TopicConfigDataList
 func (a *ConfigsV3ApiService) ListKafkaDefaultTopicConfigsExecute(r ApiListKafkaDefaultTopicConfigsRequest) (TopicConfigDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1399,10 +1404,10 @@ ListKafkaTopicConfigs List Topic Configs
 
 Return the list of configuration parameters that belong to the specified topic.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @return ApiListKafkaTopicConfigsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@return ApiListKafkaTopicConfigsRequest
 */
 func (a *ConfigsV3ApiService) ListKafkaTopicConfigs(ctx _context.Context, clusterId string, topicName string) ApiListKafkaTopicConfigsRequest {
 	return ApiListKafkaTopicConfigsRequest{
@@ -1414,7 +1419,8 @@ func (a *ConfigsV3ApiService) ListKafkaTopicConfigs(ctx _context.Context, cluste
 }
 
 // Execute executes the request
-//  @return TopicConfigDataList
+//
+//	@return TopicConfigDataList
 func (a *ConfigsV3ApiService) ListKafkaTopicConfigsExecute(r ApiListKafkaTopicConfigsRequest) (TopicConfigDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1574,12 +1580,12 @@ UpdateKafkaClusterConfig Update Dynamic Broker Config
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Update the dynamic cluster-wide broker configuration parameter specified by ``name``.
+Update the dynamic cluster-wide broker configuration parameter specified by “name“.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param name The configuration parameter name.
- @return ApiUpdateKafkaClusterConfigRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param name The configuration parameter name.
+	@return ApiUpdateKafkaClusterConfigRequest
 */
 func (a *ConfigsV3ApiService) UpdateKafkaClusterConfig(ctx _context.Context, clusterId string, name string) ApiUpdateKafkaClusterConfigRequest {
 	return ApiUpdateKafkaClusterConfigRequest{
@@ -1733,9 +1739,9 @@ UpdateKafkaClusterConfigs Batch Alter Dynamic Broker Configs
 
 Update or delete a set of dynamic cluster-wide broker configuration parameters.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiUpdateKafkaClusterConfigsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiUpdateKafkaClusterConfigsRequest
 */
 func (a *ConfigsV3ApiService) UpdateKafkaClusterConfigs(ctx _context.Context, clusterId string) ApiUpdateKafkaClusterConfigsRequest {
 	return ApiUpdateKafkaClusterConfigsRequest{
@@ -1889,11 +1895,11 @@ UpdateKafkaTopicConfig Update Topic Config
 
 Update the configuration parameter with given `name`.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @param name The configuration parameter name.
- @return ApiUpdateKafkaTopicConfigRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@param name The configuration parameter name.
+	@return ApiUpdateKafkaTopicConfigRequest
 */
 func (a *ConfigsV3ApiService) UpdateKafkaTopicConfig(ctx _context.Context, clusterId string, topicName string, name string) ApiUpdateKafkaTopicConfigRequest {
 	return ApiUpdateKafkaTopicConfigRequest{
@@ -2060,12 +2066,12 @@ UpdateKafkaTopicConfigBatch Batch Alter Topic Configs
 
 Update or delete a set of topic configuration parameters.
 Also supports a dry-run mode that only validates whether the operation would succeed if the
-``validate_only`` request property is explicitly specified and set to true.
+“validate_only“ request property is explicitly specified and set to true.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @return ApiUpdateKafkaTopicConfigBatchRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@return ApiUpdateKafkaTopicConfigBatchRequest
 */
 func (a *ConfigsV3ApiService) UpdateKafkaTopicConfigBatch(ctx _context.Context, clusterId string, topicName string) ApiUpdateKafkaTopicConfigBatchRequest {
 	return ApiUpdateKafkaTopicConfigBatchRequest{

--- a/kafkarest/v3/api_consumer_group_v3.go
+++ b/kafkarest/v3/api_consumer_group_v3.go
@@ -42,17 +42,17 @@ var (
 type ConsumerGroupV3Api interface {
 
 	/*
-		GetKafkaConsumer Get Consumer
+			GetKafkaConsumer Get Consumer
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Return the consumer specified by the ``consumer_id``.
+		Return the consumer specified by the ``consumer_id``.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param consumerGroupId The consumer group ID.
-		 @param consumerId The consumer ID.
-		 @return ApiGetKafkaConsumerRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param consumerGroupId The consumer group ID.
+			 @param consumerId The consumer ID.
+			 @return ApiGetKafkaConsumerRequest
 	*/
 	GetKafkaConsumer(ctx _context.Context, clusterId string, consumerGroupId string, consumerId string) ApiGetKafkaConsumerRequest
 
@@ -61,16 +61,16 @@ type ConsumerGroupV3Api interface {
 	GetKafkaConsumerExecute(r ApiGetKafkaConsumerRequest) (ConsumerData, *_nethttp.Response, error)
 
 	/*
-		GetKafkaConsumerGroup Get Consumer Group
+			GetKafkaConsumerGroup Get Consumer Group
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Return the consumer group specified by the ``consumer_group_id``.
+		Return the consumer group specified by the ``consumer_group_id``.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param consumerGroupId The consumer group ID.
-		 @return ApiGetKafkaConsumerGroupRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param consumerGroupId The consumer group ID.
+			 @return ApiGetKafkaConsumerGroupRequest
 	*/
 	GetKafkaConsumerGroup(ctx _context.Context, clusterId string, consumerGroupId string) ApiGetKafkaConsumerGroupRequest
 
@@ -79,17 +79,17 @@ type ConsumerGroupV3Api interface {
 	GetKafkaConsumerGroupExecute(r ApiGetKafkaConsumerGroupRequest) (ConsumerGroupData, *_nethttp.Response, error)
 
 	/*
-		GetKafkaConsumerGroupLagSummary Get Consumer Group Lag Summary
+			GetKafkaConsumerGroupLagSummary Get Consumer Group Lag Summary
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Available in dedicated clusters only](https://img.shields.io/badge/-Available%20in%20dedicated%20clusters%20only-%23bc8540)](https://docs.confluent.io/cloud/current/clusters/cluster-types.html#dedicated-cluster)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Available in dedicated clusters only](https://img.shields.io/badge/-Available%20in%20dedicated%20clusters%20only-%23bc8540)](https://docs.confluent.io/cloud/current/clusters/cluster-types.html#dedicated-cluster)
 
-	Return the maximum and total lag of the consumers belonging to the
-	specified consumer group.
+		Return the maximum and total lag of the consumers belonging to the
+		specified consumer group.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param consumerGroupId The consumer group ID.
-		 @return ApiGetKafkaConsumerGroupLagSummaryRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param consumerGroupId The consumer group ID.
+			 @return ApiGetKafkaConsumerGroupLagSummaryRequest
 	*/
 	GetKafkaConsumerGroupLagSummary(ctx _context.Context, clusterId string, consumerGroupId string) ApiGetKafkaConsumerGroupLagSummaryRequest
 
@@ -98,18 +98,18 @@ type ConsumerGroupV3Api interface {
 	GetKafkaConsumerGroupLagSummaryExecute(r ApiGetKafkaConsumerGroupLagSummaryRequest) (ConsumerGroupLagSummaryData, *_nethttp.Response, error)
 
 	/*
-		GetKafkaConsumerLag Get Consumer Lag
+			GetKafkaConsumerLag Get Consumer Lag
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Available in dedicated clusters only](https://img.shields.io/badge/-Available%20in%20dedicated%20clusters%20only-%23bc8540)](https://docs.confluent.io/cloud/current/clusters/cluster-types.html#dedicated-cluster)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Available in dedicated clusters only](https://img.shields.io/badge/-Available%20in%20dedicated%20clusters%20only-%23bc8540)](https://docs.confluent.io/cloud/current/clusters/cluster-types.html#dedicated-cluster)
 
-	Return the consumer lag on a partition with the given `partition_id`.
+		Return the consumer lag on a partition with the given `partition_id`.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param consumerGroupId The consumer group ID.
-		 @param topicName The topic name.
-		 @param partitionId The partition ID.
-		 @return ApiGetKafkaConsumerLagRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param consumerGroupId The consumer group ID.
+			 @param topicName The topic name.
+			 @param partitionId The partition ID.
+			 @return ApiGetKafkaConsumerLagRequest
 	*/
 	GetKafkaConsumerLag(ctx _context.Context, clusterId string, consumerGroupId string, topicName string, partitionId int32) ApiGetKafkaConsumerLagRequest
 
@@ -118,16 +118,16 @@ type ConsumerGroupV3Api interface {
 	GetKafkaConsumerLagExecute(r ApiGetKafkaConsumerLagRequest) (ConsumerLagData, *_nethttp.Response, error)
 
 	/*
-		ListKafkaConsumerGroups List Consumer Groups
+			ListKafkaConsumerGroups List Consumer Groups
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Return the list of consumer groups that belong to the specified
-	Kafka cluster.
+		Return the list of consumer groups that belong to the specified
+		Kafka cluster.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @return ApiListKafkaConsumerGroupsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiListKafkaConsumerGroupsRequest
 	*/
 	ListKafkaConsumerGroups(ctx _context.Context, clusterId string) ApiListKafkaConsumerGroupsRequest
 
@@ -136,17 +136,17 @@ type ConsumerGroupV3Api interface {
 	ListKafkaConsumerGroupsExecute(r ApiListKafkaConsumerGroupsRequest) (ConsumerGroupDataList, *_nethttp.Response, error)
 
 	/*
-		ListKafkaConsumerLags List Consumer Lags
+			ListKafkaConsumerLags List Consumer Lags
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Available in dedicated clusters only](https://img.shields.io/badge/-Available%20in%20dedicated%20clusters%20only-%23bc8540)](https://docs.confluent.io/cloud/current/clusters/cluster-types.html#dedicated-cluster)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Available in dedicated clusters only](https://img.shields.io/badge/-Available%20in%20dedicated%20clusters%20only-%23bc8540)](https://docs.confluent.io/cloud/current/clusters/cluster-types.html#dedicated-cluster)
 
-	Return a list of consumer lags of the consumers belonging to the
-	specified consumer group.
+		Return a list of consumer lags of the consumers belonging to the
+		specified consumer group.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param consumerGroupId The consumer group ID.
-		 @return ApiListKafkaConsumerLagsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param consumerGroupId The consumer group ID.
+			 @return ApiListKafkaConsumerLagsRequest
 	*/
 	ListKafkaConsumerLags(ctx _context.Context, clusterId string, consumerGroupId string) ApiListKafkaConsumerLagsRequest
 
@@ -155,17 +155,17 @@ type ConsumerGroupV3Api interface {
 	ListKafkaConsumerLagsExecute(r ApiListKafkaConsumerLagsRequest) (ConsumerLagDataList, *_nethttp.Response, error)
 
 	/*
-		ListKafkaConsumers List Consumers
+			ListKafkaConsumers List Consumers
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Return a list of consumers that belong to the specified consumer
-	group.
+		Return a list of consumers that belong to the specified consumer
+		group.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param consumerGroupId The consumer group ID.
-		 @return ApiListKafkaConsumersRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param consumerGroupId The consumer group ID.
+			 @return ApiListKafkaConsumersRequest
 	*/
 	ListKafkaConsumers(ctx _context.Context, clusterId string, consumerGroupId string) ApiListKafkaConsumersRequest
 

--- a/kafkarest/v3/api_consumer_group_v3.go
+++ b/kafkarest/v3/api_consumer_group_v3.go
@@ -194,13 +194,13 @@ GetKafkaConsumer Get Consumer
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the consumer specified by the ``consumer_id``.
+Return the consumer specified by the “consumer_id“.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param consumerGroupId The consumer group ID.
- @param consumerId The consumer ID.
- @return ApiGetKafkaConsumerRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param consumerGroupId The consumer group ID.
+	@param consumerId The consumer ID.
+	@return ApiGetKafkaConsumerRequest
 */
 func (a *ConsumerGroupV3ApiService) GetKafkaConsumer(ctx _context.Context, clusterId string, consumerGroupId string, consumerId string) ApiGetKafkaConsumerRequest {
 	return ApiGetKafkaConsumerRequest{
@@ -213,7 +213,8 @@ func (a *ConsumerGroupV3ApiService) GetKafkaConsumer(ctx _context.Context, clust
 }
 
 // Execute executes the request
-//  @return ConsumerData
+//
+//	@return ConsumerData
 func (a *ConsumerGroupV3ApiService) GetKafkaConsumerExecute(r ApiGetKafkaConsumerRequest) (ConsumerData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -357,12 +358,12 @@ GetKafkaConsumerGroup Get Consumer Group
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the consumer group specified by the ``consumer_group_id``.
+Return the consumer group specified by the “consumer_group_id“.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param consumerGroupId The consumer group ID.
- @return ApiGetKafkaConsumerGroupRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param consumerGroupId The consumer group ID.
+	@return ApiGetKafkaConsumerGroupRequest
 */
 func (a *ConsumerGroupV3ApiService) GetKafkaConsumerGroup(ctx _context.Context, clusterId string, consumerGroupId string) ApiGetKafkaConsumerGroupRequest {
 	return ApiGetKafkaConsumerGroupRequest{
@@ -374,7 +375,8 @@ func (a *ConsumerGroupV3ApiService) GetKafkaConsumerGroup(ctx _context.Context, 
 }
 
 // Execute executes the request
-//  @return ConsumerGroupData
+//
+//	@return ConsumerGroupData
 func (a *ConsumerGroupV3ApiService) GetKafkaConsumerGroupExecute(r ApiGetKafkaConsumerGroupRequest) (ConsumerGroupData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -520,10 +522,10 @@ GetKafkaConsumerGroupLagSummary Get Consumer Group Lag Summary
 Return the maximum and total lag of the consumers belonging to the
 specified consumer group.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param consumerGroupId The consumer group ID.
- @return ApiGetKafkaConsumerGroupLagSummaryRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param consumerGroupId The consumer group ID.
+	@return ApiGetKafkaConsumerGroupLagSummaryRequest
 */
 func (a *ConsumerGroupV3ApiService) GetKafkaConsumerGroupLagSummary(ctx _context.Context, clusterId string, consumerGroupId string) ApiGetKafkaConsumerGroupLagSummaryRequest {
 	return ApiGetKafkaConsumerGroupLagSummaryRequest{
@@ -535,7 +537,8 @@ func (a *ConsumerGroupV3ApiService) GetKafkaConsumerGroupLagSummary(ctx _context
 }
 
 // Execute executes the request
-//  @return ConsumerGroupLagSummaryData
+//
+//	@return ConsumerGroupLagSummaryData
 func (a *ConsumerGroupV3ApiService) GetKafkaConsumerGroupLagSummaryExecute(r ApiGetKafkaConsumerGroupLagSummaryRequest) (ConsumerGroupLagSummaryData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -682,12 +685,12 @@ GetKafkaConsumerLag Get Consumer Lag
 
 Return the consumer lag on a partition with the given `partition_id`.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param consumerGroupId The consumer group ID.
- @param topicName The topic name.
- @param partitionId The partition ID.
- @return ApiGetKafkaConsumerLagRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param consumerGroupId The consumer group ID.
+	@param topicName The topic name.
+	@param partitionId The partition ID.
+	@return ApiGetKafkaConsumerLagRequest
 */
 func (a *ConsumerGroupV3ApiService) GetKafkaConsumerLag(ctx _context.Context, clusterId string, consumerGroupId string, topicName string, partitionId int32) ApiGetKafkaConsumerLagRequest {
 	return ApiGetKafkaConsumerLagRequest{
@@ -701,7 +704,8 @@ func (a *ConsumerGroupV3ApiService) GetKafkaConsumerLag(ctx _context.Context, cl
 }
 
 // Execute executes the request
-//  @return ConsumerLagData
+//
+//	@return ConsumerLagData
 func (a *ConsumerGroupV3ApiService) GetKafkaConsumerLagExecute(r ApiGetKafkaConsumerLagRequest) (ConsumerLagData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -848,9 +852,9 @@ ListKafkaConsumerGroups List Consumer Groups
 Return the list of consumer groups that belong to the specified
 Kafka cluster.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiListKafkaConsumerGroupsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiListKafkaConsumerGroupsRequest
 */
 func (a *ConsumerGroupV3ApiService) ListKafkaConsumerGroups(ctx _context.Context, clusterId string) ApiListKafkaConsumerGroupsRequest {
 	return ApiListKafkaConsumerGroupsRequest{
@@ -861,7 +865,8 @@ func (a *ConsumerGroupV3ApiService) ListKafkaConsumerGroups(ctx _context.Context
 }
 
 // Execute executes the request
-//  @return ConsumerGroupDataList
+//
+//	@return ConsumerGroupDataList
 func (a *ConsumerGroupV3ApiService) ListKafkaConsumerGroupsExecute(r ApiListKafkaConsumerGroupsRequest) (ConsumerGroupDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1006,10 +1011,10 @@ ListKafkaConsumerLags List Consumer Lags
 Return a list of consumer lags of the consumers belonging to the
 specified consumer group.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param consumerGroupId The consumer group ID.
- @return ApiListKafkaConsumerLagsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param consumerGroupId The consumer group ID.
+	@return ApiListKafkaConsumerLagsRequest
 */
 func (a *ConsumerGroupV3ApiService) ListKafkaConsumerLags(ctx _context.Context, clusterId string, consumerGroupId string) ApiListKafkaConsumerLagsRequest {
 	return ApiListKafkaConsumerLagsRequest{
@@ -1021,7 +1026,8 @@ func (a *ConsumerGroupV3ApiService) ListKafkaConsumerLags(ctx _context.Context, 
 }
 
 // Execute executes the request
-//  @return ConsumerLagDataList
+//
+//	@return ConsumerLagDataList
 func (a *ConsumerGroupV3ApiService) ListKafkaConsumerLagsExecute(r ApiListKafkaConsumerLagsRequest) (ConsumerLagDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1167,10 +1173,10 @@ ListKafkaConsumers List Consumers
 Return a list of consumers that belong to the specified consumer
 group.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param consumerGroupId The consumer group ID.
- @return ApiListKafkaConsumersRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param consumerGroupId The consumer group ID.
+	@return ApiListKafkaConsumersRequest
 */
 func (a *ConsumerGroupV3ApiService) ListKafkaConsumers(ctx _context.Context, clusterId string, consumerGroupId string) ApiListKafkaConsumersRequest {
 	return ApiListKafkaConsumersRequest{
@@ -1182,7 +1188,8 @@ func (a *ConsumerGroupV3ApiService) ListKafkaConsumers(ctx _context.Context, clu
 }
 
 // Execute executes the request
-//  @return ConsumerDataList
+//
+//	@return ConsumerDataList
 func (a *ConsumerGroupV3ApiService) ListKafkaConsumersExecute(r ApiListKafkaConsumersRequest) (ConsumerDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet

--- a/kafkarest/v3/api_partition_v3.go
+++ b/kafkarest/v3/api_partition_v3.go
@@ -101,11 +101,11 @@ GetKafkaPartition Get Partition
 
 Return the partition with the given `partition_id`.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @param partitionId The partition ID.
- @return ApiGetKafkaPartitionRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@param partitionId The partition ID.
+	@return ApiGetKafkaPartitionRequest
 */
 func (a *PartitionV3ApiService) GetKafkaPartition(ctx _context.Context, clusterId string, topicName string, partitionId int32) ApiGetKafkaPartitionRequest {
 	return ApiGetKafkaPartitionRequest{
@@ -118,7 +118,8 @@ func (a *PartitionV3ApiService) GetKafkaPartition(ctx _context.Context, clusterI
 }
 
 // Execute executes the request
-//  @return PartitionData
+//
+//	@return PartitionData
 func (a *PartitionV3ApiService) GetKafkaPartitionExecute(r ApiGetKafkaPartitionRequest) (PartitionData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -274,10 +275,10 @@ ListKafkaPartitions List Partitions
 
 Return the list of partitions that belong to the specified topic.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @return ApiListKafkaPartitionsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@return ApiListKafkaPartitionsRequest
 */
 func (a *PartitionV3ApiService) ListKafkaPartitions(ctx _context.Context, clusterId string, topicName string) ApiListKafkaPartitionsRequest {
 	return ApiListKafkaPartitionsRequest{
@@ -289,7 +290,8 @@ func (a *PartitionV3ApiService) ListKafkaPartitions(ctx _context.Context, cluste
 }
 
 // Execute executes the request
-//  @return PartitionDataList
+//
+//	@return PartitionDataList
 func (a *PartitionV3ApiService) ListKafkaPartitionsExecute(r ApiListKafkaPartitionsRequest) (PartitionDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet

--- a/kafkarest/v3/api_partition_v3.go
+++ b/kafkarest/v3/api_partition_v3.go
@@ -42,17 +42,17 @@ var (
 type PartitionV3Api interface {
 
 	/*
-		GetKafkaPartition Get Partition
+			GetKafkaPartition Get Partition
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Return the partition with the given `partition_id`.
+		Return the partition with the given `partition_id`.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param topicName The topic name.
-		 @param partitionId The partition ID.
-		 @return ApiGetKafkaPartitionRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @param partitionId The partition ID.
+			 @return ApiGetKafkaPartitionRequest
 	*/
 	GetKafkaPartition(ctx _context.Context, clusterId string, topicName string, partitionId int32) ApiGetKafkaPartitionRequest
 
@@ -61,16 +61,16 @@ type PartitionV3Api interface {
 	GetKafkaPartitionExecute(r ApiGetKafkaPartitionRequest) (PartitionData, *_nethttp.Response, error)
 
 	/*
-		ListKafkaPartitions List Partitions
+			ListKafkaPartitions List Partitions
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Return the list of partitions that belong to the specified topic.
+		Return the list of partitions that belong to the specified topic.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param topicName The topic name.
-		 @return ApiListKafkaPartitionsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @return ApiListKafkaPartitionsRequest
 	*/
 	ListKafkaPartitions(ctx _context.Context, clusterId string, topicName string) ApiListKafkaPartitionsRequest
 

--- a/kafkarest/v3/api_records_v3.go
+++ b/kafkarest/v3/api_records_v3.go
@@ -47,14 +47,19 @@ type RecordsV3Api interface {
 		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 	Produce records to the given topic, returning delivery reports for each
-	            record produced. This API can be used in streaming mode by setting "Transfer-Encoding:
-	            chunked" header. For as long as the connection is kept open, the server will
-	            keep accepting records. Records are streamed to and from the server as Concatenated
-	            JSON. For each record sent to the server, the server will
-	            asynchronously send back a delivery report, in the same order, each with its own
-	            error_code. An error_code of 200 indicates success. The HTTP status code will be HTTP
-	            200 OK as long as the connection is successfully established. To identify records
-	            that have encountered an error, check the error_code of each delivery report.
+	record produced. This API can be used in streaming mode by setting
+	"Transfer-Encoding: chunked" header. For as long as the connection is
+	kept open, the server will keep accepting records. Records are streamed
+	to and from the server as Concatenated JSON. For each record sent to the
+	server, the server will asynchronously send back a delivery report, in
+	the same order, each with its own error_code. An error_code of 200
+	indicates success. The HTTP status code will be HTTP 200 OK as long as
+	the connection is successfully established. To identify records that
+	have encountered an error, check the error_code of each delivery report.
+
+	This API currently does not support Schema Registry integration. Sending
+	schemas is not supported. Only BINARY, JSON, and STRING formats are
+	supported.
 
 		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 		 @param clusterId The Kafka cluster ID.
@@ -95,19 +100,24 @@ ProduceRecord Produce Records
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Produce records to the given topic, returning delivery reports for each
-            record produced. This API can be used in streaming mode by setting "Transfer-Encoding:
-            chunked" header. For as long as the connection is kept open, the server will
-            keep accepting records. Records are streamed to and from the server as Concatenated
-            JSON. For each record sent to the server, the server will
-            asynchronously send back a delivery report, in the same order, each with its own
-            error_code. An error_code of 200 indicates success. The HTTP status code will be HTTP
-            200 OK as long as the connection is successfully established. To identify records
-            that have encountered an error, check the error_code of each delivery report.
+record produced. This API can be used in streaming mode by setting
+"Transfer-Encoding: chunked" header. For as long as the connection is
+kept open, the server will keep accepting records. Records are streamed
+to and from the server as Concatenated JSON. For each record sent to the
+server, the server will asynchronously send back a delivery report, in
+the same order, each with its own error_code. An error_code of 200
+indicates success. The HTTP status code will be HTTP 200 OK as long as
+the connection is successfully established. To identify records that
+have encountered an error, check the error_code of each delivery report.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @return ApiProduceRecordRequest
+This API currently does not support Schema Registry integration. Sending
+schemas is not supported. Only BINARY, JSON, and STRING formats are
+supported.
+
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@return ApiProduceRecordRequest
 */
 func (a *RecordsV3ApiService) ProduceRecord(ctx _context.Context, clusterId string, topicName string) ApiProduceRecordRequest {
 	return ApiProduceRecordRequest{
@@ -119,7 +129,8 @@ func (a *RecordsV3ApiService) ProduceRecord(ctx _context.Context, clusterId stri
 }
 
 // Execute executes the request
-//  @return ProduceResponse
+//
+//	@return ProduceResponse
 func (a *RecordsV3ApiService) ProduceRecordExecute(r ApiProduceRecordRequest) (ProduceResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost

--- a/kafkarest/v3/api_records_v3.go
+++ b/kafkarest/v3/api_records_v3.go
@@ -42,29 +42,29 @@ var (
 type RecordsV3Api interface {
 
 	/*
-		ProduceRecord Produce Records
+			ProduceRecord Produce Records
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Produce records to the given topic, returning delivery reports for each
-	record produced. This API can be used in streaming mode by setting
-	"Transfer-Encoding: chunked" header. For as long as the connection is
-	kept open, the server will keep accepting records. Records are streamed
-	to and from the server as Concatenated JSON. For each record sent to the
-	server, the server will asynchronously send back a delivery report, in
-	the same order, each with its own error_code. An error_code of 200
-	indicates success. The HTTP status code will be HTTP 200 OK as long as
-	the connection is successfully established. To identify records that
-	have encountered an error, check the error_code of each delivery report.
+		Produce records to the given topic, returning delivery reports for each
+		record produced. This API can be used in streaming mode by setting
+		"Transfer-Encoding: chunked" header. For as long as the connection is
+		kept open, the server will keep accepting records. Records are streamed
+		to and from the server as Concatenated JSON. For each record sent to the
+		server, the server will asynchronously send back a delivery report, in
+		the same order, each with its own error_code. An error_code of 200
+		indicates success. The HTTP status code will be HTTP 200 OK as long as
+		the connection is successfully established. To identify records that
+		have encountered an error, check the error_code of each delivery report.
 
-	This API currently does not support Schema Registry integration. Sending
-	schemas is not supported. Only BINARY, JSON, and STRING formats are
-	supported.
+		This API currently does not support Schema Registry integration. Sending
+		schemas is not supported. Only BINARY, JSON, and STRING formats are
+		supported.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param topicName The topic name.
-		 @return ApiProduceRecordRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @return ApiProduceRecordRequest
 	*/
 	ProduceRecord(ctx _context.Context, clusterId string, topicName string) ApiProduceRecordRequest
 

--- a/kafkarest/v3/api_topic_v3.go
+++ b/kafkarest/v3/api_topic_v3.go
@@ -42,18 +42,18 @@ var (
 type TopicV3Api interface {
 
 	/*
-		CreateKafkaTopic Create Topic
+			CreateKafkaTopic Create Topic
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Create a topic.
-	Also supports a dry-run mode that only validates whether the topic creation would succeed
-	if the ``validate_only`` request property is explicitly specified and set to true. Note that
-	when dry-run mode is being used the response status would be 200 OK instead of 201 Created.
+		Create a topic.
+		Also supports a dry-run mode that only validates whether the topic creation would succeed
+		if the ``validate_only`` request property is explicitly specified and set to true. Note that
+		when dry-run mode is being used the response status would be 200 OK instead of 201 Created.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @return ApiCreateKafkaTopicRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiCreateKafkaTopicRequest
 	*/
 	CreateKafkaTopic(ctx _context.Context, clusterId string) ApiCreateKafkaTopicRequest
 
@@ -62,16 +62,16 @@ type TopicV3Api interface {
 	CreateKafkaTopicExecute(r ApiCreateKafkaTopicRequest) (TopicData, *_nethttp.Response, error)
 
 	/*
-		DeleteKafkaTopic Delete Topic
+			DeleteKafkaTopic Delete Topic
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Delete the topic with the given `topic_name`.
+		Delete the topic with the given `topic_name`.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param topicName The topic name.
-		 @return ApiDeleteKafkaTopicRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @return ApiDeleteKafkaTopicRequest
 	*/
 	DeleteKafkaTopic(ctx _context.Context, clusterId string, topicName string) ApiDeleteKafkaTopicRequest
 
@@ -79,16 +79,16 @@ type TopicV3Api interface {
 	DeleteKafkaTopicExecute(r ApiDeleteKafkaTopicRequest) (*_nethttp.Response, error)
 
 	/*
-		GetKafkaTopic Get Topic
+			GetKafkaTopic Get Topic
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Return the topic with the given `topic_name`.
+		Return the topic with the given `topic_name`.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param topicName The topic name.
-		 @return ApiGetKafkaTopicRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @return ApiGetKafkaTopicRequest
 	*/
 	GetKafkaTopic(ctx _context.Context, clusterId string, topicName string) ApiGetKafkaTopicRequest
 
@@ -97,15 +97,15 @@ type TopicV3Api interface {
 	GetKafkaTopicExecute(r ApiGetKafkaTopicRequest) (TopicData, *_nethttp.Response, error)
 
 	/*
-		ListKafkaTopics List Topics
+			ListKafkaTopics List Topics
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Return the list of topics that belong to the specified Kafka cluster.
+		Return the list of topics that belong to the specified Kafka cluster.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @return ApiListKafkaTopicsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiListKafkaTopicsRequest
 	*/
 	ListKafkaTopics(ctx _context.Context, clusterId string) ApiListKafkaTopicsRequest
 
@@ -114,16 +114,16 @@ type TopicV3Api interface {
 	ListKafkaTopicsExecute(r ApiListKafkaTopicsRequest) (TopicDataList, *_nethttp.Response, error)
 
 	/*
-		UpdatePartitionCountKafkaTopic Update Partition Count
+			UpdatePartitionCountKafkaTopic Update Partition Count
 
-		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Increase the number of partitions for a topic.
+		Increase the number of partitions for a topic.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param clusterId The Kafka cluster ID.
-		 @param topicName The topic name.
-		 @return ApiUpdatePartitionCountKafkaTopicRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @return ApiUpdatePartitionCountKafkaTopicRequest
 	*/
 	UpdatePartitionCountKafkaTopic(ctx _context.Context, clusterId string, topicName string) ApiUpdatePartitionCountKafkaTopicRequest
 

--- a/kafkarest/v3/api_topic_v3.go
+++ b/kafkarest/v3/api_topic_v3.go
@@ -159,12 +159,12 @@ CreateKafkaTopic Create Topic
 
 Create a topic.
 Also supports a dry-run mode that only validates whether the topic creation would succeed
-if the ``validate_only`` request property is explicitly specified and set to true. Note that
+if the “validate_only“ request property is explicitly specified and set to true. Note that
 when dry-run mode is being used the response status would be 200 OK instead of 201 Created.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiCreateKafkaTopicRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiCreateKafkaTopicRequest
 */
 func (a *TopicV3ApiService) CreateKafkaTopic(ctx _context.Context, clusterId string) ApiCreateKafkaTopicRequest {
 	return ApiCreateKafkaTopicRequest{
@@ -175,7 +175,8 @@ func (a *TopicV3ApiService) CreateKafkaTopic(ctx _context.Context, clusterId str
 }
 
 // Execute executes the request
-//  @return TopicData
+//
+//	@return TopicData
 func (a *TopicV3ApiService) CreateKafkaTopicExecute(r ApiCreateKafkaTopicRequest) (TopicData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
@@ -321,10 +322,10 @@ DeleteKafkaTopic Delete Topic
 
 Delete the topic with the given `topic_name`.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @return ApiDeleteKafkaTopicRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@return ApiDeleteKafkaTopicRequest
 */
 func (a *TopicV3ApiService) DeleteKafkaTopic(ctx _context.Context, clusterId string, topicName string) ApiDeleteKafkaTopicRequest {
 	return ApiDeleteKafkaTopicRequest{
@@ -487,10 +488,10 @@ GetKafkaTopic Get Topic
 
 Return the topic with the given `topic_name`.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @return ApiGetKafkaTopicRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@return ApiGetKafkaTopicRequest
 */
 func (a *TopicV3ApiService) GetKafkaTopic(ctx _context.Context, clusterId string, topicName string) ApiGetKafkaTopicRequest {
 	return ApiGetKafkaTopicRequest{
@@ -502,7 +503,8 @@ func (a *TopicV3ApiService) GetKafkaTopic(ctx _context.Context, clusterId string
 }
 
 // Execute executes the request
-//  @return TopicData
+//
+//	@return TopicData
 func (a *TopicV3ApiService) GetKafkaTopicExecute(r ApiGetKafkaTopicRequest) (TopicData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -659,9 +661,9 @@ ListKafkaTopics List Topics
 
 Return the list of topics that belong to the specified Kafka cluster.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiListKafkaTopicsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiListKafkaTopicsRequest
 */
 func (a *TopicV3ApiService) ListKafkaTopics(ctx _context.Context, clusterId string) ApiListKafkaTopicsRequest {
 	return ApiListKafkaTopicsRequest{
@@ -672,7 +674,8 @@ func (a *TopicV3ApiService) ListKafkaTopics(ctx _context.Context, clusterId stri
 }
 
 // Execute executes the request
-//  @return TopicDataList
+//
+//	@return TopicDataList
 func (a *TopicV3ApiService) ListKafkaTopicsExecute(r ApiListKafkaTopicsRequest) (TopicDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -822,10 +825,10 @@ UpdatePartitionCountKafkaTopic Update Partition Count
 
 Increase the number of partitions for a topic.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @return ApiUpdatePartitionCountKafkaTopicRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@return ApiUpdatePartitionCountKafkaTopicRequest
 */
 func (a *TopicV3ApiService) UpdatePartitionCountKafkaTopic(ctx _context.Context, clusterId string, topicName string) ApiUpdatePartitionCountKafkaTopicRequest {
 	return ApiUpdatePartitionCountKafkaTopicRequest{
@@ -837,7 +840,8 @@ func (a *TopicV3ApiService) UpdatePartitionCountKafkaTopic(ctx _context.Context,
 }
 
 // Execute executes the request
-//  @return TopicData
+//
+//	@return TopicData
 func (a *TopicV3ApiService) UpdatePartitionCountKafkaTopicExecute(r ApiUpdatePartitionCountKafkaTopicRequest) (TopicData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch

--- a/kafkarest/v3/docs/ACLV3Api.md
+++ b/kafkarest/v3/docs/ACLV3Api.md
@@ -69,7 +69,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -139,7 +139,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -223,7 +223,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -307,7 +307,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 

--- a/kafkarest/v3/docs/ClusterLinkingV3Api.md
+++ b/kafkarest/v3/docs/ClusterLinkingV3Api.md
@@ -88,7 +88,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -161,7 +161,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -236,7 +236,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -310,7 +310,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -383,7 +383,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -459,7 +459,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -532,7 +532,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -602,7 +602,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -674,7 +674,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -749,7 +749,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -825,7 +825,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -901,7 +901,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -976,7 +976,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -1053,7 +1053,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -1130,7 +1130,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -1207,7 +1207,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -1284,7 +1284,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 

--- a/kafkarest/v3/docs/ClusterV3Api.md
+++ b/kafkarest/v3/docs/ClusterV3Api.md
@@ -66,7 +66,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 

--- a/kafkarest/v3/docs/ConfigsV3Api.md
+++ b/kafkarest/v3/docs/ConfigsV3Api.md
@@ -78,7 +78,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -152,7 +152,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -225,7 +225,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -301,7 +301,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -371,7 +371,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -441,7 +441,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -514,7 +514,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -587,7 +587,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -660,7 +660,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -730,7 +730,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -806,7 +806,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -879,7 +879,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 

--- a/kafkarest/v3/docs/ConsumerGroupV3Api.md
+++ b/kafkarest/v3/docs/ConsumerGroupV3Api.md
@@ -78,7 +78,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -151,7 +151,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -224,7 +224,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -303,7 +303,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -373,7 +373,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -446,7 +446,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -519,7 +519,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 

--- a/kafkarest/v3/docs/MirrorTopicStatus.md
+++ b/kafkarest/v3/docs/MirrorTopicStatus.md
@@ -7,11 +7,17 @@
 
 * `FAILED` (value: `"FAILED"`)
 
+* `LINK_FAILED` (value: `"LINK_FAILED"`)
+
+* `LINK_PAUSED` (value: `"LINK_PAUSED"`)
+
 * `PAUSED` (value: `"PAUSED"`)
 
-* `STOPPED` (value: `"STOPPED"`)
-
 * `PENDING_STOPPED` (value: `"PENDING_STOPPED"`)
+
+* `SOURCE_UNAVAILABLE` (value: `"SOURCE_UNAVAILABLE"`)
+
+* `STOPPED` (value: `"STOPPED"`)
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/kafkarest/v3/docs/PartitionV3Api.md
+++ b/kafkarest/v3/docs/PartitionV3Api.md
@@ -73,7 +73,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -146,7 +146,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 

--- a/kafkarest/v3/docs/RecordsV3Api.md
+++ b/kafkarest/v3/docs/RecordsV3Api.md
@@ -71,7 +71,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 

--- a/kafkarest/v3/docs/TopicV3Api.md
+++ b/kafkarest/v3/docs/TopicV3Api.md
@@ -72,7 +72,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -143,7 +143,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -218,7 +218,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -288,7 +288,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 
@@ -363,7 +363,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api-key](../README.md#api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
+[external-access-token](../README.md#external-access-token), [resource-api-key](../README.md#resource-api-key)
 
 ### HTTP request headers
 

--- a/kafkarest/v3/model_create_link_request_data.go
+++ b/kafkarest/v3/model_create_link_request_data.go
@@ -36,9 +36,7 @@ import (
 
 // CreateLinkRequestData struct for CreateLinkRequestData
 type CreateLinkRequestData struct {
-	// Deprecated
-	SourceClusterId *string `json:"source_cluster_id,omitempty"`
-	// Deprecated
+	SourceClusterId      *string `json:"source_cluster_id,omitempty"`
 	DestinationClusterId *string `json:"destination_cluster_id,omitempty"`
 	// The expected remote cluster ID.
 	RemoteClusterId *string `json:"remote_cluster_id,omitempty"`
@@ -65,7 +63,6 @@ func NewCreateLinkRequestDataWithDefaults() *CreateLinkRequestData {
 }
 
 // GetSourceClusterId returns the SourceClusterId field value if set, zero value otherwise.
-// Deprecated
 func (o *CreateLinkRequestData) GetSourceClusterId() string {
 	if o == nil || o.SourceClusterId == nil {
 		var ret string
@@ -76,7 +73,6 @@ func (o *CreateLinkRequestData) GetSourceClusterId() string {
 
 // GetSourceClusterIdOk returns a tuple with the SourceClusterId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-// Deprecated
 func (o *CreateLinkRequestData) GetSourceClusterIdOk() (*string, bool) {
 	if o == nil || o.SourceClusterId == nil {
 		return nil, false
@@ -94,13 +90,11 @@ func (o *CreateLinkRequestData) HasSourceClusterId() bool {
 }
 
 // SetSourceClusterId gets a reference to the given string and assigns it to the SourceClusterId field.
-// Deprecated
 func (o *CreateLinkRequestData) SetSourceClusterId(v string) {
 	o.SourceClusterId = &v
 }
 
 // GetDestinationClusterId returns the DestinationClusterId field value if set, zero value otherwise.
-// Deprecated
 func (o *CreateLinkRequestData) GetDestinationClusterId() string {
 	if o == nil || o.DestinationClusterId == nil {
 		var ret string
@@ -111,7 +105,6 @@ func (o *CreateLinkRequestData) GetDestinationClusterId() string {
 
 // GetDestinationClusterIdOk returns a tuple with the DestinationClusterId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-// Deprecated
 func (o *CreateLinkRequestData) GetDestinationClusterIdOk() (*string, bool) {
 	if o == nil || o.DestinationClusterId == nil {
 		return nil, false
@@ -129,7 +122,6 @@ func (o *CreateLinkRequestData) HasDestinationClusterId() bool {
 }
 
 // SetDestinationClusterId gets a reference to the given string and assigns it to the DestinationClusterId field.
-// Deprecated
 func (o *CreateLinkRequestData) SetDestinationClusterId(v string) {
 	o.DestinationClusterId = &v
 }

--- a/kafkarest/v3/model_list_links_response_data.go
+++ b/kafkarest/v3/model_list_links_response_data.go
@@ -36,14 +36,12 @@ import (
 
 // ListLinksResponseData struct for ListLinksResponseData
 type ListLinksResponseData struct {
-	Kind     string           `json:"kind,omitempty"`
-	Metadata ResourceMetadata `json:"metadata,omitempty"`
-	// Deprecated
-	SourceClusterId NullableString `json:"source_cluster_id,omitempty"`
-	// Deprecated
-	DestinationClusterId NullableString `json:"destination_cluster_id,omitempty"`
-	RemoteClusterId      NullableString `json:"remote_cluster_id,omitempty"`
-	LinkName             string         `json:"link_name,omitempty"`
+	Kind                 string           `json:"kind,omitempty"`
+	Metadata             ResourceMetadata `json:"metadata,omitempty"`
+	SourceClusterId      NullableString   `json:"source_cluster_id,omitempty"`
+	DestinationClusterId NullableString   `json:"destination_cluster_id,omitempty"`
+	RemoteClusterId      NullableString   `json:"remote_cluster_id,omitempty"`
+	LinkName             string           `json:"link_name,omitempty"`
 	// Deprecated
 	LinkId           *string        `json:"link_id,omitempty"`
 	ClusterLinkId    string         `json:"cluster_link_id,omitempty"`
@@ -124,7 +122,6 @@ func (o *ListLinksResponseData) SetMetadata(v ResourceMetadata) {
 }
 
 // GetSourceClusterId returns the SourceClusterId field value if set, zero value otherwise (both if not set or set to explicit null).
-// Deprecated
 func (o *ListLinksResponseData) GetSourceClusterId() string {
 	if o == nil || o.SourceClusterId.Get() == nil {
 		var ret string
@@ -136,7 +133,6 @@ func (o *ListLinksResponseData) GetSourceClusterId() string {
 // GetSourceClusterIdOk returns a tuple with the SourceClusterId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-// Deprecated
 func (o *ListLinksResponseData) GetSourceClusterIdOk() (*string, bool) {
 	if o == nil {
 		return nil, false
@@ -154,7 +150,6 @@ func (o *ListLinksResponseData) HasSourceClusterId() bool {
 }
 
 // SetSourceClusterId gets a reference to the given NullableString and assigns it to the SourceClusterId field.
-// Deprecated
 func (o *ListLinksResponseData) SetSourceClusterId(v string) {
 	o.SourceClusterId.Set(&v)
 }
@@ -170,7 +165,6 @@ func (o *ListLinksResponseData) UnsetSourceClusterId() {
 }
 
 // GetDestinationClusterId returns the DestinationClusterId field value if set, zero value otherwise (both if not set or set to explicit null).
-// Deprecated
 func (o *ListLinksResponseData) GetDestinationClusterId() string {
 	if o == nil || o.DestinationClusterId.Get() == nil {
 		var ret string
@@ -182,7 +176,6 @@ func (o *ListLinksResponseData) GetDestinationClusterId() string {
 // GetDestinationClusterIdOk returns a tuple with the DestinationClusterId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-// Deprecated
 func (o *ListLinksResponseData) GetDestinationClusterIdOk() (*string, bool) {
 	if o == nil {
 		return nil, false
@@ -200,7 +193,6 @@ func (o *ListLinksResponseData) HasDestinationClusterId() bool {
 }
 
 // SetDestinationClusterId gets a reference to the given NullableString and assigns it to the DestinationClusterId field.
-// Deprecated
 func (o *ListLinksResponseData) SetDestinationClusterId(v string) {
 	o.DestinationClusterId.Set(&v)
 }

--- a/kafkarest/v3/model_list_links_response_data_all_of.go
+++ b/kafkarest/v3/model_list_links_response_data_all_of.go
@@ -36,9 +36,7 @@ import (
 
 // ListLinksResponseDataAllOf struct for ListLinksResponseDataAllOf
 type ListLinksResponseDataAllOf struct {
-	// Deprecated
-	SourceClusterId NullableString `json:"source_cluster_id,omitempty"`
-	// Deprecated
+	SourceClusterId      NullableString `json:"source_cluster_id,omitempty"`
 	DestinationClusterId NullableString `json:"destination_cluster_id,omitempty"`
 	RemoteClusterId      NullableString `json:"remote_cluster_id,omitempty"`
 	LinkName             string         `json:"link_name,omitempty"`
@@ -72,7 +70,6 @@ func NewListLinksResponseDataAllOfWithDefaults() *ListLinksResponseDataAllOf {
 }
 
 // GetSourceClusterId returns the SourceClusterId field value if set, zero value otherwise (both if not set or set to explicit null).
-// Deprecated
 func (o *ListLinksResponseDataAllOf) GetSourceClusterId() string {
 	if o == nil || o.SourceClusterId.Get() == nil {
 		var ret string
@@ -84,7 +81,6 @@ func (o *ListLinksResponseDataAllOf) GetSourceClusterId() string {
 // GetSourceClusterIdOk returns a tuple with the SourceClusterId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-// Deprecated
 func (o *ListLinksResponseDataAllOf) GetSourceClusterIdOk() (*string, bool) {
 	if o == nil {
 		return nil, false
@@ -102,7 +98,6 @@ func (o *ListLinksResponseDataAllOf) HasSourceClusterId() bool {
 }
 
 // SetSourceClusterId gets a reference to the given NullableString and assigns it to the SourceClusterId field.
-// Deprecated
 func (o *ListLinksResponseDataAllOf) SetSourceClusterId(v string) {
 	o.SourceClusterId.Set(&v)
 }
@@ -118,7 +113,6 @@ func (o *ListLinksResponseDataAllOf) UnsetSourceClusterId() {
 }
 
 // GetDestinationClusterId returns the DestinationClusterId field value if set, zero value otherwise (both if not set or set to explicit null).
-// Deprecated
 func (o *ListLinksResponseDataAllOf) GetDestinationClusterId() string {
 	if o == nil || o.DestinationClusterId.Get() == nil {
 		var ret string
@@ -130,7 +124,6 @@ func (o *ListLinksResponseDataAllOf) GetDestinationClusterId() string {
 // GetDestinationClusterIdOk returns a tuple with the DestinationClusterId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-// Deprecated
 func (o *ListLinksResponseDataAllOf) GetDestinationClusterIdOk() (*string, bool) {
 	if o == nil {
 		return nil, false
@@ -148,7 +141,6 @@ func (o *ListLinksResponseDataAllOf) HasDestinationClusterId() bool {
 }
 
 // SetDestinationClusterId gets a reference to the given NullableString and assigns it to the DestinationClusterId field.
-// Deprecated
 func (o *ListLinksResponseDataAllOf) SetDestinationClusterId(v string) {
 	o.DestinationClusterId.Set(&v)
 }

--- a/kafkarest/v3/model_mirror_topic_status.go
+++ b/kafkarest/v3/model_mirror_topic_status.go
@@ -36,19 +36,25 @@ type MirrorTopicStatus string
 
 // List of MirrorTopicStatus
 const (
-	ACTIVE          MirrorTopicStatus = "ACTIVE"
-	FAILED          MirrorTopicStatus = "FAILED"
-	PAUSED          MirrorTopicStatus = "PAUSED"
-	STOPPED         MirrorTopicStatus = "STOPPED"
-	PENDING_STOPPED MirrorTopicStatus = "PENDING_STOPPED"
+	ACTIVE             MirrorTopicStatus = "ACTIVE"
+	FAILED             MirrorTopicStatus = "FAILED"
+	LINK_FAILED        MirrorTopicStatus = "LINK_FAILED"
+	LINK_PAUSED        MirrorTopicStatus = "LINK_PAUSED"
+	PAUSED             MirrorTopicStatus = "PAUSED"
+	PENDING_STOPPED    MirrorTopicStatus = "PENDING_STOPPED"
+	SOURCE_UNAVAILABLE MirrorTopicStatus = "SOURCE_UNAVAILABLE"
+	STOPPED            MirrorTopicStatus = "STOPPED"
 )
 
 var allowedMirrorTopicStatusEnumValues = []MirrorTopicStatus{
 	"ACTIVE",
 	"FAILED",
+	"LINK_FAILED",
+	"LINK_PAUSED",
 	"PAUSED",
-	"STOPPED",
 	"PENDING_STOPPED",
+	"SOURCE_UNAVAILABLE",
+	"STOPPED",
 }
 
 func (v *MirrorTopicStatus) UnmarshalJSON(src []byte) error {


### PR DESCRIPTION
Output of `go vet -v`:
```
go vet -v
internal/unsafeheader
internal/goarch
internal/goos
unicode/utf8
internal/coverage/rtcov
internal/itoa
runtime/internal/math
internal/race
encoding
internal/godebugs
runtime/internal/sys
unicode
unicode/utf16
crypto/internal/alias
crypto/subtle
runtime/internal/atomic
crypto/internal/boring/sig
math/bits
vendor/golang.org/x/crypto/cryptobyte/asn1
internal/goexperiment
sync/atomic
internal/nettrace
internal/cpu
log/internal
vendor/golang.org/x/crypto/internal/alias
container/list
internal/bytealg
internal/abi
math
runtime
internal/reflectlite
sync
errors
internal/testlog
internal/bisect
internal/singleflight
sort
internal/oserror
path
internal/safefilepath
internal/godebug
io
vendor/golang.org/x/net/dns/dnsmessage
internal/intern
strconv
hash
bytes
crypto/internal/randutil
math/rand
strings
crypto/internal/nistec/fiat
crypto
crypto/rc4
net/http/internal/ascii
net/netip
vendor/golang.org/x/text/transform
bufio
hash/crc32
reflect
regexp/syntax
syscall
internal/fmtsort
encoding/binary
regexp
internal/syscall/execenv
encoding/base64
time
internal/syscall/unix
crypto/md5
vendor/golang.org/x/crypto/internal/poly1305
crypto/cipher
crypto/internal/edwards25519/field
context
encoding/pem
crypto/x509/internal/macos
io/fs
crypto/internal/boring
vendor/golang.org/x/crypto/chacha20
internal/poll
crypto/internal/edwards25519
crypto/des
embed
crypto/hmac
crypto/sha256
crypto/sha1
crypto/sha512
crypto/aes
vendor/golang.org/x/crypto/hkdf
crypto/internal/nistec
os
crypto/ecdh
io/ioutil
path/filepath
fmt
vendor/golang.org/x/sys/cpu
vendor/golang.org/x/net/route
encoding/hex
net/url
log
encoding/xml
mime
vendor/golang.org/x/net/http2/hpack
compress/flate
mime/quotedprintable
encoding/json
vendor/golang.org/x/crypto/chacha20poly1305
net/http/internal
vendor/golang.org/x/text/unicode/norm
math/big
crypto/internal/boring/bbig
compress/gzip
vendor/golang.org/x/text/unicode/bidi
crypto/internal/bigmod
crypto/dsa
crypto/rand
crypto/elliptic
encoding/asn1
vendor/golang.org/x/text/secure/bidirule
crypto/ed25519
crypto/x509/pkix
crypto/rsa
vendor/golang.org/x/crypto/cryptobyte
crypto/ecdsa
vendor/golang.org/x/net/idna
runtime/cgo
net
vendor/golang.org/x/net/http/httpproxy
net/textproto
vendor/golang.org/x/net/http/httpguts
crypto/x509
mime/multipart
crypto/tls
net/http/httptrace
net/http
golang.org/x/net/context/ctxhttp
net/http/httputil
golang.org/x/oauth2/internal
golang.org/x/oauth2
github.com/confluentinc/ccloud-sdk-go-v2/kafkarest/v3
```