### PR TITLE
SCP-2763-update-flink-artifact-with-runtime_lang-arg

### DIFF
--- a/connect-custom-plugin/go.sum
+++ b/connect-custom-plugin/go.sum
@@ -184,6 +184,7 @@ golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99 h1:5vD4XjIc0X5+kHZjx4UecYdjA6mJo+XXNoaW0EjU5Os=
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558 h1:D7nTwh4J0i+5mW4Zjzn5omvlr6YBcWywE6KOcatyNxY=
 golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/connect-custom-plugin/v1/README.md
+++ b/connect-custom-plugin/v1/README.md
@@ -124,6 +124,34 @@ r, err := client.Service.Operation(auth, args)
 ```
 
 
+### confluent-sts-access-token
+
+
+- **Type**: OAuth
+- **Flow**: application
+- **Authorization URL**: 
+- **Scopes**: N/A
+
+Example
+
+```golang
+auth := context.WithValue(context.Background(), sw.ContextAccessToken, "ACCESSTOKENSTRING")
+r, err := client.Service.Operation(auth, args)
+```
+
+Or via OAuth2 module to automatically refresh tokens and perform user authentication.
+
+```golang
+import "golang.org/x/oauth2"
+
+/* Perform OAuth2 round trip request and obtain a token */
+
+tokenSource := oauth2cfg.TokenSource(createContext(httpClient), &token)
+auth := context.WithValue(oauth2.NoContext, sw.ContextOAuth2, tokenSource)
+r, err := client.Service.Operation(auth, args)
+```
+
+
 ## Documentation for Utility Methods
 
 Due to the fact that model structure members are all pointers, this package contains

--- a/connect-custom-plugin/v1/api/openapi.yaml
+++ b/connect-custom-plugin/v1/api/openapi.yaml
@@ -14,10 +14,6 @@ info:
 servers:
 - description: Confluent Cloud production
   url: https://api.confluent.cloud
-- description: Confluent Cloud staging
-  url: https://api.stag.cpdev.cloud
-- description: Confluent Cloud development
-  url: https://api.devel.cpdev.cloud
 tags:
 - description: |-
     [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)

--- a/connect-custom-plugin/v1/api/openapi.yaml
+++ b/connect-custom-plugin/v1/api/openapi.yaml
@@ -14,6 +14,10 @@ info:
 servers:
 - description: Confluent Cloud production
   url: https://api.confluent.cloud
+- description: Confluent Cloud staging
+  url: https://api.stag.cpdev.cloud
+- description: Confluent Cloud development
+  url: https://api.devel.cpdev.cloud
 tags:
 - description: |-
     [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
@@ -256,6 +260,7 @@ paths:
               style: simple
       security:
       - cloud-api-key: []
+      - confluent-sts-access-token: []
       summary: List of Custom Connector Plugins
       tags:
       - Custom Connector Plugins (connect/v1)
@@ -603,6 +608,7 @@ paths:
               style: simple
       security:
       - cloud-api-key: []
+      - confluent-sts-access-token: []
       summary: Create a Custom Connector Plugin
       tags:
       - Custom Connector Plugins (connect/v1)
@@ -613,13 +619,13 @@ paths:
             --url https://api.confluent.cloud/connect/v1/custom-connector-plugins \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
             --header 'content-type: application/json' \
-            --data '{"display_name":"string","description":"string","documentation_link":"https://github.com/confluentinc/kafka-connect-datagen","connector_class":"io.confluent.kafka.connect.datagen.DatagenConnector","connector_type":"SOURCE","cloud":"AWS","sensitive_config_properties":["passwords","keys","tokens"],"upload_source":{"location":"PRESIGNED_URL_LOCATION","upload_id":"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66"}}'
+            --data '{"display_name":"string","description":"string","documentation_link":"https://github.com/confluentinc/kafka-connect-datagen","connector_class":"io.confluent.kafka.connect.datagen.DatagenConnector","connector_type":"SOURCE","cloud":"AWS","sensitive_config_properties":["passwords","keys","tokens"],"upload_source":{"location":"PRESIGNED_URL_LOCATION","upload_id":"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66"},"runtime_language":"JAVA"}'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           MediaType mediaType = MediaType.parse("application/json");
-          RequestBody body = RequestBody.create(mediaType, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}");
+          RequestBody body = RequestBody.create(mediaType, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\"}");
           Request request = new Request.Builder()
             .url("https://api.confluent.cloud/connect/v1/custom-connector-plugins")
             .post(body)
@@ -637,19 +643,20 @@ paths:
           \",\\\"connector_type\\\":\\\"SOURCE\\\",\\\"cloud\\\":\\\"AWS\\\",\\\"\
           sensitive_config_properties\\\":[\\\"passwords\\\",\\\"keys\\\",\\\"tokens\\\
           \"],\\\"upload_source\\\":{\\\"location\\\":\\\"PRESIGNED_URL_LOCATION\\\
-          \",\\\"upload_id\\\":\\\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\\\"}}\")\n\
-          \n\treq, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"\
-          content-type\", \"application/json\")\n\treq.Header.Add(\"Authorization\"\
-          , \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
-          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
-          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          \",\\\"upload_id\\\":\\\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\\\"},\\\"\
+          runtime_language\\\":\\\"JAVA\\\"}\")\n\n\treq, _ := http.NewRequest(\"\
+          POST\", url, payload)\n\n\treq.Header.Add(\"content-type\", \"application/json\"\
+          )\n\treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\
+          \tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody,\
+          \ _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
+          \n}"
       - lang: Python
         source: |-
           import http.client
 
           conn = http.client.HTTPSConnection("api.confluent.cloud")
 
-          payload = "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}"
+          payload = "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\"}"
 
           headers = {
               'content-type': "application/json",
@@ -701,7 +708,8 @@ paths:
             upload_source: {
               location: 'PRESIGNED_URL_LOCATION',
               upload_id: 'e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66'
-            }
+            },
+            runtime_language: 'JAVA'
           }));
           req.end();
       - lang: C
@@ -716,7 +724,7 @@ paths:
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}");
+          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\"}");
 
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
@@ -725,7 +733,7 @@ paths:
           var request = new RestRequest(Method.POST);
           request.AddHeader("content-type", "application/json");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("application/json", "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}", ParameterType.RequestBody);
+          request.AddParameter("application/json", "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\"}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /connect/v1/custom-connector-plugins/{id}:
     delete:
@@ -931,6 +939,7 @@ paths:
               style: simple
       security:
       - cloud-api-key: []
+      - confluent-sts-access-token: []
       summary: Delete a Custom Connector Plugin
       tags:
       - Custom Connector Plugins (connect/v1)
@@ -938,14 +947,14 @@ paths:
       - lang: Shell
         source: |-
           curl --request DELETE \
-            --url https://api.confluent.cloud/connect/v1/custom-connector-plugins/%7Bid%7D \
+            --url 'https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           Request request = new Request.Builder()
-            .url("https://api.confluent.cloud/connect/v1/custom-connector-plugins/%7Bid%7D")
+            .url("https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}")
             .delete(null)
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
             .build();
@@ -953,7 +962,7 @@ paths:
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io/ioutil\"\
-          \n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/connect/v1/custom-connector-plugins/%7Bid%7D\"\
+          \n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}\"\
           \n\n\treq, _ := http.NewRequest(\"DELETE\", url, nil)\n\n\treq.Header.Add(\"\
           Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
           \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
@@ -966,7 +975,7 @@ paths:
 
           headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
 
-          conn.request("DELETE", "/connect/v1/custom-connector-plugins/%7Bid%7D", headers=headers)
+          conn.request("DELETE", "/connect/v1/custom-connector-plugins/{id}", headers=headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -980,7 +989,7 @@ paths:
             "method": "DELETE",
             "hostname": "api.confluent.cloud",
             "port": null,
-            "path": "/connect/v1/custom-connector-plugins/%7Bid%7D",
+            "path": "/connect/v1/custom-connector-plugins/{id}",
             "headers": {
               "Authorization": "Basic REPLACE_BASIC_AUTH"
             }
@@ -1005,7 +1014,7 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "DELETE");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://api.confluent.cloud/connect/v1/custom-connector-plugins/%7Bid%7D");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
@@ -1014,7 +1023,7 @@ paths:
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://api.confluent.cloud/connect/v1/custom-connector-plugins/%7Bid%7D");
+          var client = new RestClient("https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}");
           var request = new RestRequest(Method.DELETE);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
           IRestResponse response = client.Execute(request);
@@ -1235,6 +1244,7 @@ paths:
               style: simple
       security:
       - cloud-api-key: []
+      - confluent-sts-access-token: []
       summary: Read a Custom Connector Plugin
       tags:
       - Custom Connector Plugins (connect/v1)
@@ -1242,14 +1252,14 @@ paths:
       - lang: Shell
         source: |-
           curl --request GET \
-            --url https://api.confluent.cloud/connect/v1/custom-connector-plugins/%7Bid%7D \
+            --url 'https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           Request request = new Request.Builder()
-            .url("https://api.confluent.cloud/connect/v1/custom-connector-plugins/%7Bid%7D")
+            .url("https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}")
             .get()
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
             .build();
@@ -1257,7 +1267,7 @@ paths:
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io/ioutil\"\
-          \n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/connect/v1/custom-connector-plugins/%7Bid%7D\"\
+          \n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}\"\
           \n\n\treq, _ := http.NewRequest(\"GET\", url, nil)\n\n\treq.Header.Add(\"\
           Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
           \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
@@ -1270,7 +1280,7 @@ paths:
 
           headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
 
-          conn.request("GET", "/connect/v1/custom-connector-plugins/%7Bid%7D", headers=headers)
+          conn.request("GET", "/connect/v1/custom-connector-plugins/{id}", headers=headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -1284,7 +1294,7 @@ paths:
             "method": "GET",
             "hostname": "api.confluent.cloud",
             "port": null,
-            "path": "/connect/v1/custom-connector-plugins/%7Bid%7D",
+            "path": "/connect/v1/custom-connector-plugins/{id}",
             "headers": {
               "Authorization": "Basic REPLACE_BASIC_AUTH"
             }
@@ -1309,7 +1319,7 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "GET");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://api.confluent.cloud/connect/v1/custom-connector-plugins/%7Bid%7D");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
@@ -1318,7 +1328,7 @@ paths:
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://api.confluent.cloud/connect/v1/custom-connector-plugins/%7Bid%7D");
+          var client = new RestClient("https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}");
           var request = new RestRequest(Method.GET);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
           IRestResponse response = client.Execute(request);
@@ -1598,6 +1608,7 @@ paths:
               style: simple
       security:
       - cloud-api-key: []
+      - confluent-sts-access-token: []
       summary: Update a Custom Connector Plugin
       tags:
       - Custom Connector Plugins (connect/v1)
@@ -1605,18 +1616,18 @@ paths:
       - lang: Shell
         source: |-
           curl --request PATCH \
-            --url https://api.confluent.cloud/connect/v1/custom-connector-plugins/%7Bid%7D \
+            --url 'https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
             --header 'content-type: application/json' \
-            --data '{"display_name":"string","description":"string","documentation_link":"https://github.com/confluentinc/kafka-connect-datagen","connector_class":"io.confluent.kafka.connect.datagen.DatagenConnector","connector_type":"SOURCE","cloud":"AWS","sensitive_config_properties":["passwords","keys","tokens"],"upload_source":{"location":"PRESIGNED_URL_LOCATION","upload_id":"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66"}}'
+            --data '{"display_name":"string","description":"string","documentation_link":"https://github.com/confluentinc/kafka-connect-datagen","connector_class":"io.confluent.kafka.connect.datagen.DatagenConnector","connector_type":"SOURCE","cloud":"AWS","sensitive_config_properties":["passwords","keys","tokens"],"upload_source":{"location":"PRESIGNED_URL_LOCATION","upload_id":"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66"},"runtime_language":"JAVA"}'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           MediaType mediaType = MediaType.parse("application/json");
-          RequestBody body = RequestBody.create(mediaType, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}");
+          RequestBody body = RequestBody.create(mediaType, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\"}");
           Request request = new Request.Builder()
-            .url("https://api.confluent.cloud/connect/v1/custom-connector-plugins/%7Bid%7D")
+            .url("https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}")
             .patch(body)
             .addHeader("content-type", "application/json")
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
@@ -1625,33 +1636,34 @@ paths:
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\
-          \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/connect/v1/custom-connector-plugins/%7Bid%7D\"\
+          \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}\"\
           \n\n\tpayload := strings.NewReader(\"{\\\"display_name\\\":\\\"string\\\"\
           ,\\\"description\\\":\\\"string\\\",\\\"documentation_link\\\":\\\"https://github.com/confluentinc/kafka-connect-datagen\\\
           \",\\\"connector_class\\\":\\\"io.confluent.kafka.connect.datagen.DatagenConnector\\\
           \",\\\"connector_type\\\":\\\"SOURCE\\\",\\\"cloud\\\":\\\"AWS\\\",\\\"\
           sensitive_config_properties\\\":[\\\"passwords\\\",\\\"keys\\\",\\\"tokens\\\
           \"],\\\"upload_source\\\":{\\\"location\\\":\\\"PRESIGNED_URL_LOCATION\\\
-          \",\\\"upload_id\\\":\\\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\\\"}}\")\n\
-          \n\treq, _ := http.NewRequest(\"PATCH\", url, payload)\n\n\treq.Header.Add(\"\
-          content-type\", \"application/json\")\n\treq.Header.Add(\"Authorization\"\
-          , \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
-          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
-          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          \",\\\"upload_id\\\":\\\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\\\"},\\\"\
+          runtime_language\\\":\\\"JAVA\\\"}\")\n\n\treq, _ := http.NewRequest(\"\
+          PATCH\", url, payload)\n\n\treq.Header.Add(\"content-type\", \"application/json\"\
+          )\n\treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\
+          \tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody,\
+          \ _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
+          \n}"
       - lang: Python
         source: |-
           import http.client
 
           conn = http.client.HTTPSConnection("api.confluent.cloud")
 
-          payload = "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}"
+          payload = "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\"}"
 
           headers = {
               'content-type': "application/json",
               'Authorization': "Basic REPLACE_BASIC_AUTH"
               }
 
-          conn.request("PATCH", "/connect/v1/custom-connector-plugins/%7Bid%7D", payload, headers)
+          conn.request("PATCH", "/connect/v1/custom-connector-plugins/{id}", payload, headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -1665,7 +1677,7 @@ paths:
             "method": "PATCH",
             "hostname": "api.confluent.cloud",
             "port": null,
-            "path": "/connect/v1/custom-connector-plugins/%7Bid%7D",
+            "path": "/connect/v1/custom-connector-plugins/{id}",
             "headers": {
               "content-type": "application/json",
               "Authorization": "Basic REPLACE_BASIC_AUTH"
@@ -1696,7 +1708,8 @@ paths:
             upload_source: {
               location: 'PRESIGNED_URL_LOCATION',
               upload_id: 'e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66'
-            }
+            },
+            runtime_language: 'JAVA'
           }));
           req.end();
       - lang: C
@@ -1704,23 +1717,23 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "PATCH");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://api.confluent.cloud/connect/v1/custom-connector-plugins/%7Bid%7D");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "content-type: application/json");
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}");
+          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\"}");
 
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://api.confluent.cloud/connect/v1/custom-connector-plugins/%7Bid%7D");
+          var client = new RestClient("https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}");
           var request = new RestRequest(Method.PATCH);
           request.AddHeader("content-type", "application/json");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("application/json", "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}", ParameterType.RequestBody);
+          request.AddParameter("application/json", "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\"}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /connect/v1/presigned-upload-url:
     post:
@@ -2386,6 +2399,15 @@ components:
           - $ref: '#/components/schemas/connect.v1.UploadSource.PresignedUrl'
           type: object
           x-one-of-name: ConnectV1CustomConnectorPluginUploadSourceOneOf
+        runtime_language:
+          default: JAVA
+          description: Runtime language of Custom Connector Plugin.
+          example: JAVA
+          type: string
+          x-extensible-enum:
+          - JAVA
+          - PYTHON
+          x-immutable: true
       type: object
     connect.v1.PresignedUrl:
       description: |-
@@ -2864,3 +2886,11 @@ components:
         Cloud API Key ID as the username and Cloud API Key Secret as the password.
       scheme: basic
       type: http
+    confluent-sts-access-token:
+      description: Authenticate with Confluent API using this credentials (JSON Web
+        Tokens) following OAuth 2.0.
+      flows:
+        clientCredentials:
+          scopes: {}
+          tokenUrl: https://api.confluent.cloud/sts/v1/oauth2/token
+      type: oauth2

--- a/connect-custom-plugin/v1/configuration.go
+++ b/connect-custom-plugin/v1/configuration.go
@@ -123,6 +123,14 @@ func NewConfiguration() *Configuration {
 				URL:         "https://api.confluent.cloud",
 				Description: "Confluent Cloud production",
 			},
+			{
+				URL:         "https://api.stag.cpdev.cloud",
+				Description: "Confluent Cloud staging",
+			},
+			{
+				URL:         "https://api.devel.cpdev.cloud",
+				Description: "Confluent Cloud development",
+			},
 		},
 		OperationServers: map[string]ServerConfigurations{},
 	}

--- a/connect-custom-plugin/v1/configuration.go
+++ b/connect-custom-plugin/v1/configuration.go
@@ -123,14 +123,6 @@ func NewConfiguration() *Configuration {
 				URL:         "https://api.confluent.cloud",
 				Description: "Confluent Cloud production",
 			},
-			{
-				URL:         "https://api.stag.cpdev.cloud",
-				Description: "Confluent Cloud staging",
-			},
-			{
-				URL:         "https://api.devel.cpdev.cloud",
-				Description: "Confluent Cloud development",
-			},
 		},
 		OperationServers: map[string]ServerConfigurations{},
 	}

--- a/connect-custom-plugin/v1/docs/ConnectV1CustomConnectorPlugin.md
+++ b/connect-custom-plugin/v1/docs/ConnectV1CustomConnectorPlugin.md
@@ -17,6 +17,7 @@ Name | Type | Description | Notes
 **Cloud** | Pointer to **string** | Cloud provider where the Custom Connector Plugin archive is uploaded. | [optional] [default to "AWS"]
 **SensitiveConfigProperties** | Pointer to **[]string** | A sensitive property is a connector configuration property that must be hidden after a user enters property value when setting up connector. | [optional] 
 **UploadSource** | Pointer to [**ConnectV1CustomConnectorPluginUploadSourceOneOf**](ConnectV1CustomConnectorPluginUploadSourceOneOf.md) | [immutable] Upload source of Custom Connector Plugin. Only required in &#x60;create&#x60; request, will be ignored in &#x60;read&#x60;, &#x60;update&#x60; or &#x60;list&#x60;. | [optional] 
+**RuntimeLanguage** | Pointer to **string** | Runtime language of Custom Connector Plugin. | [optional] [default to "JAVA"]
 
 ## Methods
 
@@ -361,6 +362,31 @@ SetUploadSource sets UploadSource field to given value.
 `func (o *ConnectV1CustomConnectorPlugin) HasUploadSource() bool`
 
 HasUploadSource returns a boolean if a field has been set.
+
+### GetRuntimeLanguage
+
+`func (o *ConnectV1CustomConnectorPlugin) GetRuntimeLanguage() string`
+
+GetRuntimeLanguage returns the RuntimeLanguage field if non-nil, zero value otherwise.
+
+### GetRuntimeLanguageOk
+
+`func (o *ConnectV1CustomConnectorPlugin) GetRuntimeLanguageOk() (*string, bool)`
+
+GetRuntimeLanguageOk returns a tuple with the RuntimeLanguage field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetRuntimeLanguage
+
+`func (o *ConnectV1CustomConnectorPlugin) SetRuntimeLanguage(v string)`
+
+SetRuntimeLanguage sets RuntimeLanguage field to given value.
+
+### HasRuntimeLanguage
+
+`func (o *ConnectV1CustomConnectorPlugin) HasRuntimeLanguage() bool`
+
+HasRuntimeLanguage returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/connect-custom-plugin/v1/docs/CustomConnectorPluginsConnectV1Api.md
+++ b/connect-custom-plugin/v1/docs/CustomConnectorPluginsConnectV1Api.md
@@ -66,7 +66,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[cloud-api-key](../README.md#cloud-api-key)
+[cloud-api-key](../README.md#cloud-api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
 
 ### HTTP request headers
 
@@ -134,7 +134,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[cloud-api-key](../README.md#cloud-api-key)
+[cloud-api-key](../README.md#cloud-api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
 
 ### HTTP request headers
 
@@ -204,7 +204,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[cloud-api-key](../README.md#cloud-api-key)
+[cloud-api-key](../README.md#cloud-api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
 
 ### HTTP request headers
 
@@ -274,7 +274,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[cloud-api-key](../README.md#cloud-api-key)
+[cloud-api-key](../README.md#cloud-api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
 
 ### HTTP request headers
 
@@ -346,7 +346,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[cloud-api-key](../README.md#cloud-api-key)
+[cloud-api-key](../README.md#cloud-api-key), [confluent-sts-access-token](../README.md#confluent-sts-access-token)
 
 ### HTTP request headers
 

--- a/connect-custom-plugin/v1/model_connect_v1_custom_connector_plugin.go
+++ b/connect-custom-plugin/v1/model_connect_v1_custom_connector_plugin.go
@@ -61,6 +61,8 @@ type ConnectV1CustomConnectorPlugin struct {
 	SensitiveConfigProperties *[]string `json:"sensitive_config_properties,omitempty"`
 	// [immutable] Upload source of Custom Connector Plugin. Only required in `create` request, will be ignored in `read`, `update` or `list`.
 	UploadSource *ConnectV1CustomConnectorPluginUploadSourceOneOf `json:"upload_source,omitempty"`
+	// Runtime language of Custom Connector Plugin.
+	RuntimeLanguage *string `json:"runtime_language,omitempty"`
 }
 
 // NewConnectV1CustomConnectorPlugin instantiates a new ConnectV1CustomConnectorPlugin object
@@ -71,6 +73,8 @@ func NewConnectV1CustomConnectorPlugin() *ConnectV1CustomConnectorPlugin {
 	this := ConnectV1CustomConnectorPlugin{}
 	var cloud string = "AWS"
 	this.Cloud = &cloud
+	var runtimeLanguage string = "JAVA"
+	this.RuntimeLanguage = &runtimeLanguage
 	return &this
 }
 
@@ -81,6 +85,8 @@ func NewConnectV1CustomConnectorPluginWithDefaults() *ConnectV1CustomConnectorPl
 	this := ConnectV1CustomConnectorPlugin{}
 	var cloud string = "AWS"
 	this.Cloud = &cloud
+	var runtimeLanguage string = "JAVA"
+	this.RuntimeLanguage = &runtimeLanguage
 	return &this
 }
 
@@ -500,6 +506,38 @@ func (o *ConnectV1CustomConnectorPlugin) SetUploadSource(v ConnectV1CustomConnec
 	o.UploadSource = &v
 }
 
+// GetRuntimeLanguage returns the RuntimeLanguage field value if set, zero value otherwise.
+func (o *ConnectV1CustomConnectorPlugin) GetRuntimeLanguage() string {
+	if o == nil || o.RuntimeLanguage == nil {
+		var ret string
+		return ret
+	}
+	return *o.RuntimeLanguage
+}
+
+// GetRuntimeLanguageOk returns a tuple with the RuntimeLanguage field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ConnectV1CustomConnectorPlugin) GetRuntimeLanguageOk() (*string, bool) {
+	if o == nil || o.RuntimeLanguage == nil {
+		return nil, false
+	}
+	return o.RuntimeLanguage, true
+}
+
+// HasRuntimeLanguage returns a boolean if a field has been set.
+func (o *ConnectV1CustomConnectorPlugin) HasRuntimeLanguage() bool {
+	if o != nil && o.RuntimeLanguage != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetRuntimeLanguage gets a reference to the given string and assigns it to the RuntimeLanguage field.
+func (o *ConnectV1CustomConnectorPlugin) SetRuntimeLanguage(v string) {
+	o.RuntimeLanguage = &v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *ConnectV1CustomConnectorPlugin) Redact() {
 	o.recurseRedact(o.ApiVersion)
@@ -515,6 +553,7 @@ func (o *ConnectV1CustomConnectorPlugin) Redact() {
 	o.recurseRedact(o.Cloud)
 	o.recurseRedact(o.SensitiveConfigProperties)
 	o.recurseRedact(o.UploadSource)
+	o.recurseRedact(o.RuntimeLanguage)
 }
 
 func (o *ConnectV1CustomConnectorPlugin) recurseRedact(v interface{}) {
@@ -587,6 +626,9 @@ func (o ConnectV1CustomConnectorPlugin) MarshalJSON() ([]byte, error) {
 	}
 	if o.UploadSource != nil {
 		toSerialize["upload_source"] = o.UploadSource
+	}
+	if o.RuntimeLanguage != nil {
+		toSerialize["runtime_language"] = o.RuntimeLanguage
 	}
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)


### PR DESCRIPTION
API change: https://github.com/confluentinc/api/pull/1584
ccloud-sdk-go-v2-internal change: https://github.com/confluentinc/ccloud-sdk-go-v2-internal/pull/413
new release: https://github.com/confluentinc/ccloud-sdk-go-v2-internal/releases/tag/connect-custom-plugin%2Fv0.0.3

```
% go vet -v
internal/goexperiment
unicode/utf8
internal/itoa
encoding
math/bits
math
unicode/utf16
crypto/internal/alias
crypto/subtle
crypto/internal/boring/sig
vendor/golang.org/x/crypto/cryptobyte/asn1
internal/nettrace
container/list
vendor/golang.org/x/crypto/internal/alias
log/internal
internal/goos
internal/godebugs
internal/unsafeheader
internal/goarch
internal/race
internal/coverage/rtcov
sync/atomic
unicode
internal/cpu
runtime/internal/math
runtime/internal/sys
internal/abi
runtime/internal/atomic
internal/bytealg
runtime
internal/reflectlite
sync
errors
internal/testlog
internal/singleflight
sort
internal/bisect
internal/safefilepath
io
internal/oserror
internal/godebug
path
vendor/golang.org/x/net/dns/dnsmessage
crypto/internal/randutil
strconv
hash
internal/intern
bytes
crypto/internal/nistec/fiat
math/rand
strings
crypto
crypto/rc4
net/netip
hash/crc32
vendor/golang.org/x/text/transform
bufio
net/http/internal/ascii
reflect
regexp/syntax
encoding/binary
internal/fmtsort
syscall
regexp
encoding/base64
internal/syscall/execenv
crypto/md5
crypto/cipher
vendor/golang.org/x/crypto/internal/poly1305
crypto/internal/edwards25519/field
encoding/pem
time
internal/syscall/unix
vendor/golang.org/x/crypto/chacha20
crypto/des
crypto/internal/boring
crypto/internal/edwards25519
context
crypto/x509/internal/macos
io/fs
crypto/sha256
crypto/sha512
crypto/sha1
crypto/hmac
vendor/golang.org/x/crypto/chacha20poly1305
crypto/aes
internal/poll
embed
vendor/golang.org/x/crypto/hkdf
crypto/internal/nistec
crypto/ecdh
os
io/ioutil
fmt
path/filepath
encoding/hex
vendor/golang.org/x/net/route
net/url
log
encoding/xml
compress/flate
encoding/json
vendor/golang.org/x/net/http2/hpack
mime/quotedprintable
mime
vendor/golang.org/x/text/unicode/norm
compress/gzip
net/http/internal
vendor/golang.org/x/text/unicode/bidi
math/big
vendor/golang.org/x/text/secure/bidirule
crypto/internal/bigmod
crypto/internal/boring/bbig
crypto/dsa
crypto/rand
crypto/elliptic
encoding/asn1
crypto/rsa
crypto/ed25519
vendor/golang.org/x/net/idna
crypto/x509/pkix
vendor/golang.org/x/crypto/cryptobyte
crypto/ecdsa
runtime/cgo
net
vendor/golang.org/x/net/http/httpproxy
net/textproto
crypto/x509
vendor/golang.org/x/net/http/httpguts
mime/multipart
crypto/tls
net/http/httptrace
net/http
net/http/httputil
golang.org/x/net/context/ctxhttp
golang.org/x/oauth2/internal
golang.org/x/oauth2
github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin/v1
```