### PR TITLE
Update the Flink SDK

### DIFF
--- a/flink/go.mod
+++ b/flink/go.mod
@@ -1,4 +1,4 @@
-module github.com/confluentinc/ccloud-sdk-go-v2-internal/flink
+module github.com/confluentinc/ccloud-sdk-go-v2/flink
 
 go 1.16
 

--- a/flink/go.mod
+++ b/flink/go.mod
@@ -1,4 +1,4 @@
-module github.com/confluentinc/ccloud-sdk-go-v2/flink
+module github.com/confluentinc/ccloud-sdk-go-v2-internal/flink
 
 go 1.16
 

--- a/flink/v2/README.md
+++ b/flink/v2/README.md
@@ -126,6 +126,34 @@ r, err := client.Service.Operation(auth, args)
 ```
 
 
+### confluent-sts-access-token
+
+
+- **Type**: OAuth
+- **Flow**: application
+- **Authorization URL**: 
+- **Scopes**: N/A
+
+Example
+
+```golang
+auth := context.WithValue(context.Background(), sw.ContextAccessToken, "ACCESSTOKENSTRING")
+r, err := client.Service.Operation(auth, args)
+```
+
+Or via OAuth2 module to automatically refresh tokens and perform user authentication.
+
+```golang
+import "golang.org/x/oauth2"
+
+/* Perform OAuth2 round trip request and obtain a token */
+
+tokenSource := oauth2cfg.TokenSource(createContext(httpClient), &token)
+auth := context.WithValue(oauth2.NoContext, sw.ContextOAuth2, tokenSource)
+r, err := client.Service.Operation(auth, args)
+```
+
+
 ## Documentation for Utility Methods
 
 Due to the fact that model structure members are all pointers, this package contains

--- a/flink/v2/api/openapi.yaml
+++ b/flink/v2/api/openapi.yaml
@@ -14,10 +14,13 @@ info:
 servers:
 - description: Confluent Cloud production
   url: https://api.confluent.cloud
-
+- description: Confluent Cloud staging
+  url: https://api.stag.cpdev.cloud
+- description: Confluent Cloud development
+  url: https://api.devel.cpdev.cloud
 tags:
 - description: |-
-    [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+    [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
     A Compute Pool represents a set of compute resources that is used to run your Queries.
     The resources (CPUs, memory,…) provided by a Compute Pool are shared between all Queries that use it.
@@ -27,7 +30,7 @@ tags:
     <SchemaDefinition schemaRef="#/components/schemas/fcpm.v2.ComputePool" />
   name: Compute Pools (fcpm/v2)
 - description: |-
-    [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+    [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
     `Region` objects represent cloud provider regions available when placing Flink compute pools.
     The API allows you to list Flink regions.
@@ -40,7 +43,7 @@ paths:
   /fcpm/v2/compute-pools:
     get:
       description: |-
-        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Retrieve a sorted, filtered, paginated list of all compute pools.
       operationId: listFcpmV2ComputePools
@@ -286,6 +289,7 @@ paths:
               style: simple
       security:
       - cloud-api-key: []
+      - confluent-sts-access-token: []
       summary: List of Compute Pools
       tags:
       - Compute Pools (fcpm/v2)
@@ -293,14 +297,14 @@ paths:
       - lang: Shell
         source: |-
           curl --request GET \
-            --url 'https://api.confluent.cloud/fcpm/v2/compute-pools?spec.region=SOME_STRING_VALUE&environment=SOME_STRING_VALUE&spec.network=SOME_STRING_VALUE&page_size=SOME_INTEGER_VALUE&page_token=SOME_STRING_VALUE' \
+            --url 'https://api.confluent.cloud/fcpm/v2/compute-pools?spec.region=us-west-1&environment=env-00000&spec.network=n-00000' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           Request request = new Request.Builder()
-            .url("https://api.confluent.cloud/fcpm/v2/compute-pools?spec.region=SOME_STRING_VALUE&environment=SOME_STRING_VALUE&spec.network=SOME_STRING_VALUE&page_size=SOME_INTEGER_VALUE&page_token=SOME_STRING_VALUE")
+            .url("https://api.confluent.cloud/fcpm/v2/compute-pools?spec.region=us-west-1&environment=env-00000&spec.network=n-00000")
             .get()
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
             .build();
@@ -308,7 +312,7 @@ paths:
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io/ioutil\"\
-          \n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/fcpm/v2/compute-pools?spec.region=SOME_STRING_VALUE&environment=SOME_STRING_VALUE&spec.network=SOME_STRING_VALUE&page_size=SOME_INTEGER_VALUE&page_token=SOME_STRING_VALUE\"\
+          \n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/fcpm/v2/compute-pools?spec.region=us-west-1&environment=env-00000&spec.network=n-00000\"\
           \n\n\treq, _ := http.NewRequest(\"GET\", url, nil)\n\n\treq.Header.Add(\"\
           Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
           \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
@@ -321,7 +325,7 @@ paths:
 
           headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
 
-          conn.request("GET", "/fcpm/v2/compute-pools?spec.region=SOME_STRING_VALUE&environment=SOME_STRING_VALUE&spec.network=SOME_STRING_VALUE&page_size=SOME_INTEGER_VALUE&page_token=SOME_STRING_VALUE", headers=headers)
+          conn.request("GET", "/fcpm/v2/compute-pools?spec.region=us-west-1&environment=env-00000&spec.network=n-00000", headers=headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -335,7 +339,7 @@ paths:
             "method": "GET",
             "hostname": "api.confluent.cloud",
             "port": null,
-            "path": "/fcpm/v2/compute-pools?spec.region=SOME_STRING_VALUE&environment=SOME_STRING_VALUE&spec.network=SOME_STRING_VALUE&page_size=SOME_INTEGER_VALUE&page_token=SOME_STRING_VALUE",
+            "path": "/fcpm/v2/compute-pools?spec.region=us-west-1&environment=env-00000&spec.network=n-00000",
             "headers": {
               "Authorization": "Basic REPLACE_BASIC_AUTH"
             }
@@ -360,7 +364,7 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "GET");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://api.confluent.cloud/fcpm/v2/compute-pools?spec.region=SOME_STRING_VALUE&environment=SOME_STRING_VALUE&spec.network=SOME_STRING_VALUE&page_size=SOME_INTEGER_VALUE&page_token=SOME_STRING_VALUE");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://api.confluent.cloud/fcpm/v2/compute-pools?spec.region=us-west-1&environment=env-00000&spec.network=n-00000");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
@@ -369,13 +373,13 @@ paths:
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://api.confluent.cloud/fcpm/v2/compute-pools?spec.region=SOME_STRING_VALUE&environment=SOME_STRING_VALUE&spec.network=SOME_STRING_VALUE&page_size=SOME_INTEGER_VALUE&page_token=SOME_STRING_VALUE");
+          var client = new RestClient("https://api.confluent.cloud/fcpm/v2/compute-pools?spec.region=us-west-1&environment=env-00000&spec.network=n-00000");
           var request = new RestRequest(Method.GET);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
           IRestResponse response = client.Execute(request);
     post:
       description: |-
-        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Make a request to create a compute pool.
       operationId: createFcpmV2ComputePool
@@ -672,6 +676,7 @@ paths:
               style: simple
       security:
       - cloud-api-key: []
+      - confluent-sts-access-token: []
       summary: Create a Compute Pool
       tags:
       - Compute Pools (fcpm/v2)
@@ -793,7 +798,7 @@ paths:
   /fcpm/v2/compute-pools/{id}:
     delete:
       description: |-
-        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Make a request to delete a compute pool.
       operationId: deleteFcpmV2ComputePool
@@ -1003,6 +1008,7 @@ paths:
               style: simple
       security:
       - cloud-api-key: []
+      - confluent-sts-access-token: []
       summary: Delete a Compute Pool
       tags:
       - Compute Pools (fcpm/v2)
@@ -1010,14 +1016,14 @@ paths:
       - lang: Shell
         source: |-
           curl --request DELETE \
-            --url 'https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=SOME_STRING_VALUE' \
+            --url 'https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=env-00000' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           Request request = new Request.Builder()
-            .url("https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=SOME_STRING_VALUE")
+            .url("https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=env-00000")
             .delete(null)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
             .build();
@@ -1025,7 +1031,7 @@ paths:
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io/ioutil\"\
-          \n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=SOME_STRING_VALUE\"\
+          \n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=env-00000\"\
           \n\n\treq, _ := http.NewRequest(\"DELETE\", url, nil)\n\n\treq.Header.Add(\"\
           Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
           \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
@@ -1038,7 +1044,7 @@ paths:
 
           headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
 
-          conn.request("DELETE", "/fcpm/v2/compute-pools/{id}?environment=SOME_STRING_VALUE", headers=headers)
+          conn.request("DELETE", "/fcpm/v2/compute-pools/{id}?environment=env-00000", headers=headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -1052,7 +1058,7 @@ paths:
             "method": "DELETE",
             "hostname": "api.confluent.cloud",
             "port": null,
-            "path": "/fcpm/v2/compute-pools/{id}?environment=SOME_STRING_VALUE",
+            "path": "/fcpm/v2/compute-pools/{id}?environment=env-00000",
             "headers": {
               "Authorization": "Basic REPLACE_BASIC_AUTH"
             }
@@ -1077,7 +1083,7 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "DELETE");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=SOME_STRING_VALUE");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=env-00000");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
@@ -1086,13 +1092,13 @@ paths:
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=SOME_STRING_VALUE");
+          var client = new RestClient("https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=env-00000");
           var request = new RestRequest(Method.DELETE);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
           IRestResponse response = client.Execute(request);
     get:
       description: |-
-        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Make a request to read a compute pool.
       operationId: getFcpmV2ComputePool
@@ -1338,6 +1344,7 @@ paths:
               style: simple
       security:
       - cloud-api-key: []
+      - confluent-sts-access-token: []
       summary: Read a Compute Pool
       tags:
       - Compute Pools (fcpm/v2)
@@ -1345,14 +1352,14 @@ paths:
       - lang: Shell
         source: |-
           curl --request GET \
-            --url 'https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=SOME_STRING_VALUE' \
+            --url 'https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=env-00000' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           Request request = new Request.Builder()
-            .url("https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=SOME_STRING_VALUE")
+            .url("https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=env-00000")
             .get()
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
             .build();
@@ -1360,7 +1367,7 @@ paths:
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io/ioutil\"\
-          \n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=SOME_STRING_VALUE\"\
+          \n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=env-00000\"\
           \n\n\treq, _ := http.NewRequest(\"GET\", url, nil)\n\n\treq.Header.Add(\"\
           Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
           \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
@@ -1373,7 +1380,7 @@ paths:
 
           headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
 
-          conn.request("GET", "/fcpm/v2/compute-pools/{id}?environment=SOME_STRING_VALUE", headers=headers)
+          conn.request("GET", "/fcpm/v2/compute-pools/{id}?environment=env-00000", headers=headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -1387,7 +1394,7 @@ paths:
             "method": "GET",
             "hostname": "api.confluent.cloud",
             "port": null,
-            "path": "/fcpm/v2/compute-pools/{id}?environment=SOME_STRING_VALUE",
+            "path": "/fcpm/v2/compute-pools/{id}?environment=env-00000",
             "headers": {
               "Authorization": "Basic REPLACE_BASIC_AUTH"
             }
@@ -1412,7 +1419,7 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "GET");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=SOME_STRING_VALUE");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=env-00000");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
@@ -1421,13 +1428,13 @@ paths:
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=SOME_STRING_VALUE");
+          var client = new RestClient("https://api.confluent.cloud/fcpm/v2/compute-pools/{id}?environment=env-00000");
           var request = new RestRequest(Method.GET);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
           IRestResponse response = client.Execute(request);
     patch:
       description: |-
-        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Make a request to update a compute pool.
       operationId: updateFcpmV2ComputePool
@@ -1735,6 +1742,7 @@ paths:
               style: simple
       security:
       - cloud-api-key: []
+      - confluent-sts-access-token: []
       summary: Update a Compute Pool
       tags:
       - Compute Pools (fcpm/v2)
@@ -1856,7 +1864,7 @@ paths:
   /fcpm/v2/regions:
     get:
       description: |-
-        [![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Retrieve a sorted, filtered, paginated list of all regions.
       operationId: listFcpmV2Regions
@@ -2074,6 +2082,7 @@ paths:
               style: simple
       security:
       - cloud-api-key: []
+      - confluent-sts-access-token: []
       summary: List of Regions
       tags:
       - Regions (fcpm/v2)
@@ -2081,14 +2090,14 @@ paths:
       - lang: Shell
         source: |-
           curl --request GET \
-            --url 'https://api.confluent.cloud/fcpm/v2/regions?cloud=SOME_STRING_VALUE&region_name=SOME_STRING_VALUE&page_size=SOME_INTEGER_VALUE&page_token=SOME_STRING_VALUE' \
+            --url 'https://api.confluent.cloud/fcpm/v2/regions?cloud=AWS&region_name=us-east-2' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           Request request = new Request.Builder()
-            .url("https://api.confluent.cloud/fcpm/v2/regions?cloud=SOME_STRING_VALUE&region_name=SOME_STRING_VALUE&page_size=SOME_INTEGER_VALUE&page_token=SOME_STRING_VALUE")
+            .url("https://api.confluent.cloud/fcpm/v2/regions?cloud=AWS&region_name=us-east-2")
             .get()
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
             .build();
@@ -2096,7 +2105,7 @@ paths:
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io/ioutil\"\
-          \n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/fcpm/v2/regions?cloud=SOME_STRING_VALUE&region_name=SOME_STRING_VALUE&page_size=SOME_INTEGER_VALUE&page_token=SOME_STRING_VALUE\"\
+          \n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/fcpm/v2/regions?cloud=AWS&region_name=us-east-2\"\
           \n\n\treq, _ := http.NewRequest(\"GET\", url, nil)\n\n\treq.Header.Add(\"\
           Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
           \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
@@ -2109,7 +2118,7 @@ paths:
 
           headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
 
-          conn.request("GET", "/fcpm/v2/regions?cloud=SOME_STRING_VALUE&region_name=SOME_STRING_VALUE&page_size=SOME_INTEGER_VALUE&page_token=SOME_STRING_VALUE", headers=headers)
+          conn.request("GET", "/fcpm/v2/regions?cloud=AWS&region_name=us-east-2", headers=headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -2123,7 +2132,7 @@ paths:
             "method": "GET",
             "hostname": "api.confluent.cloud",
             "port": null,
-            "path": "/fcpm/v2/regions?cloud=SOME_STRING_VALUE&region_name=SOME_STRING_VALUE&page_size=SOME_INTEGER_VALUE&page_token=SOME_STRING_VALUE",
+            "path": "/fcpm/v2/regions?cloud=AWS&region_name=us-east-2",
             "headers": {
               "Authorization": "Basic REPLACE_BASIC_AUTH"
             }
@@ -2148,7 +2157,7 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "GET");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://api.confluent.cloud/fcpm/v2/regions?cloud=SOME_STRING_VALUE&region_name=SOME_STRING_VALUE&page_size=SOME_INTEGER_VALUE&page_token=SOME_STRING_VALUE");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://api.confluent.cloud/fcpm/v2/regions?cloud=AWS&region_name=us-east-2");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
@@ -2157,7 +2166,7 @@ paths:
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://api.confluent.cloud/fcpm/v2/regions?cloud=SOME_STRING_VALUE&region_name=SOME_STRING_VALUE&page_size=SOME_INTEGER_VALUE&page_token=SOME_STRING_VALUE");
+          var client = new RestClient("https://api.confluent.cloud/fcpm/v2/regions?cloud=AWS&region_name=us-east-2");
           var request = new RestRequest(Method.GET);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
           IRestResponse response = client.Execute(request);
@@ -2521,7 +2530,13 @@ components:
           type: string
           x-immutable: true
         http_endpoint:
-          description: The regional API endpoint for flink compute pools.
+          description: The regional API endpoint for Flink compute pools.
+          format: uri
+          readOnly: true
+          type: string
+          x-immutable: true
+        private_http_endpoint:
+          description: The private regional API endpoint for Flink compute pools.
           format: uri
           readOnly: true
           type: string
@@ -2611,12 +2626,6 @@ components:
           - GCP
           - AZURE
           x-immutable: true
-        http_endpoint:
-          description: The API endpoint of the Flink compute pool.
-          format: uri
-          readOnly: true
-          type: string
-          x-immutable: true
         region:
           description: Flink compute pools in the region provided will be able to
             use this identity pool
@@ -2693,6 +2702,7 @@ components:
             - required:
               - cloud
               - display_name
+              - http_endpoint
               - id
               - metadata
               - region_name
@@ -3023,3 +3033,11 @@ components:
         Cloud API Key ID as the username and Cloud API Key Secret as the password.
       scheme: basic
       type: http
+    confluent-sts-access-token:
+      description: Authenticate with Confluent API using this credentials (JSON Web
+        Tokens) following OAuth 2.0.
+      flows:
+        clientCredentials:
+          scopes: {}
+          tokenUrl: https://api.confluent.cloud/sts/v1/oauth2/token
+      type: oauth2

--- a/flink/v2/api_compute_pools_fcpm_v2.go
+++ b/flink/v2/api_compute_pools_fcpm_v2.go
@@ -44,7 +44,7 @@ type ComputePoolsFcpmV2Api interface {
 	/*
 		CreateFcpmV2ComputePool Create a Compute Pool
 
-		[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 	Make a request to create a compute pool.
 
@@ -60,7 +60,7 @@ type ComputePoolsFcpmV2Api interface {
 	/*
 		DeleteFcpmV2ComputePool Delete a Compute Pool
 
-		[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 	Make a request to delete a compute pool.
 
@@ -76,7 +76,7 @@ type ComputePoolsFcpmV2Api interface {
 	/*
 		GetFcpmV2ComputePool Read a Compute Pool
 
-		[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 	Make a request to read a compute pool.
 
@@ -93,7 +93,7 @@ type ComputePoolsFcpmV2Api interface {
 	/*
 		ListFcpmV2ComputePools List of Compute Pools
 
-		[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 	Retrieve a sorted, filtered, paginated list of all compute pools.
 
@@ -109,7 +109,7 @@ type ComputePoolsFcpmV2Api interface {
 	/*
 		UpdateFcpmV2ComputePool Update a Compute Pool
 
-		[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 	Make a request to update a compute pool.
 
@@ -145,7 +145,7 @@ func (r ApiCreateFcpmV2ComputePoolRequest) Execute() (FcpmV2ComputePool, *_netht
 /*
 CreateFcpmV2ComputePool Create a Compute Pool
 
-[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to create a compute pool.
 
@@ -318,7 +318,7 @@ func (r ApiDeleteFcpmV2ComputePoolRequest) Execute() (*_nethttp.Response, error)
 /*
 DeleteFcpmV2ComputePool Delete a Compute Pool
 
-[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to delete a compute pool.
 
@@ -474,7 +474,7 @@ func (r ApiGetFcpmV2ComputePoolRequest) Execute() (FcpmV2ComputePool, *_nethttp.
 /*
 GetFcpmV2ComputePool Read a Compute Pool
 
-[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to read a compute pool.
 
@@ -669,7 +669,7 @@ func (r ApiListFcpmV2ComputePoolsRequest) Execute() (FcpmV2ComputePoolList, *_ne
 /*
 ListFcpmV2ComputePools List of Compute Pools
 
-[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Retrieve a sorted, filtered, paginated list of all compute pools.
 
@@ -835,7 +835,7 @@ func (r ApiUpdateFcpmV2ComputePoolRequest) Execute() (FcpmV2ComputePool, *_netht
 /*
 UpdateFcpmV2ComputePool Update a Compute Pool
 
-[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to update a compute pool.
 

--- a/flink/v2/api_regions_fcpm_v2.go
+++ b/flink/v2/api_regions_fcpm_v2.go
@@ -43,7 +43,7 @@ type RegionsFcpmV2Api interface {
 	/*
 		ListFcpmV2Regions List of Regions
 
-		[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 	Retrieve a sorted, filtered, paginated list of all regions.
 
@@ -100,7 +100,7 @@ func (r ApiListFcpmV2RegionsRequest) Execute() (FcpmV2RegionList, *_nethttp.Resp
 /*
 ListFcpmV2Regions List of Regions
 
-[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](#section/Versioning/API-Lifecycle-Policy)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Retrieve a sorted, filtered, paginated list of all regions.
 

--- a/flink/v2/configuration.go
+++ b/flink/v2/configuration.go
@@ -123,6 +123,14 @@ func NewConfiguration() *Configuration {
 				URL:         "https://api.confluent.cloud",
 				Description: "Confluent Cloud production",
 			},
+			{
+				URL:         "https://api.stag.cpdev.cloud",
+				Description: "Confluent Cloud staging",
+			},
+			{
+				URL:         "https://api.devel.cpdev.cloud",
+				Description: "Confluent Cloud development",
+			},
 		},
 		OperationServers: map[string]ServerConfigurations{},
 	}

--- a/flink/v2/docs/ComputePoolsFcpmV2Api.md
+++ b/flink/v2/docs/ComputePoolsFcpmV2Api.md
@@ -66,7 +66,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[cloud-api-key](../README.md#cloud-api-key)
+[cloud-api-key](../README.md#cloud-api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
 
 ### HTTP request headers
 
@@ -136,7 +136,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[cloud-api-key](../README.md#cloud-api-key)
+[cloud-api-key](../README.md#cloud-api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
 
 ### HTTP request headers
 
@@ -208,7 +208,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[cloud-api-key](../README.md#cloud-api-key)
+[cloud-api-key](../README.md#cloud-api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
 
 ### HTTP request headers
 
@@ -282,7 +282,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[cloud-api-key](../README.md#cloud-api-key)
+[cloud-api-key](../README.md#cloud-api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
 
 ### HTTP request headers
 
@@ -354,7 +354,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[cloud-api-key](../README.md#cloud-api-key)
+[cloud-api-key](../README.md#cloud-api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
 
 ### HTTP request headers
 

--- a/flink/v2/docs/FcpmV2ComputePoolSpec.md
+++ b/flink/v2/docs/FcpmV2ComputePoolSpec.md
@@ -6,7 +6,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **DisplayName** | Pointer to **string** | The name of the Flink compute pool. | [optional] 
 **Cloud** | Pointer to **string** | The cloud service provider that runs the compute pool. | [optional] 
-**HttpEndpoint** | Pointer to **string** | The API endpoint of the Flink compute pool. | [optional] [readonly] 
 **Region** | Pointer to **string** | Flink compute pools in the region provided will be able to use this identity pool | [optional] 
 **MaxCfu** | Pointer to **int32** | Maximum number of Confluent Flink Units (CFUs) that the Flink compute pool should auto-scale to.  | [optional] 
 **Environment** | Pointer to [**GlobalObjectReference**](GlobalObjectReference.md) | The environment to which this belongs. | [optional] 
@@ -80,31 +79,6 @@ SetCloud sets Cloud field to given value.
 `func (o *FcpmV2ComputePoolSpec) HasCloud() bool`
 
 HasCloud returns a boolean if a field has been set.
-
-### GetHttpEndpoint
-
-`func (o *FcpmV2ComputePoolSpec) GetHttpEndpoint() string`
-
-GetHttpEndpoint returns the HttpEndpoint field if non-nil, zero value otherwise.
-
-### GetHttpEndpointOk
-
-`func (o *FcpmV2ComputePoolSpec) GetHttpEndpointOk() (*string, bool)`
-
-GetHttpEndpointOk returns a tuple with the HttpEndpoint field if it's non-nil, zero value otherwise
-and a boolean to check if the value has been set.
-
-### SetHttpEndpoint
-
-`func (o *FcpmV2ComputePoolSpec) SetHttpEndpoint(v string)`
-
-SetHttpEndpoint sets HttpEndpoint field to given value.
-
-### HasHttpEndpoint
-
-`func (o *FcpmV2ComputePoolSpec) HasHttpEndpoint() bool`
-
-HasHttpEndpoint returns a boolean if a field has been set.
 
 ### GetRegion
 

--- a/flink/v2/docs/FcpmV2Region.md
+++ b/flink/v2/docs/FcpmV2Region.md
@@ -11,7 +11,8 @@ Name | Type | Description | Notes
 **DisplayName** | Pointer to **string** | The display name. | [optional] [readonly] 
 **Cloud** | Pointer to **string** | The cloud service provider that hosts the region. | [optional] [readonly] 
 **RegionName** | Pointer to **string** | The region name. | [optional] [readonly] 
-**HttpEndpoint** | Pointer to **string** | The regional API endpoint for flink compute pools. | [optional] [readonly] 
+**HttpEndpoint** | Pointer to **string** | The regional API endpoint for Flink compute pools. | [optional] [readonly] 
+**PrivateHttpEndpoint** | Pointer to **string** | The private regional API endpoint for Flink compute pools. | [optional] [readonly] 
 
 ## Methods
 
@@ -231,6 +232,31 @@ SetHttpEndpoint sets HttpEndpoint field to given value.
 `func (o *FcpmV2Region) HasHttpEndpoint() bool`
 
 HasHttpEndpoint returns a boolean if a field has been set.
+
+### GetPrivateHttpEndpoint
+
+`func (o *FcpmV2Region) GetPrivateHttpEndpoint() string`
+
+GetPrivateHttpEndpoint returns the PrivateHttpEndpoint field if non-nil, zero value otherwise.
+
+### GetPrivateHttpEndpointOk
+
+`func (o *FcpmV2Region) GetPrivateHttpEndpointOk() (*string, bool)`
+
+GetPrivateHttpEndpointOk returns a tuple with the PrivateHttpEndpoint field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetPrivateHttpEndpoint
+
+`func (o *FcpmV2Region) SetPrivateHttpEndpoint(v string)`
+
+SetPrivateHttpEndpoint sets PrivateHttpEndpoint field to given value.
+
+### HasPrivateHttpEndpoint
+
+`func (o *FcpmV2Region) HasPrivateHttpEndpoint() bool`
+
+HasPrivateHttpEndpoint returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/flink/v2/docs/RegionsFcpmV2Api.md
+++ b/flink/v2/docs/RegionsFcpmV2Api.md
@@ -68,7 +68,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[cloud-api-key](../README.md#cloud-api-key)
+[cloud-api-key](../README.md#cloud-api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
 
 ### HTTP request headers
 

--- a/flink/v2/model_fcpm_v2_compute_pool_spec.go
+++ b/flink/v2/model_fcpm_v2_compute_pool_spec.go
@@ -40,8 +40,6 @@ type FcpmV2ComputePoolSpec struct {
 	DisplayName *string `json:"display_name,omitempty"`
 	// The cloud service provider that runs the compute pool.
 	Cloud *string `json:"cloud,omitempty"`
-	// The API endpoint of the Flink compute pool.
-	HttpEndpoint *string `json:"http_endpoint,omitempty"`
 	// Flink compute pools in the region provided will be able to use this identity pool
 	Region *string `json:"region,omitempty"`
 	// Maximum number of Confluent Flink Units (CFUs) that the Flink compute pool should auto-scale to.
@@ -131,38 +129,6 @@ func (o *FcpmV2ComputePoolSpec) HasCloud() bool {
 // SetCloud gets a reference to the given string and assigns it to the Cloud field.
 func (o *FcpmV2ComputePoolSpec) SetCloud(v string) {
 	o.Cloud = &v
-}
-
-// GetHttpEndpoint returns the HttpEndpoint field value if set, zero value otherwise.
-func (o *FcpmV2ComputePoolSpec) GetHttpEndpoint() string {
-	if o == nil || o.HttpEndpoint == nil {
-		var ret string
-		return ret
-	}
-	return *o.HttpEndpoint
-}
-
-// GetHttpEndpointOk returns a tuple with the HttpEndpoint field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *FcpmV2ComputePoolSpec) GetHttpEndpointOk() (*string, bool) {
-	if o == nil || o.HttpEndpoint == nil {
-		return nil, false
-	}
-	return o.HttpEndpoint, true
-}
-
-// HasHttpEndpoint returns a boolean if a field has been set.
-func (o *FcpmV2ComputePoolSpec) HasHttpEndpoint() bool {
-	if o != nil && o.HttpEndpoint != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHttpEndpoint gets a reference to the given string and assigns it to the HttpEndpoint field.
-func (o *FcpmV2ComputePoolSpec) SetHttpEndpoint(v string) {
-	o.HttpEndpoint = &v
 }
 
 // GetRegion returns the Region field value if set, zero value otherwise.
@@ -297,7 +263,6 @@ func (o *FcpmV2ComputePoolSpec) SetNetwork(v EnvScopedObjectReference) {
 func (o *FcpmV2ComputePoolSpec) Redact() {
 	o.recurseRedact(o.DisplayName)
 	o.recurseRedact(o.Cloud)
-	o.recurseRedact(o.HttpEndpoint)
 	o.recurseRedact(o.Region)
 	o.recurseRedact(o.MaxCfu)
 	o.recurseRedact(o.Environment)
@@ -341,9 +306,6 @@ func (o FcpmV2ComputePoolSpec) MarshalJSON() ([]byte, error) {
 	}
 	if o.Cloud != nil {
 		toSerialize["cloud"] = o.Cloud
-	}
-	if o.HttpEndpoint != nil {
-		toSerialize["http_endpoint"] = o.HttpEndpoint
 	}
 	if o.Region != nil {
 		toSerialize["region"] = o.Region

--- a/flink/v2/model_fcpm_v2_region.go
+++ b/flink/v2/model_fcpm_v2_region.go
@@ -49,8 +49,10 @@ type FcpmV2Region struct {
 	Cloud *string `json:"cloud,omitempty"`
 	// The region name.
 	RegionName *string `json:"region_name,omitempty"`
-	// The regional API endpoint for flink compute pools.
+	// The regional API endpoint for Flink compute pools.
 	HttpEndpoint *string `json:"http_endpoint,omitempty"`
+	// The private regional API endpoint for Flink compute pools.
+	PrivateHttpEndpoint *string `json:"private_http_endpoint,omitempty"`
 }
 
 // NewFcpmV2Region instantiates a new FcpmV2Region object
@@ -326,6 +328,38 @@ func (o *FcpmV2Region) SetHttpEndpoint(v string) {
 	o.HttpEndpoint = &v
 }
 
+// GetPrivateHttpEndpoint returns the PrivateHttpEndpoint field value if set, zero value otherwise.
+func (o *FcpmV2Region) GetPrivateHttpEndpoint() string {
+	if o == nil || o.PrivateHttpEndpoint == nil {
+		var ret string
+		return ret
+	}
+	return *o.PrivateHttpEndpoint
+}
+
+// GetPrivateHttpEndpointOk returns a tuple with the PrivateHttpEndpoint field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *FcpmV2Region) GetPrivateHttpEndpointOk() (*string, bool) {
+	if o == nil || o.PrivateHttpEndpoint == nil {
+		return nil, false
+	}
+	return o.PrivateHttpEndpoint, true
+}
+
+// HasPrivateHttpEndpoint returns a boolean if a field has been set.
+func (o *FcpmV2Region) HasPrivateHttpEndpoint() bool {
+	if o != nil && o.PrivateHttpEndpoint != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetPrivateHttpEndpoint gets a reference to the given string and assigns it to the PrivateHttpEndpoint field.
+func (o *FcpmV2Region) SetPrivateHttpEndpoint(v string) {
+	o.PrivateHttpEndpoint = &v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *FcpmV2Region) Redact() {
 	o.recurseRedact(o.ApiVersion)
@@ -336,6 +370,7 @@ func (o *FcpmV2Region) Redact() {
 	o.recurseRedact(o.Cloud)
 	o.recurseRedact(o.RegionName)
 	o.recurseRedact(o.HttpEndpoint)
+	o.recurseRedact(o.PrivateHttpEndpoint)
 }
 
 func (o *FcpmV2Region) recurseRedact(v interface{}) {
@@ -393,6 +428,9 @@ func (o FcpmV2Region) MarshalJSON() ([]byte, error) {
 	}
 	if o.HttpEndpoint != nil {
 		toSerialize["http_endpoint"] = o.HttpEndpoint
+	}
+	if o.PrivateHttpEndpoint != nil {
+		toSerialize["private_http_endpoint"] = o.PrivateHttpEndpoint
 	}
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)


### PR DESCRIPTION
go vet -v
internal/unsafeheader
internal/itoa
encoding
math/bits
math
unicode/utf16
crypto/internal/alias
crypto/subtle
crypto/internal/boring/sig
vendor/golang.org/x/crypto/cryptobyte/asn1
internal/nettrace
container/list
vendor/golang.org/x/crypto/internal/alias
internal/race
unicode/utf8
sync/atomic
internal/cpu
internal/goarch
internal/goos
unicode
internal/goexperiment
internal/coverage/rtcov
runtime/internal/math
internal/abi
runtime/internal/sys
runtime/internal/atomic
internal/bytealg
runtime
internal/reflectlite
sync
errors
sort
internal/singleflight
path
internal/oserror
internal/testlog
internal/safefilepath
io
internal/godebug
vendor/golang.org/x/net/dns/dnsmessage
crypto/internal/randutil
hash
internal/intern
bytes
math/rand
crypto/internal/nistec/fiat
strings
vendor/golang.org/x/text/transform
hash/crc32
strconv
bufio
net/http/internal/ascii
crypto
crypto/rc4
net/netip
regexp/syntax
reflect
encoding/binary
internal/fmtsort
regexp
encoding/base64
syscall
crypto/md5
encoding/pem
crypto/internal/edwards25519/field
crypto/cipher
internal/syscall/execenv
vendor/golang.org/x/crypto/internal/poly1305
crypto/des
internal/syscall/unix
crypto/internal/boring
vendor/golang.org/x/crypto/chacha20
crypto/internal/edwards25519
time
crypto/hmac
crypto/sha512
crypto/sha256
vendor/golang.org/x/crypto/chacha20poly1305
crypto/sha1
context
vendor/golang.org/x/crypto/hkdf
crypto/aes
crypto/x509/internal/macos
io/fs
embed
internal/poll
crypto/internal/nistec
crypto/ecdh
os
io/ioutil
path/filepath
fmt
net/url
encoding/hex
log
vendor/golang.org/x/net/route
encoding/xml
encoding/json
vendor/golang.org/x/net/http2/hpack
compress/flate
mime/quotedprintable
vendor/golang.org/x/text/unicode/norm
mime
compress/gzip
vendor/golang.org/x/text/unicode/bidi
net/http/internal
math/big
vendor/golang.org/x/text/secure/bidirule
crypto/internal/bigmod
crypto/internal/boring/bbig
crypto/rand
crypto/dsa
vendor/golang.org/x/net/idna
encoding/asn1
crypto/ed25519
crypto/rsa
crypto/elliptic
crypto/x509/pkix
vendor/golang.org/x/crypto/cryptobyte
crypto/ecdsa
net
vendor/golang.org/x/net/http/httpproxy
net/textproto
crypto/x509
mime/multipart
vendor/golang.org/x/net/http/httpguts
crypto/tls
net/http/httptrace
net/http
golang.org/x/net/context/ctxhttp
net/http/httputil
golang.org/x/oauth2/internal
golang.org/x/oauth2
github.com/confluentinc/ccloud-sdk-go-v2-internal/flink/v2