### PR TITLE
Avoid generating the tag if changes are from root folder (#6)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ IMPACTED_FOLDER_NAME := $(shell \
         folder=$$(echo "$$path" | grep "/" | cut -d'/' -f1 | uniq | head -n1); \
         echo $$folder; \
     else \
-        echo ROOT_FOLDER; \
+        echo $(ROOT_FOLDER); \
     fi \
 )
 


### PR DESCRIPTION
Fix a bug in Makefile to avoid generating the tag if changes are from root folder.