### PR TITLE
SCP-2763 implement-custom-connect-plugin-getPresignedUrl-with-runtime-language

### DIFF
--- a/connect-custom-plugin/v1/api/openapi.yaml
+++ b/connect-custom-plugin/v1/api/openapi.yaml
@@ -1955,13 +1955,13 @@ paths:
             --url https://api.confluent.cloud/connect/v1/presigned-upload-url \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
             --header 'content-type: application/json' \
-            --data '{"content_format":"ZIP","cloud":"AWS"}'
+            --data '{"content_format":"ZIP","cloud":"AWS","runtime_language":"JAVA"}'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           MediaType mediaType = MediaType.parse("application/json");
-          RequestBody body = RequestBody.create(mediaType, "{\"content_format\":\"ZIP\",\"cloud\":\"AWS\"}");
+          RequestBody body = RequestBody.create(mediaType, "{\"content_format\":\"ZIP\",\"cloud\":\"AWS\",\"runtime_language\":\"JAVA\"}");
           Request request = new Request.Builder()
             .url("https://api.confluent.cloud/connect/v1/presigned-upload-url")
             .post(body)
@@ -1974,19 +1974,19 @@ paths:
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\
           \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/connect/v1/presigned-upload-url\"\
           \n\n\tpayload := strings.NewReader(\"{\\\"content_format\\\":\\\"ZIP\\\"\
-          ,\\\"cloud\\\":\\\"AWS\\\"}\")\n\n\treq, _ := http.NewRequest(\"POST\",\
-          \ url, payload)\n\n\treq.Header.Add(\"content-type\", \"application/json\"\
-          )\n\treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\
-          \tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody,\
-          \ _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
-          \n}"
+          ,\\\"cloud\\\":\\\"AWS\\\",\\\"runtime_language\\\":\\\"JAVA\\\"}\")\n\n\
+          \treq, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"\
+          content-type\", \"application/json\")\n\treq.Header.Add(\"Authorization\"\
+          , \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
+          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
+          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
       - lang: Python
         source: |-
           import http.client
 
           conn = http.client.HTTPSConnection("api.confluent.cloud")
 
-          payload = "{\"content_format\":\"ZIP\",\"cloud\":\"AWS\"}"
+          payload = "{\"content_format\":\"ZIP\",\"cloud\":\"AWS\",\"runtime_language\":\"JAVA\"}"
 
           headers = {
               'content-type': "application/json",
@@ -2027,7 +2027,7 @@ paths:
             });
           });
 
-          req.write(JSON.stringify({content_format: 'ZIP', cloud: 'AWS'}));
+          req.write(JSON.stringify({content_format: 'ZIP', cloud: 'AWS', runtime_language: 'JAVA'}));
           req.end();
       - lang: C
         source: |-
@@ -2041,7 +2041,7 @@ paths:
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"content_format\":\"ZIP\",\"cloud\":\"AWS\"}");
+          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"content_format\":\"ZIP\",\"cloud\":\"AWS\",\"runtime_language\":\"JAVA\"}");
 
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
@@ -2050,7 +2050,7 @@ paths:
           var request = new RestRequest(Method.POST);
           request.AddHeader("content-type", "application/json");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("application/json", "{\"content_format\":\"ZIP\",\"cloud\":\"AWS\"}", ParameterType.RequestBody);
+          request.AddParameter("application/json", "{\"content_format\":\"ZIP\",\"cloud\":\"AWS\",\"runtime_language\":\"JAVA\"}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
 components:
   responses:
@@ -2449,6 +2449,14 @@ components:
           - AWS
           - GCP
           - AZURE
+        runtime_language:
+          description: Runtime language of Custom Connector Plugin.
+          example: JAVA
+          readOnly: true
+          type: string
+          x-extensible-enum:
+          - JAVA
+          - PYTHON
         upload_id:
           description: Unique identifier of this upload.
           example: e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66
@@ -2527,6 +2535,14 @@ components:
           - AWS
           - GCP
           - AZURE
+        runtime_language:
+          default: JAVA
+          description: Runtime language of Custom Connector Plugin.
+          example: JAVA
+          type: string
+          x-extensible-enum:
+          - JAVA
+          - PYTHON
       type: object
     connect.v1.UploadSource.PresignedUrl:
       description: Presigned URL of the uploaded Custom Connector Plugin archive.

--- a/connect-custom-plugin/v1/docs/ConnectV1PresignedUrl.md
+++ b/connect-custom-plugin/v1/docs/ConnectV1PresignedUrl.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 **Kind** | Pointer to **string** | Kind defines the object this REST resource represents. | [optional] [readonly] 
 **ContentFormat** | Pointer to **string** | Content format of the Custom Connector Plugin archive. | [optional] [readonly] 
 **Cloud** | Pointer to **string** | Cloud provider where the Custom Connector Plugin archive is uploaded. | [optional] [readonly] 
+**RuntimeLanguage** | Pointer to **string** | Runtime language of Custom Connector Plugin. | [optional] [readonly] 
 **UploadId** | Pointer to **string** | Unique identifier of this upload. | [optional] [readonly] 
 **UploadUrl** | Pointer to **string** | Upload URL for the Custom Connector Plugin archive. | [optional] [readonly] 
 **UploadFormData** | Pointer to **map[string]interface{}** | Upload form data of the Custom Connector Plugin. All values should be strings. | [optional] [readonly] 
@@ -130,6 +131,31 @@ SetCloud sets Cloud field to given value.
 `func (o *ConnectV1PresignedUrl) HasCloud() bool`
 
 HasCloud returns a boolean if a field has been set.
+
+### GetRuntimeLanguage
+
+`func (o *ConnectV1PresignedUrl) GetRuntimeLanguage() string`
+
+GetRuntimeLanguage returns the RuntimeLanguage field if non-nil, zero value otherwise.
+
+### GetRuntimeLanguageOk
+
+`func (o *ConnectV1PresignedUrl) GetRuntimeLanguageOk() (*string, bool)`
+
+GetRuntimeLanguageOk returns a tuple with the RuntimeLanguage field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetRuntimeLanguage
+
+`func (o *ConnectV1PresignedUrl) SetRuntimeLanguage(v string)`
+
+SetRuntimeLanguage sets RuntimeLanguage field to given value.
+
+### HasRuntimeLanguage
+
+`func (o *ConnectV1PresignedUrl) HasRuntimeLanguage() bool`
+
+HasRuntimeLanguage returns a boolean if a field has been set.
 
 ### GetUploadId
 

--- a/connect-custom-plugin/v1/docs/ConnectV1PresignedUrlRequest.md
+++ b/connect-custom-plugin/v1/docs/ConnectV1PresignedUrlRequest.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **Metadata** | Pointer to [**ObjectMeta**](ObjectMeta.md) |  | [optional] 
 **ContentFormat** | Pointer to **string** | Archive format of the Custom Connector Plugin. | [optional] 
 **Cloud** | Pointer to **string** | Cloud provider where the Custom Connector Plugin archive is uploaded. | [optional] [default to "AWS"]
+**RuntimeLanguage** | Pointer to **string** | Runtime language of Custom Connector Plugin. | [optional] [default to "JAVA"]
 
 ## Methods
 
@@ -179,6 +180,31 @@ SetCloud sets Cloud field to given value.
 `func (o *ConnectV1PresignedUrlRequest) HasCloud() bool`
 
 HasCloud returns a boolean if a field has been set.
+
+### GetRuntimeLanguage
+
+`func (o *ConnectV1PresignedUrlRequest) GetRuntimeLanguage() string`
+
+GetRuntimeLanguage returns the RuntimeLanguage field if non-nil, zero value otherwise.
+
+### GetRuntimeLanguageOk
+
+`func (o *ConnectV1PresignedUrlRequest) GetRuntimeLanguageOk() (*string, bool)`
+
+GetRuntimeLanguageOk returns a tuple with the RuntimeLanguage field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetRuntimeLanguage
+
+`func (o *ConnectV1PresignedUrlRequest) SetRuntimeLanguage(v string)`
+
+SetRuntimeLanguage sets RuntimeLanguage field to given value.
+
+### HasRuntimeLanguage
+
+`func (o *ConnectV1PresignedUrlRequest) HasRuntimeLanguage() bool`
+
+HasRuntimeLanguage returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/connect-custom-plugin/v1/model_connect_v1_presigned_url.go
+++ b/connect-custom-plugin/v1/model_connect_v1_presigned_url.go
@@ -44,6 +44,8 @@ type ConnectV1PresignedUrl struct {
 	ContentFormat *string `json:"content_format,omitempty"`
 	// Cloud provider where the Custom Connector Plugin archive is uploaded.
 	Cloud *string `json:"cloud,omitempty"`
+	// Runtime language of Custom Connector Plugin.
+	RuntimeLanguage *string `json:"runtime_language,omitempty"`
 	// Unique identifier of this upload.
 	UploadId *string `json:"upload_id,omitempty"`
 	// Upload URL for the Custom Connector Plugin archive.
@@ -197,6 +199,38 @@ func (o *ConnectV1PresignedUrl) SetCloud(v string) {
 	o.Cloud = &v
 }
 
+// GetRuntimeLanguage returns the RuntimeLanguage field value if set, zero value otherwise.
+func (o *ConnectV1PresignedUrl) GetRuntimeLanguage() string {
+	if o == nil || o.RuntimeLanguage == nil {
+		var ret string
+		return ret
+	}
+	return *o.RuntimeLanguage
+}
+
+// GetRuntimeLanguageOk returns a tuple with the RuntimeLanguage field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ConnectV1PresignedUrl) GetRuntimeLanguageOk() (*string, bool) {
+	if o == nil || o.RuntimeLanguage == nil {
+		return nil, false
+	}
+	return o.RuntimeLanguage, true
+}
+
+// HasRuntimeLanguage returns a boolean if a field has been set.
+func (o *ConnectV1PresignedUrl) HasRuntimeLanguage() bool {
+	if o != nil && o.RuntimeLanguage != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetRuntimeLanguage gets a reference to the given string and assigns it to the RuntimeLanguage field.
+func (o *ConnectV1PresignedUrl) SetRuntimeLanguage(v string) {
+	o.RuntimeLanguage = &v
+}
+
 // GetUploadId returns the UploadId field value if set, zero value otherwise.
 func (o *ConnectV1PresignedUrl) GetUploadId() string {
 	if o == nil || o.UploadId == nil {
@@ -299,6 +333,7 @@ func (o *ConnectV1PresignedUrl) Redact() {
 	o.recurseRedact(o.Kind)
 	o.recurseRedact(o.ContentFormat)
 	o.recurseRedact(o.Cloud)
+	o.recurseRedact(o.RuntimeLanguage)
 	o.recurseRedact(o.UploadId)
 	o.recurseRedact(o.UploadUrl)
 	o.recurseRedact(o.UploadFormData)
@@ -347,6 +382,9 @@ func (o ConnectV1PresignedUrl) MarshalJSON() ([]byte, error) {
 	}
 	if o.Cloud != nil {
 		toSerialize["cloud"] = o.Cloud
+	}
+	if o.RuntimeLanguage != nil {
+		toSerialize["runtime_language"] = o.RuntimeLanguage
 	}
 	if o.UploadId != nil {
 		toSerialize["upload_id"] = o.UploadId

--- a/connect-custom-plugin/v1/model_connect_v1_presigned_url_request.go
+++ b/connect-custom-plugin/v1/model_connect_v1_presigned_url_request.go
@@ -47,6 +47,8 @@ type ConnectV1PresignedUrlRequest struct {
 	ContentFormat *string `json:"content_format,omitempty"`
 	// Cloud provider where the Custom Connector Plugin archive is uploaded.
 	Cloud *string `json:"cloud,omitempty"`
+	// Runtime language of Custom Connector Plugin.
+	RuntimeLanguage *string `json:"runtime_language,omitempty"`
 }
 
 // NewConnectV1PresignedUrlRequest instantiates a new ConnectV1PresignedUrlRequest object
@@ -57,6 +59,8 @@ func NewConnectV1PresignedUrlRequest() *ConnectV1PresignedUrlRequest {
 	this := ConnectV1PresignedUrlRequest{}
 	var cloud string = "AWS"
 	this.Cloud = &cloud
+	var runtimeLanguage string = "JAVA"
+	this.RuntimeLanguage = &runtimeLanguage
 	return &this
 }
 
@@ -67,6 +71,8 @@ func NewConnectV1PresignedUrlRequestWithDefaults() *ConnectV1PresignedUrlRequest
 	this := ConnectV1PresignedUrlRequest{}
 	var cloud string = "AWS"
 	this.Cloud = &cloud
+	var runtimeLanguage string = "JAVA"
+	this.RuntimeLanguage = &runtimeLanguage
 	return &this
 }
 
@@ -262,6 +268,38 @@ func (o *ConnectV1PresignedUrlRequest) SetCloud(v string) {
 	o.Cloud = &v
 }
 
+// GetRuntimeLanguage returns the RuntimeLanguage field value if set, zero value otherwise.
+func (o *ConnectV1PresignedUrlRequest) GetRuntimeLanguage() string {
+	if o == nil || o.RuntimeLanguage == nil {
+		var ret string
+		return ret
+	}
+	return *o.RuntimeLanguage
+}
+
+// GetRuntimeLanguageOk returns a tuple with the RuntimeLanguage field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ConnectV1PresignedUrlRequest) GetRuntimeLanguageOk() (*string, bool) {
+	if o == nil || o.RuntimeLanguage == nil {
+		return nil, false
+	}
+	return o.RuntimeLanguage, true
+}
+
+// HasRuntimeLanguage returns a boolean if a field has been set.
+func (o *ConnectV1PresignedUrlRequest) HasRuntimeLanguage() bool {
+	if o != nil && o.RuntimeLanguage != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetRuntimeLanguage gets a reference to the given string and assigns it to the RuntimeLanguage field.
+func (o *ConnectV1PresignedUrlRequest) SetRuntimeLanguage(v string) {
+	o.RuntimeLanguage = &v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *ConnectV1PresignedUrlRequest) Redact() {
 	o.recurseRedact(o.ApiVersion)
@@ -270,6 +308,7 @@ func (o *ConnectV1PresignedUrlRequest) Redact() {
 	o.recurseRedact(o.Metadata)
 	o.recurseRedact(o.ContentFormat)
 	o.recurseRedact(o.Cloud)
+	o.recurseRedact(o.RuntimeLanguage)
 }
 
 func (o *ConnectV1PresignedUrlRequest) recurseRedact(v interface{}) {
@@ -321,6 +360,9 @@ func (o ConnectV1PresignedUrlRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.Cloud != nil {
 		toSerialize["cloud"] = o.Cloud
+	}
+	if o.RuntimeLanguage != nil {
+		toSerialize["runtime_language"] = o.RuntimeLanguage
 	}
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)


### PR DESCRIPTION
API change: https://github.com/confluentinc/api/pull/1585
ccould-sdk-go-v2-internal: https://github.com/confluentinc/ccloud-sdk-go-v2-internal/pull/414
```
% go vet -v
unicode
unicode/utf8
internal/itoa
encoding
math/bits
math
unicode/utf16
crypto/internal/alias
crypto/subtle
crypto/internal/boring/sig
vendor/golang.org/x/crypto/cryptobyte/asn1
internal/nettrace
container/list
vendor/golang.org/x/crypto/internal/alias
log/internal
internal/godebugs
internal/unsafeheader
internal/goarch
internal/coverage/rtcov
internal/race
sync/atomic
internal/cpu
internal/goos
runtime/internal/math
runtime/internal/sys
internal/goexperiment
internal/abi
runtime/internal/atomic
internal/bytealg
runtime
sync
internal/reflectlite
errors
internal/bisect
internal/singleflight
internal/testlog
sort
path
internal/oserror
internal/godebug
internal/safefilepath
io
vendor/golang.org/x/net/dns/dnsmessage
crypto/internal/randutil
hash
internal/intern
strconv
math/rand
bytes
crypto/internal/nistec/fiat
strings
crypto
crypto/rc4
hash/crc32
vendor/golang.org/x/text/transform
net/netip
net/http/internal/ascii
bufio
reflect
regexp/syntax
syscall
internal/fmtsort
encoding/binary
internal/syscall/execenv
regexp
encoding/base64
time
crypto/md5
crypto/internal/edwards25519/field
vendor/golang.org/x/crypto/internal/poly1305
internal/syscall/unix
encoding/pem
crypto/cipher
context
crypto/x509/internal/macos
io/fs
crypto/des
vendor/golang.org/x/crypto/chacha20
crypto/internal/boring
crypto/internal/edwards25519
embed
internal/poll
vendor/golang.org/x/crypto/chacha20poly1305
crypto/hmac
crypto/sha512
crypto/sha1
crypto/sha256
crypto/aes
vendor/golang.org/x/crypto/hkdf
crypto/internal/nistec
crypto/ecdh
os
io/ioutil
path/filepath
fmt
vendor/golang.org/x/net/route
encoding/hex
net/url
log
encoding/xml
encoding/json
compress/flate
vendor/golang.org/x/net/http2/hpack
mime/quotedprintable
mime
vendor/golang.org/x/text/unicode/norm
net/http/internal
compress/gzip
vendor/golang.org/x/text/unicode/bidi
math/big
vendor/golang.org/x/text/secure/bidirule
crypto/internal/boring/bbig
crypto/internal/bigmod
crypto/dsa
crypto/elliptic
crypto/rand
encoding/asn1
vendor/golang.org/x/net/idna
crypto/ed25519
crypto/x509/pkix
crypto/rsa
vendor/golang.org/x/crypto/cryptobyte
crypto/ecdsa
runtime/cgo
net
vendor/golang.org/x/net/http/httpproxy
net/textproto
vendor/golang.org/x/net/http/httpguts
crypto/x509
mime/multipart
crypto/tls
net/http/httptrace
net/http
golang.org/x/net/context/ctxhttp
net/http/httputil
golang.org/x/oauth2/internal
golang.org/x/oauth2
github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin/v1
```