### PR TITLE
chore: regenerate flink-gateway v1 SDK

### DIFF
--- a/flink-gateway/v1/api/openapi.yaml
+++ b/flink-gateway/v1/api/openapi.yaml
@@ -15,7 +15,7 @@ servers:
   url: https://flink.region.provider.confluent.cloud
 tags:
 - description: |-
-    [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+    [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
     `Statement` represents a core resource used to model SQL statements for execution.
     A statement generalizes DDL, DML, DQL, etc., but doesn’t attempt to handle session
@@ -25,7 +25,7 @@ tags:
     <SchemaDefinition schemaRef="#/components/schemas/sql.v1.Statement" />
   name: Statements (sql/v1)
 - description: |-
-    [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+    [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
     `StatementResult` represents a result of a `Statement` resource.
     The API allows you to read your statement's results.
@@ -33,7 +33,7 @@ tags:
     <SchemaDefinition schemaRef="#/components/schemas/sql.v1.StatementResult" />
   name: Statement Results (sql/v1)
 - description: |-
-    [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+    [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
     `StatementException` represents an exception of a `Statement` resource.
     The API allows you to read your statement's exceptions.
@@ -44,7 +44,8 @@ paths:
   /sql/v1/organizations/{organization_id}/environments/{environment_id}/statements/{name}/results:
     get:
       description: |-
-        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
         Read Statement Result.
       operationId: getSqlv1StatementResult
       parameters:
@@ -327,7 +328,8 @@ paths:
   /sql/v1/organizations/{organization_id}/environments/{environment_id}/statements:
     get:
       description: |-
-        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
         Retrieve a sorted, filtered, paginated list of all statements.
       operationId: listSqlv1Statements
       parameters:
@@ -606,7 +608,8 @@ paths:
           IRestResponse response = client.Execute(request);
     post:
       description: |-
-        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
         Make a request to create a statement.
       operationId: createSqlv1Statement
       parameters:
@@ -637,7 +640,6 @@ paths:
                   spec:
                     required:
                     - compute_pool_id
-                    - principal
                     - statement
                     type: object
                 required:
@@ -849,13 +851,13 @@ paths:
             --url 'https://flink.region.provider.confluent.cloud/sql/v1/organizations/{organization_id}/environments/{environment_id}/statements' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
             --header 'content-type: application/json' \
-            --data '{"name":"sql123","organization_id":"7c60d51f-b44e-4682-87d6-449835ea4de6","environment_id":"string","spec":{"statement":"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;","properties":{"key1":"value1","key2":"value2"},"compute_pool_id":"fcp-00000","principal":"sa-abc123","stopped":true}}'
+            --data '{"name":"sql123","organization_id":"7c60d51f-b44e-4682-87d6-449835ea4de6","environment_id":"string","spec":{"statement":"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;","properties":{"sql.current-catalog":"my_environment","sql.current-database":"my_kafka_cluster"},"compute_pool_id":"fcp-00000","principal":"sa-abc123","stopped":false}}'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           MediaType mediaType = MediaType.parse("application/json");
-          RequestBody body = RequestBody.create(mediaType, "{\"name\":\"sql123\",\"organization_id\":\"7c60d51f-b44e-4682-87d6-449835ea4de6\",\"environment_id\":\"string\",\"spec\":{\"statement\":\"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;\",\"properties\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"compute_pool_id\":\"fcp-00000\",\"principal\":\"sa-abc123\",\"stopped\":true}}");
+          RequestBody body = RequestBody.create(mediaType, "{\"name\":\"sql123\",\"organization_id\":\"7c60d51f-b44e-4682-87d6-449835ea4de6\",\"environment_id\":\"string\",\"spec\":{\"statement\":\"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;\",\"properties\":{\"sql.current-catalog\":\"my_environment\",\"sql.current-database\":\"my_kafka_cluster\"},\"compute_pool_id\":\"fcp-00000\",\"principal\":\"sa-abc123\",\"stopped\":false}}");
           Request request = new Request.Builder()
             .url("https://flink.region.provider.confluent.cloud/sql/v1/organizations/{organization_id}/environments/{environment_id}/statements")
             .post(body)
@@ -870,13 +872,14 @@ paths:
           \n\n\tpayload := strings.NewReader(\"{\\\"name\\\":\\\"sql123\\\",\\\"organization_id\\\
           \":\\\"7c60d51f-b44e-4682-87d6-449835ea4de6\\\",\\\"environment_id\\\":\\\
           \"string\\\",\\\"spec\\\":{\\\"statement\\\":\\\"SELECT * FROM TABLE WHERE\
-          \ VALUE1 = VALUE2;\\\",\\\"properties\\\":{\\\"key1\\\":\\\"value1\\\",\\\
-          \"key2\\\":\\\"value2\\\"},\\\"compute_pool_id\\\":\\\"fcp-00000\\\",\\\"\
-          principal\\\":\\\"sa-abc123\\\",\\\"stopped\\\":true}}\")\n\n\treq, _ :=\
-          \ http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"content-type\"\
-          , \"application/json\")\n\treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\"\
-          )\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\
-          \tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
+          \ VALUE1 = VALUE2;\\\",\\\"properties\\\":{\\\"sql.current-catalog\\\":\\\
+          \"my_environment\\\",\\\"sql.current-database\\\":\\\"my_kafka_cluster\\\
+          \"},\\\"compute_pool_id\\\":\\\"fcp-00000\\\",\\\"principal\\\":\\\"sa-abc123\\\
+          \",\\\"stopped\\\":false}}\")\n\n\treq, _ := http.NewRequest(\"POST\", url,\
+          \ payload)\n\n\treq.Header.Add(\"content-type\", \"application/json\")\n\
+          \treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\t\
+          res, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody,\
+          \ _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
           \n}"
       - lang: Python
         source: |-
@@ -884,7 +887,7 @@ paths:
 
           conn = http.client.HTTPSConnection("flink.region.provider.confluent.cloud")
 
-          payload = "{\"name\":\"sql123\",\"organization_id\":\"7c60d51f-b44e-4682-87d6-449835ea4de6\",\"environment_id\":\"string\",\"spec\":{\"statement\":\"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;\",\"properties\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"compute_pool_id\":\"fcp-00000\",\"principal\":\"sa-abc123\",\"stopped\":true}}"
+          payload = "{\"name\":\"sql123\",\"organization_id\":\"7c60d51f-b44e-4682-87d6-449835ea4de6\",\"environment_id\":\"string\",\"spec\":{\"statement\":\"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;\",\"properties\":{\"sql.current-catalog\":\"my_environment\",\"sql.current-database\":\"my_kafka_cluster\"},\"compute_pool_id\":\"fcp-00000\",\"principal\":\"sa-abc123\",\"stopped\":false}}"
 
           headers = {
               'content-type': "application/json",
@@ -931,10 +934,13 @@ paths:
             environment_id: 'string',
             spec: {
               statement: 'SELECT * FROM TABLE WHERE VALUE1 = VALUE2;',
-              properties: {key1: 'value1', key2: 'value2'},
+              properties: {
+                'sql.current-catalog': 'my_environment',
+                'sql.current-database': 'my_kafka_cluster'
+              },
               compute_pool_id: 'fcp-00000',
               principal: 'sa-abc123',
-              stopped: true
+              stopped: false
             }
           }));
           req.end();
@@ -950,7 +956,7 @@ paths:
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"name\":\"sql123\",\"organization_id\":\"7c60d51f-b44e-4682-87d6-449835ea4de6\",\"environment_id\":\"string\",\"spec\":{\"statement\":\"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;\",\"properties\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"compute_pool_id\":\"fcp-00000\",\"principal\":\"sa-abc123\",\"stopped\":true}}");
+          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"name\":\"sql123\",\"organization_id\":\"7c60d51f-b44e-4682-87d6-449835ea4de6\",\"environment_id\":\"string\",\"spec\":{\"statement\":\"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;\",\"properties\":{\"sql.current-catalog\":\"my_environment\",\"sql.current-database\":\"my_kafka_cluster\"},\"compute_pool_id\":\"fcp-00000\",\"principal\":\"sa-abc123\",\"stopped\":false}}");
 
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
@@ -959,13 +965,14 @@ paths:
           var request = new RestRequest(Method.POST);
           request.AddHeader("content-type", "application/json");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("application/json", "{\"name\":\"sql123\",\"organization_id\":\"7c60d51f-b44e-4682-87d6-449835ea4de6\",\"environment_id\":\"string\",\"spec\":{\"statement\":\"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;\",\"properties\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"compute_pool_id\":\"fcp-00000\",\"principal\":\"sa-abc123\",\"stopped\":true}}", ParameterType.RequestBody);
+          request.AddParameter("application/json", "{\"name\":\"sql123\",\"organization_id\":\"7c60d51f-b44e-4682-87d6-449835ea4de6\",\"environment_id\":\"string\",\"spec\":{\"statement\":\"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;\",\"properties\":{\"sql.current-catalog\":\"my_environment\",\"sql.current-database\":\"my_kafka_cluster\"},\"compute_pool_id\":\"fcp-00000\",\"principal\":\"sa-abc123\",\"stopped\":false}}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
     x-request-access-name: SQL API v1
   /sql/v1/organizations/{organization_id}/environments/{environment_id}/statements/{statement_name}:
     delete:
       description: |-
-        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
         Make a request to delete a statement.
       operationId: deleteSqlv1Statement
       parameters:
@@ -1219,7 +1226,8 @@ paths:
           IRestResponse response = client.Execute(request);
     get:
       description: |-
-        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
         Make a request to read a statement.
       operationId: getSqlv1Statement
       parameters:
@@ -1492,8 +1500,11 @@ paths:
           IRestResponse response = client.Execute(request);
     put:
       description: |-
-        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
         Make a request to update a statement.
+        The request will fail with a 409 Conflict error if the Statement has changed since it was fetched.
+        In this case, do a GET, reapply the modifications, and try the update again.
       operationId: updateSqlv1Statement
       parameters:
       - description: The unique identifier for the organization.
@@ -1687,13 +1698,13 @@ paths:
             --url 'https://flink.region.provider.confluent.cloud/sql/v1/organizations/{organization_id}/environments/{environment_id}/statements/{statement_name}' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
             --header 'content-type: application/json' \
-            --data '{"name":"sql123","organization_id":"7c60d51f-b44e-4682-87d6-449835ea4de6","environment_id":"string","spec":{"statement":"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;","properties":{"key1":"value1","key2":"value2"},"compute_pool_id":"fcp-00000","principal":"sa-abc123","stopped":true},"metadata":{}}'
+            --data '{"name":"sql123","organization_id":"7c60d51f-b44e-4682-87d6-449835ea4de6","environment_id":"string","spec":{"statement":"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;","properties":{"sql.current-catalog":"my_environment","sql.current-database":"my_kafka_cluster"},"compute_pool_id":"fcp-00000","principal":"sa-abc123","stopped":false},"metadata":{}}'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           MediaType mediaType = MediaType.parse("application/json");
-          RequestBody body = RequestBody.create(mediaType, "{\"name\":\"sql123\",\"organization_id\":\"7c60d51f-b44e-4682-87d6-449835ea4de6\",\"environment_id\":\"string\",\"spec\":{\"statement\":\"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;\",\"properties\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"compute_pool_id\":\"fcp-00000\",\"principal\":\"sa-abc123\",\"stopped\":true},\"metadata\":{}}");
+          RequestBody body = RequestBody.create(mediaType, "{\"name\":\"sql123\",\"organization_id\":\"7c60d51f-b44e-4682-87d6-449835ea4de6\",\"environment_id\":\"string\",\"spec\":{\"statement\":\"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;\",\"properties\":{\"sql.current-catalog\":\"my_environment\",\"sql.current-database\":\"my_kafka_cluster\"},\"compute_pool_id\":\"fcp-00000\",\"principal\":\"sa-abc123\",\"stopped\":false},\"metadata\":{}}");
           Request request = new Request.Builder()
             .url("https://flink.region.provider.confluent.cloud/sql/v1/organizations/{organization_id}/environments/{environment_id}/statements/{statement_name}")
             .put(body)
@@ -1708,21 +1719,22 @@ paths:
           \n\n\tpayload := strings.NewReader(\"{\\\"name\\\":\\\"sql123\\\",\\\"organization_id\\\
           \":\\\"7c60d51f-b44e-4682-87d6-449835ea4de6\\\",\\\"environment_id\\\":\\\
           \"string\\\",\\\"spec\\\":{\\\"statement\\\":\\\"SELECT * FROM TABLE WHERE\
-          \ VALUE1 = VALUE2;\\\",\\\"properties\\\":{\\\"key1\\\":\\\"value1\\\",\\\
-          \"key2\\\":\\\"value2\\\"},\\\"compute_pool_id\\\":\\\"fcp-00000\\\",\\\"\
-          principal\\\":\\\"sa-abc123\\\",\\\"stopped\\\":true},\\\"metadata\\\":{}}\"\
-          )\n\n\treq, _ := http.NewRequest(\"PUT\", url, payload)\n\n\treq.Header.Add(\"\
-          content-type\", \"application/json\")\n\treq.Header.Add(\"Authorization\"\
-          , \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
-          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
-          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          \ VALUE1 = VALUE2;\\\",\\\"properties\\\":{\\\"sql.current-catalog\\\":\\\
+          \"my_environment\\\",\\\"sql.current-database\\\":\\\"my_kafka_cluster\\\
+          \"},\\\"compute_pool_id\\\":\\\"fcp-00000\\\",\\\"principal\\\":\\\"sa-abc123\\\
+          \",\\\"stopped\\\":false},\\\"metadata\\\":{}}\")\n\n\treq, _ := http.NewRequest(\"\
+          PUT\", url, payload)\n\n\treq.Header.Add(\"content-type\", \"application/json\"\
+          )\n\treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\
+          \tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody,\
+          \ _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
+          \n}"
       - lang: Python
         source: |-
           import http.client
 
           conn = http.client.HTTPSConnection("flink.region.provider.confluent.cloud")
 
-          payload = "{\"name\":\"sql123\",\"organization_id\":\"7c60d51f-b44e-4682-87d6-449835ea4de6\",\"environment_id\":\"string\",\"spec\":{\"statement\":\"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;\",\"properties\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"compute_pool_id\":\"fcp-00000\",\"principal\":\"sa-abc123\",\"stopped\":true},\"metadata\":{}}"
+          payload = "{\"name\":\"sql123\",\"organization_id\":\"7c60d51f-b44e-4682-87d6-449835ea4de6\",\"environment_id\":\"string\",\"spec\":{\"statement\":\"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;\",\"properties\":{\"sql.current-catalog\":\"my_environment\",\"sql.current-database\":\"my_kafka_cluster\"},\"compute_pool_id\":\"fcp-00000\",\"principal\":\"sa-abc123\",\"stopped\":false},\"metadata\":{}}"
 
           headers = {
               'content-type': "application/json",
@@ -1769,10 +1781,13 @@ paths:
             environment_id: 'string',
             spec: {
               statement: 'SELECT * FROM TABLE WHERE VALUE1 = VALUE2;',
-              properties: {key1: 'value1', key2: 'value2'},
+              properties: {
+                'sql.current-catalog': 'my_environment',
+                'sql.current-database': 'my_kafka_cluster'
+              },
               compute_pool_id: 'fcp-00000',
               principal: 'sa-abc123',
-              stopped: true
+              stopped: false
             },
             metadata: {}
           }));
@@ -1789,7 +1804,7 @@ paths:
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"name\":\"sql123\",\"organization_id\":\"7c60d51f-b44e-4682-87d6-449835ea4de6\",\"environment_id\":\"string\",\"spec\":{\"statement\":\"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;\",\"properties\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"compute_pool_id\":\"fcp-00000\",\"principal\":\"sa-abc123\",\"stopped\":true},\"metadata\":{}}");
+          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"name\":\"sql123\",\"organization_id\":\"7c60d51f-b44e-4682-87d6-449835ea4de6\",\"environment_id\":\"string\",\"spec\":{\"statement\":\"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;\",\"properties\":{\"sql.current-catalog\":\"my_environment\",\"sql.current-database\":\"my_kafka_cluster\"},\"compute_pool_id\":\"fcp-00000\",\"principal\":\"sa-abc123\",\"stopped\":false},\"metadata\":{}}");
 
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
@@ -1798,13 +1813,14 @@ paths:
           var request = new RestRequest(Method.PUT);
           request.AddHeader("content-type", "application/json");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("application/json", "{\"name\":\"sql123\",\"organization_id\":\"7c60d51f-b44e-4682-87d6-449835ea4de6\",\"environment_id\":\"string\",\"spec\":{\"statement\":\"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;\",\"properties\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"compute_pool_id\":\"fcp-00000\",\"principal\":\"sa-abc123\",\"stopped\":true},\"metadata\":{}}", ParameterType.RequestBody);
+          request.AddParameter("application/json", "{\"name\":\"sql123\",\"organization_id\":\"7c60d51f-b44e-4682-87d6-449835ea4de6\",\"environment_id\":\"string\",\"spec\":{\"statement\":\"SELECT * FROM TABLE WHERE VALUE1 = VALUE2;\",\"properties\":{\"sql.current-catalog\":\"my_environment\",\"sql.current-database\":\"my_kafka_cluster\"},\"compute_pool_id\":\"fcp-00000\",\"principal\":\"sa-abc123\",\"stopped\":false},\"metadata\":{}}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
     x-request-access-name: SQL API v1
   /sql/v1/organizations/{organization_id}/environments/{environment_id}/statements/{statement_name}/exceptions:
     get:
       description: |-
-        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
         Retrieve a list of the 10 most recent statement exceptions.
       operationId: getSqlv1StatementExceptions
       parameters:
@@ -2284,11 +2300,21 @@ components:
         metadata:
           allOf:
           - $ref: '#/components/schemas/ObjectMeta'
+          - properties:
+              self:
+                example: https://flink.us-west1.aws.confluent.cloud/sql/v1/environments/env-123/statements/my-statement
+              uid:
+                example: 12345678-1234-1234-1234-123456789012
+              resource_version:
+                example: a23av
+              resource_name:
+                example: ""
         name:
           description: The user provided name of the resource, unique within this
             environment.
           example: sql123
-          maxLength: 255
+          maxLength: 100
+          pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
           type: string
           x-immutable: true
         organization_id:
@@ -2311,12 +2337,19 @@ components:
         phase:
           description: |
             The lifecycle phase of the submitted SQL statement:
+
             PENDING: SQL statement is pending execution;
+
             RUNNING: SQL statement execution is in progress;
+
             COMPLETED: SQL statement is completed;
+
             DELETING: SQL statement deletion is in progress;
+
             FAILING: SQL statement is failing;
+
             FAILED: SQL statement execution has failed;
+
             STOPPED: SQL statement execution has successfully been stopped;
           example: RUNNING
           readOnly: true
@@ -2332,12 +2365,25 @@ components:
         scaling_status:
           $ref: '#/components/schemas/sql.v1.ScalingStatus'
         detail:
-          description: Description of a SQL statement phase.
-          example: 'COMPLETED: SQL statement is completed'
+          description: Details about the execution status of this statement.
+          example: Statement is running successfully
           readOnly: true
           type: string
         traits:
           $ref: '#/components/schemas/sql.v1.StatementTraits'
+        network_kind:
+          description: |
+            The networking type used by the submitted SQL statement:
+
+            PUBLIC: SQL statement is using public networking;
+
+            PRIVATE: SQL statement is using private networking;
+          example: PUBLIC
+          readOnly: true
+          type: string
+          x-extensible-enum:
+          - PUBLIC
+          - PRIVATE
       readOnly: true
       required:
       - phase
@@ -2408,6 +2454,17 @@ components:
         metadata:
           allOf:
           - $ref: '#/components/schemas/ListMeta'
+          - properties:
+              self:
+                example: https://flink.us-west1.aws.confluent.cloud/sql/v1/environments/env-123/statements
+              first:
+                example: https://flink.us-west1.aws.confluent.cloud/sql/v1/environments/env-abc123/statements
+              last:
+                example: ""
+              prev:
+                example: ""
+              next:
+                example: https://flink.us-west1.aws.confluent.cloud/sql/v1/environments/env-abc123/statements?page_token=UvmDWOB1iwfAIBPj6EYb
         data:
           description: A data property that contains an array of resource items. Each
             entry in the array is a separate resource.
@@ -2520,8 +2577,8 @@ components:
             type: string
           description: A map (key-value pairs) of statement properties.
           example:
-            key1: value1
-            key2: value2
+            sql.current-catalog: my_environment
+            sql.current-database: my_kafka_cluster
           maximum: 8192
           type: object
         compute_pool_id:
@@ -2537,6 +2594,7 @@ components:
           x-immutable: true
         stopped:
           description: Indicates whether the statement should be stopped.
+          example: false
           type: boolean
       type: object
       x-enable-listmeta: true
@@ -2616,8 +2674,11 @@ components:
         scaling_state:
           description: |
             OK: The statement runs at the right scale.
+
             PENDING_SCALE_DOWN: The statement requires less resources, and will be scaled down in the near future.
+
             PENDING_SCALE_UP: The statement requires more resources, and will be scaled up in the near future.
+
             POOL_EXHAUSTED: The statement requires more resources, but not enough resources are available.
           example: OK
           readOnly: true

--- a/flink-gateway/v1/api_statement_exceptions_sql_v1.go
+++ b/flink-gateway/v1/api_statement_exceptions_sql_v1.go
@@ -42,16 +42,17 @@ var (
 type StatementExceptionsSqlV1Api interface {
 
 	/*
-		GetSqlv1StatementExceptions List of Statement Exceptions
+			GetSqlv1StatementExceptions List of Statement Exceptions
 
-		[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
-	Retrieve a list of the 10 most recent statement exceptions.
+			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param organizationId The unique identifier for the organization.
-		 @param environmentId The unique identifier for the environment.
-		 @param statementName The unique identifier for the statement.
-		 @return ApiGetSqlv1StatementExceptionsRequest
+		Retrieve a list of the 10 most recent statement exceptions.
+
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param organizationId The unique identifier for the organization.
+			 @param environmentId The unique identifier for the environment.
+			 @param statementName The unique identifier for the statement.
+			 @return ApiGetSqlv1StatementExceptionsRequest
 	*/
 	GetSqlv1StatementExceptions(ctx _context.Context, organizationId string, environmentId string, statementName string) ApiGetSqlv1StatementExceptionsRequest
 
@@ -78,7 +79,8 @@ func (r ApiGetSqlv1StatementExceptionsRequest) Execute() (SqlV1StatementExceptio
 /*
 GetSqlv1StatementExceptions List of Statement Exceptions
 
-[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
 Retrieve a list of the 10 most recent statement exceptions.
 
 	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().

--- a/flink-gateway/v1/api_statement_results_sql_v1.go
+++ b/flink-gateway/v1/api_statement_results_sql_v1.go
@@ -42,16 +42,17 @@ var (
 type StatementResultsSqlV1Api interface {
 
 	/*
-		GetSqlv1StatementResult Read Statement Result
+			GetSqlv1StatementResult Read Statement Result
 
-		[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
-	Read Statement Result.
+			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param organizationId The unique identifier for the organization.
-		 @param environmentId The unique identifier for the environment.
-		 @param name The unique identifier for the statement.
-		 @return ApiGetSqlv1StatementResultRequest
+		Read Statement Result.
+
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param organizationId The unique identifier for the organization.
+			 @param environmentId The unique identifier for the environment.
+			 @param name The unique identifier for the statement.
+			 @return ApiGetSqlv1StatementResultRequest
 	*/
 	GetSqlv1StatementResult(ctx _context.Context, organizationId string, environmentId string, name string) ApiGetSqlv1StatementResultRequest
 
@@ -85,7 +86,8 @@ func (r ApiGetSqlv1StatementResultRequest) Execute() (SqlV1StatementResult, *_ne
 /*
 GetSqlv1StatementResult Read Statement Result
 
-[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
 Read Statement Result.
 
 	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().

--- a/flink-gateway/v1/api_statements_sql_v1.go
+++ b/flink-gateway/v1/api_statements_sql_v1.go
@@ -42,15 +42,16 @@ var (
 type StatementsSqlV1Api interface {
 
 	/*
-		CreateSqlv1Statement Create a Statement
+			CreateSqlv1Statement Create a Statement
 
-		[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
-	Make a request to create a statement.
+			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param organizationId The unique identifier for the organization.
-		 @param environmentId The unique identifier for the environment.
-		 @return ApiCreateSqlv1StatementRequest
+		Make a request to create a statement.
+
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param organizationId The unique identifier for the organization.
+			 @param environmentId The unique identifier for the environment.
+			 @return ApiCreateSqlv1StatementRequest
 	*/
 	CreateSqlv1Statement(ctx _context.Context, organizationId string, environmentId string) ApiCreateSqlv1StatementRequest
 
@@ -59,16 +60,17 @@ type StatementsSqlV1Api interface {
 	CreateSqlv1StatementExecute(r ApiCreateSqlv1StatementRequest) (SqlV1Statement, *_nethttp.Response, error)
 
 	/*
-		DeleteSqlv1Statement Delete a Statement
+			DeleteSqlv1Statement Delete a Statement
 
-		[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
-	Make a request to delete a statement.
+			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param organizationId The unique identifier for the organization.
-		 @param environmentId The unique identifier for the environment.
-		 @param statementName The unique identifier for the statement.
-		 @return ApiDeleteSqlv1StatementRequest
+		Make a request to delete a statement.
+
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param organizationId The unique identifier for the organization.
+			 @param environmentId The unique identifier for the environment.
+			 @param statementName The unique identifier for the statement.
+			 @return ApiDeleteSqlv1StatementRequest
 	*/
 	DeleteSqlv1Statement(ctx _context.Context, organizationId string, environmentId string, statementName string) ApiDeleteSqlv1StatementRequest
 
@@ -76,16 +78,17 @@ type StatementsSqlV1Api interface {
 	DeleteSqlv1StatementExecute(r ApiDeleteSqlv1StatementRequest) (*_nethttp.Response, error)
 
 	/*
-		GetSqlv1Statement Read a Statement
+			GetSqlv1Statement Read a Statement
 
-		[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
-	Make a request to read a statement.
+			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param organizationId The unique identifier for the organization.
-		 @param environmentId The unique identifier for the environment.
-		 @param statementName The unique identifier for the statement.
-		 @return ApiGetSqlv1StatementRequest
+		Make a request to read a statement.
+
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param organizationId The unique identifier for the organization.
+			 @param environmentId The unique identifier for the environment.
+			 @param statementName The unique identifier for the statement.
+			 @return ApiGetSqlv1StatementRequest
 	*/
 	GetSqlv1Statement(ctx _context.Context, organizationId string, environmentId string, statementName string) ApiGetSqlv1StatementRequest
 
@@ -94,15 +97,16 @@ type StatementsSqlV1Api interface {
 	GetSqlv1StatementExecute(r ApiGetSqlv1StatementRequest) (SqlV1Statement, *_nethttp.Response, error)
 
 	/*
-		ListSqlv1Statements List of Statements
+			ListSqlv1Statements List of Statements
 
-		[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
-	Retrieve a sorted, filtered, paginated list of all statements.
+			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param organizationId The unique identifier for the organization.
-		 @param environmentId The unique identifier for the environment.
-		 @return ApiListSqlv1StatementsRequest
+		Retrieve a sorted, filtered, paginated list of all statements.
+
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param organizationId The unique identifier for the organization.
+			 @param environmentId The unique identifier for the environment.
+			 @return ApiListSqlv1StatementsRequest
 	*/
 	ListSqlv1Statements(ctx _context.Context, organizationId string, environmentId string) ApiListSqlv1StatementsRequest
 
@@ -111,16 +115,19 @@ type StatementsSqlV1Api interface {
 	ListSqlv1StatementsExecute(r ApiListSqlv1StatementsRequest) (SqlV1StatementList, *_nethttp.Response, error)
 
 	/*
-		UpdateSqlv1Statement Update a Statement
+			UpdateSqlv1Statement Update a Statement
 
-		[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
-	Make a request to update a statement.
+			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param organizationId The unique identifier for the organization.
-		 @param environmentId The unique identifier for the environment.
-		 @param statementName The unique identifier for the statement.
-		 @return ApiUpdateSqlv1StatementRequest
+		Make a request to update a statement.
+		The request will fail with a 409 Conflict error if the Statement has changed since it was fetched.
+		In this case, do a GET, reapply the modifications, and try the update again.
+
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param organizationId The unique identifier for the organization.
+			 @param environmentId The unique identifier for the environment.
+			 @param statementName The unique identifier for the statement.
+			 @return ApiUpdateSqlv1StatementRequest
 	*/
 	UpdateSqlv1Statement(ctx _context.Context, organizationId string, environmentId string, statementName string) ApiUpdateSqlv1StatementRequest
 
@@ -151,7 +158,8 @@ func (r ApiCreateSqlv1StatementRequest) Execute() (SqlV1Statement, *_nethttp.Res
 /*
 CreateSqlv1Statement Create a Statement
 
-[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
 Make a request to create a statement.
 
 	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -324,7 +332,8 @@ func (r ApiDeleteSqlv1StatementRequest) Execute() (*_nethttp.Response, error) {
 /*
 DeleteSqlv1Statement Delete a Statement
 
-[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
 Make a request to delete a statement.
 
 	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -476,7 +485,8 @@ func (r ApiGetSqlv1StatementRequest) Execute() (SqlV1Statement, *_nethttp.Respon
 /*
 GetSqlv1Statement Read a Statement
 
-[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
 Make a request to read a statement.
 
 	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -660,7 +670,8 @@ func (r ApiListSqlv1StatementsRequest) Execute() (SqlV1StatementList, *_nethttp.
 /*
 ListSqlv1Statements List of Statements
 
-[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
 Retrieve a sorted, filtered, paginated list of all statements.
 
 	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -836,8 +847,11 @@ func (r ApiUpdateSqlv1StatementRequest) Execute() (*_nethttp.Response, error) {
 /*
 UpdateSqlv1Statement Update a Statement
 
-[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+
 Make a request to update a statement.
+The request will fail with a 409 Conflict error if the Statement has changed since it was fetched.
+In this case, do a GET, reapply the modifications, and try the update again.
 
 	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param organizationId The unique identifier for the organization.

--- a/flink-gateway/v1/docs/SqlV1ScalingStatus.md
+++ b/flink-gateway/v1/docs/SqlV1ScalingStatus.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**ScalingState** | Pointer to **string** | OK: The statement runs at the right scale. PENDING_SCALE_DOWN: The statement requires less resources, and will be scaled down in the near future. PENDING_SCALE_UP: The statement requires more resources, and will be scaled up in the near future. POOL_EXHAUSTED: The statement requires more resources, but not enough resources are available.  | [optional] [readonly] 
+**ScalingState** | Pointer to **string** | OK: The statement runs at the right scale.  PENDING_SCALE_DOWN: The statement requires less resources, and will be scaled down in the near future.  PENDING_SCALE_UP: The statement requires more resources, and will be scaled up in the near future.  POOL_EXHAUSTED: The statement requires more resources, but not enough resources are available.  | [optional] [readonly] 
 **LastUpdated** | Pointer to **time.Time** | The last time the scaling status was updated. | [optional] [readonly] 
 
 ## Methods

--- a/flink-gateway/v1/docs/SqlV1StatementStatus.md
+++ b/flink-gateway/v1/docs/SqlV1StatementStatus.md
@@ -4,10 +4,11 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Phase** | **string** | The lifecycle phase of the submitted SQL statement: PENDING: SQL statement is pending execution; RUNNING: SQL statement execution is in progress; COMPLETED: SQL statement is completed; DELETING: SQL statement deletion is in progress; FAILING: SQL statement is failing; FAILED: SQL statement execution has failed; STOPPED: SQL statement execution has successfully been stopped;  | [readonly] 
+**Phase** | **string** | The lifecycle phase of the submitted SQL statement:  PENDING: SQL statement is pending execution;  RUNNING: SQL statement execution is in progress;  COMPLETED: SQL statement is completed;  DELETING: SQL statement deletion is in progress;  FAILING: SQL statement is failing;  FAILED: SQL statement execution has failed;  STOPPED: SQL statement execution has successfully been stopped;  | [readonly] 
 **ScalingStatus** | Pointer to [**SqlV1ScalingStatus**](SqlV1ScalingStatus.md) |  | [optional] 
-**Detail** | Pointer to **string** | Description of a SQL statement phase. | [optional] [readonly] 
+**Detail** | Pointer to **string** | Details about the execution status of this statement. | [optional] [readonly] 
 **Traits** | Pointer to [**SqlV1StatementTraits**](SqlV1StatementTraits.md) |  | [optional] 
+**NetworkKind** | Pointer to **string** | The networking type used by the submitted SQL statement:  PUBLIC: SQL statement is using public networking;  PRIVATE: SQL statement is using private networking;  | [optional] [readonly] 
 
 ## Methods
 
@@ -122,6 +123,31 @@ SetTraits sets Traits field to given value.
 `func (o *SqlV1StatementStatus) HasTraits() bool`
 
 HasTraits returns a boolean if a field has been set.
+
+### GetNetworkKind
+
+`func (o *SqlV1StatementStatus) GetNetworkKind() string`
+
+GetNetworkKind returns the NetworkKind field if non-nil, zero value otherwise.
+
+### GetNetworkKindOk
+
+`func (o *SqlV1StatementStatus) GetNetworkKindOk() (*string, bool)`
+
+GetNetworkKindOk returns a tuple with the NetworkKind field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetNetworkKind
+
+`func (o *SqlV1StatementStatus) SetNetworkKind(v string)`
+
+SetNetworkKind sets NetworkKind field to given value.
+
+### HasNetworkKind
+
+`func (o *SqlV1StatementStatus) HasNetworkKind() bool`
+
+HasNetworkKind returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/flink-gateway/v1/model_sql_v1_scaling_status.go
+++ b/flink-gateway/v1/model_sql_v1_scaling_status.go
@@ -37,7 +37,7 @@ import (
 
 // SqlV1ScalingStatus Scaling status for this statement.
 type SqlV1ScalingStatus struct {
-	// OK: The statement runs at the right scale. PENDING_SCALE_DOWN: The statement requires less resources, and will be scaled down in the near future. PENDING_SCALE_UP: The statement requires more resources, and will be scaled up in the near future. POOL_EXHAUSTED: The statement requires more resources, but not enough resources are available.
+	// OK: The statement runs at the right scale.  PENDING_SCALE_DOWN: The statement requires less resources, and will be scaled down in the near future.  PENDING_SCALE_UP: The statement requires more resources, and will be scaled up in the near future.  POOL_EXHAUSTED: The statement requires more resources, but not enough resources are available.
 	ScalingState *string `json:"scaling_state,omitempty"`
 	// The last time the scaling status was updated.
 	LastUpdated *time.Time `json:"last_updated,omitempty"`

--- a/flink-gateway/v1/model_sql_v1_statement_status.go
+++ b/flink-gateway/v1/model_sql_v1_statement_status.go
@@ -36,12 +36,14 @@ import (
 
 // SqlV1StatementStatus The status of the Statement
 type SqlV1StatementStatus struct {
-	// The lifecycle phase of the submitted SQL statement: PENDING: SQL statement is pending execution; RUNNING: SQL statement execution is in progress; COMPLETED: SQL statement is completed; DELETING: SQL statement deletion is in progress; FAILING: SQL statement is failing; FAILED: SQL statement execution has failed; STOPPED: SQL statement execution has successfully been stopped;
+	// The lifecycle phase of the submitted SQL statement:  PENDING: SQL statement is pending execution;  RUNNING: SQL statement execution is in progress;  COMPLETED: SQL statement is completed;  DELETING: SQL statement deletion is in progress;  FAILING: SQL statement is failing;  FAILED: SQL statement execution has failed;  STOPPED: SQL statement execution has successfully been stopped;
 	Phase         string              `json:"phase,omitempty"`
 	ScalingStatus *SqlV1ScalingStatus `json:"scaling_status,omitempty"`
-	// Description of a SQL statement phase.
+	// Details about the execution status of this statement.
 	Detail *string               `json:"detail,omitempty"`
 	Traits *SqlV1StatementTraits `json:"traits,omitempty"`
+	// The networking type used by the submitted SQL statement:  PUBLIC: SQL statement is using public networking;  PRIVATE: SQL statement is using private networking;
+	NetworkKind *string `json:"network_kind,omitempty"`
 }
 
 // NewSqlV1StatementStatus instantiates a new SqlV1StatementStatus object
@@ -182,12 +184,45 @@ func (o *SqlV1StatementStatus) SetTraits(v SqlV1StatementTraits) {
 	o.Traits = &v
 }
 
+// GetNetworkKind returns the NetworkKind field value if set, zero value otherwise.
+func (o *SqlV1StatementStatus) GetNetworkKind() string {
+	if o == nil || o.NetworkKind == nil {
+		var ret string
+		return ret
+	}
+	return *o.NetworkKind
+}
+
+// GetNetworkKindOk returns a tuple with the NetworkKind field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *SqlV1StatementStatus) GetNetworkKindOk() (*string, bool) {
+	if o == nil || o.NetworkKind == nil {
+		return nil, false
+	}
+	return o.NetworkKind, true
+}
+
+// HasNetworkKind returns a boolean if a field has been set.
+func (o *SqlV1StatementStatus) HasNetworkKind() bool {
+	if o != nil && o.NetworkKind != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetNetworkKind gets a reference to the given string and assigns it to the NetworkKind field.
+func (o *SqlV1StatementStatus) SetNetworkKind(v string) {
+	o.NetworkKind = &v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *SqlV1StatementStatus) Redact() {
 	o.recurseRedact(&o.Phase)
 	o.recurseRedact(o.ScalingStatus)
 	o.recurseRedact(o.Detail)
 	o.recurseRedact(o.Traits)
+	o.recurseRedact(o.NetworkKind)
 }
 
 func (o *SqlV1StatementStatus) recurseRedact(v interface{}) {
@@ -233,6 +268,9 @@ func (o SqlV1StatementStatus) MarshalJSON() ([]byte, error) {
 	}
 	if o.Traits != nil {
 		toSerialize["traits"] = o.Traits
+	}
+	if o.NetworkKind != nil {
+		toSerialize["network_kind"] = o.NetworkKind
 	}
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)


### PR DESCRIPTION
Regnerate the SDK after API change: https://github.com/confluentinc/api/pull/1560
 
```
❯ go vet -v 
internal/race
unicode/utf8
internal/itoa
encoding
math/bits
math
cmp
slices
unicode/utf16
crypto/internal/alias
crypto/subtle
crypto/internal/boring/sig
vendor/golang.org/x/crypto/cryptobyte/asn1
internal/nettrace
container/list
vendor/golang.org/x/crypto/internal/alias
log/internal
internal/unsafeheader
internal/goos
internal/godebugs
internal/coverage/rtcov
sync/atomic
internal/cpu
unicode
internal/goarch
internal/goexperiment
runtime/internal/math
runtime/internal/atomic
internal/chacha8rand
runtime/internal/sys
internal/bytealg
internal/abi
runtime
internal/reflectlite
sync
internal/testlog
internal/bisect
errors
sort
internal/singleflight
internal/godebug
vendor/golang.org/x/net/dns/dnsmessage
io
internal/safefilepath
path
internal/oserror
internal/intern
bytes
crypto/internal/randutil
hash
math/rand
crypto/internal/nistec/fiat
strconv
strings
crypto/rc4
vendor/golang.org/x/text/transform
crypto
hash/crc32
net/netip
net/http/internal/ascii
bufio
reflect
regexp/syntax
syscall
internal/fmtsort
encoding/binary
internal/syscall/execenv
regexp
encoding/base64
time
crypto/internal/edwards25519/field
vendor/golang.org/x/crypto/internal/poly1305
crypto/md5
crypto/cipher
internal/syscall/unix
encoding/pem
context
crypto/des
crypto/x509/internal/macos
crypto/internal/boring
crypto/internal/edwards25519
io/fs
vendor/golang.org/x/crypto/chacha20
crypto/hmac
embed
crypto/sha512
crypto/sha1
crypto/sha256
vendor/golang.org/x/crypto/chacha20poly1305
vendor/golang.org/x/crypto/hkdf
crypto/aes
internal/poll
crypto/internal/nistec
crypto/ecdh
os
io/ioutil
path/filepath
fmt
vendor/golang.org/x/net/route
encoding/hex
net/url
log
encoding/json
encoding/xml
vendor/golang.org/x/net/http2/hpack
compress/flate
mime/quotedprintable
mime
net/http/internal
vendor/golang.org/x/text/unicode/norm
vendor/golang.org/x/text/unicode/bidi
compress/gzip
math/big
vendor/golang.org/x/text/secure/bidirule
crypto/internal/bigmod
crypto/internal/boring/bbig
crypto/rand
crypto/dsa
encoding/asn1
crypto/elliptic
crypto/ed25519
vendor/golang.org/x/net/idna
crypto/rsa
crypto/x509/pkix
vendor/golang.org/x/crypto/cryptobyte
crypto/ecdsa
runtime/cgo
net
vendor/golang.org/x/net/http/httpproxy
net/textproto
vendor/golang.org/x/net/http/httpguts
crypto/x509
mime/multipart
crypto/tls
net/http/httptrace
net/http
net/http/httputil
golang.org/x/net/context/ctxhttp
golang.org/x/oauth2/internal
golang.org/x/oauth2
github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1

```