### PR TITLE
Update networking-access-point SDK (#4)

### DIFF
--- a/networking-access-point/v1/api/openapi.yaml
+++ b/networking-access-point/v1/api/openapi.yaml
@@ -26,7 +26,7 @@ tags:
     <SchemaDefinition schemaRef="#/components/schemas/networking.v1.AccessPoint" />
   name: Access Points (networking/v1)
 - description: |-
-    [![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Networking v1](https://img.shields.io/badge/-Request%20Access%20To%20Networking%20v1-%23bc8540)](mailto:ccloud-api-access+networking-v1-early-access@confluent.io?subject=Request%20to%20join%20networking/v1%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Early%20Access%20for%20networking/v1%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+    [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
     DNS record objects are associated with Confluent Cloud networking resources. This API allows you to list, create, read, update, and delete your DNS records.
 
@@ -1865,7 +1865,7 @@ paths:
   /networking/v1/dns-records:
     get:
       description: |-
-        [![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Networking v1](https://img.shields.io/badge/-Request%20Access%20To%20Networking%20v1-%23bc8540)](mailto:ccloud-api-access+networking-v1-early-access@confluent.io?subject=Request%20to%20join%20networking/v1%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Early%20Access%20for%20networking/v1%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Retrieve a sorted, filtered, paginated list of all DNS records.
       operationId: listNetworkingV1DnsRecords
@@ -2145,7 +2145,6 @@ paths:
       summary: List of DNS Records
       tags:
       - DNS Records (networking/v1)
-      x-request-access-name: Networking v1
       x-codeSamples:
       - lang: Shell
         source: |-
@@ -2232,7 +2231,7 @@ paths:
           IRestResponse response = client.Execute(request);
     post:
       description: |-
-        [![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Networking v1](https://img.shields.io/badge/-Request%20Access%20To%20Networking%20v1-%23bc8540)](mailto:ccloud-api-access+networking-v1-early-access@confluent.io?subject=Request%20to%20join%20networking/v1%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Early%20Access%20for%20networking/v1%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Make a request to create a DNS record.
       operationId: createNetworkingV1DnsRecord
@@ -2531,7 +2530,6 @@ paths:
       summary: Create a DNS Record
       tags:
       - DNS Records (networking/v1)
-      x-request-access-name: Networking v1
       x-codeSamples:
       - lang: Shell
         source: |-
@@ -2647,11 +2645,10 @@ paths:
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
           request.AddParameter("application/json", "{\"spec\":{\"display_name\":\"prod-dnsrec-1\",\"domain\":\"example.com\",\"config\":{\"kind\":\"PrivateLinkAccessPoint\",\"resource_id\":\"ap-12345\"},\"environment\":{\"id\":\"env-00000\",\"environment\":\"string\"},\"gateway\":{\"id\":\"gw-00000\",\"environment\":\"string\"}}}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
-    x-request-access-name: Networking v1
   /networking/v1/dns-records/{id}:
     delete:
       description: |-
-        [![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Networking v1](https://img.shields.io/badge/-Request%20Access%20To%20Networking%20v1-%23bc8540)](mailto:ccloud-api-access+networking-v1-early-access@confluent.io?subject=Request%20to%20join%20networking/v1%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Early%20Access%20for%20networking/v1%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Make a request to delete a DNS record.
       operationId: deleteNetworkingV1DnsRecord
@@ -2865,7 +2862,6 @@ paths:
       summary: Delete a DNS Record
       tags:
       - DNS Records (networking/v1)
-      x-request-access-name: Networking v1
       x-codeSamples:
       - lang: Shell
         source: |-
@@ -2952,7 +2948,7 @@ paths:
           IRestResponse response = client.Execute(request);
     get:
       description: |-
-        [![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Networking v1](https://img.shields.io/badge/-Request%20Access%20To%20Networking%20v1-%23bc8540)](mailto:ccloud-api-access+networking-v1-early-access@confluent.io?subject=Request%20to%20join%20networking/v1%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Early%20Access%20for%20networking/v1%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Make a request to read a DNS record.
       operationId: getNetworkingV1DnsRecord
@@ -3201,7 +3197,6 @@ paths:
       summary: Read a DNS Record
       tags:
       - DNS Records (networking/v1)
-      x-request-access-name: Networking v1
       x-codeSamples:
       - lang: Shell
         source: |-
@@ -3288,7 +3283,7 @@ paths:
           IRestResponse response = client.Execute(request);
     patch:
       description: |+
-        [![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Networking v1](https://img.shields.io/badge/-Request%20Access%20To%20Networking%20v1-%23bc8540)](mailto:ccloud-api-access+networking-v1-early-access@confluent.io?subject=Request%20to%20join%20networking/v1%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Early%20Access%20for%20networking/v1%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Make a request to update a DNS record.
 
@@ -3600,7 +3595,6 @@ paths:
       summary: Update a DNS Record
       tags:
       - DNS Records (networking/v1)
-      x-request-access-name: Networking v1
       x-codeSamples:
       - lang: Shell
         source: |-
@@ -3716,7 +3710,6 @@ paths:
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
           request.AddParameter("application/json", "{\"spec\":{\"display_name\":\"prod-dnsrec-1\",\"domain\":\"example.com\",\"config\":{\"kind\":\"PrivateLinkAccessPoint\",\"resource_id\":\"ap-12345\"},\"environment\":{\"id\":\"env-00000\",\"environment\":\"string\"},\"gateway\":{\"id\":\"string\",\"environment\":\"string\"}}}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
-    x-request-access-name: Networking v1
 components:
   responses:
     BadRequestError:
@@ -4005,6 +3998,8 @@ components:
               FAILED: Access point is in a failed state;
 
               DEPROVISIONING: Access point deprovisioning is in progress;
+
+              DISCONNECTED: Access Point has been disconnected in the cloud provider by the customer;
           example: READY
           readOnly: true
           type: string
@@ -4014,6 +4009,7 @@ components:
           - READY
           - FAILED
           - DEPROVISIONING
+          - DISCONNECTED
         error_code:
           description: Error code if access point is in a failed state. May be used
             for programmatic error checking.
@@ -4220,6 +4216,16 @@ components:
           example: 10.2.0.68
           readOnly: true
           type: string
+        private_endpoint_custom_dns_config_domains:
+          description: Domains of the Private Endpoint (if any) based off FQDNs in
+            Azure custom DNS configs, which are required in your private DNS setup.
+          example:
+          - dbname.database.windows.net
+          - dbname-region.database.windows.net
+          items:
+            type: string
+          readOnly: true
+          type: array
       required:
       - kind
       - private_endpoint_ip_address

--- a/networking-access-point/v1/api_dns_records_networking_v1.go
+++ b/networking-access-point/v1/api_dns_records_networking_v1.go
@@ -45,7 +45,7 @@ type DNSRecordsNetworkingV1Api interface {
 	/*
 			CreateNetworkingV1DnsRecord Create a DNS Record
 
-			[![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Networking v1](https://img.shields.io/badge/-Request%20Access%20To%20Networking%20v1-%23bc8540)](mailto:ccloud-api-access+networking-v1-early-access@confluent.io?subject=Request%20to%20join%20networking/v1%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Early%20Access%20for%20networking/v1%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 		Make a request to create a DNS record.
 
@@ -61,7 +61,7 @@ type DNSRecordsNetworkingV1Api interface {
 	/*
 			DeleteNetworkingV1DnsRecord Delete a DNS Record
 
-			[![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Networking v1](https://img.shields.io/badge/-Request%20Access%20To%20Networking%20v1-%23bc8540)](mailto:ccloud-api-access+networking-v1-early-access@confluent.io?subject=Request%20to%20join%20networking/v1%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Early%20Access%20for%20networking/v1%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 		Make a request to delete a DNS record.
 
@@ -77,7 +77,7 @@ type DNSRecordsNetworkingV1Api interface {
 	/*
 			GetNetworkingV1DnsRecord Read a DNS Record
 
-			[![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Networking v1](https://img.shields.io/badge/-Request%20Access%20To%20Networking%20v1-%23bc8540)](mailto:ccloud-api-access+networking-v1-early-access@confluent.io?subject=Request%20to%20join%20networking/v1%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Early%20Access%20for%20networking/v1%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 		Make a request to read a DNS record.
 
@@ -94,7 +94,7 @@ type DNSRecordsNetworkingV1Api interface {
 	/*
 			ListNetworkingV1DnsRecords List of DNS Records
 
-			[![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Networking v1](https://img.shields.io/badge/-Request%20Access%20To%20Networking%20v1-%23bc8540)](mailto:ccloud-api-access+networking-v1-early-access@confluent.io?subject=Request%20to%20join%20networking/v1%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Early%20Access%20for%20networking/v1%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 		Retrieve a sorted, filtered, paginated list of all DNS records.
 
@@ -110,7 +110,7 @@ type DNSRecordsNetworkingV1Api interface {
 	/*
 			UpdateNetworkingV1DnsRecord Update a DNS Record
 
-			[![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Networking v1](https://img.shields.io/badge/-Request%20Access%20To%20Networking%20v1-%23bc8540)](mailto:ccloud-api-access+networking-v1-early-access@confluent.io?subject=Request%20to%20join%20networking/v1%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Early%20Access%20for%20networking/v1%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 		Make a request to update a DNS record.
 
@@ -148,7 +148,7 @@ func (r ApiCreateNetworkingV1DnsRecordRequest) Execute() (NetworkingV1DnsRecord,
 /*
 CreateNetworkingV1DnsRecord Create a DNS Record
 
-[![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Networking v1](https://img.shields.io/badge/-Request%20Access%20To%20Networking%20v1-%23bc8540)](mailto:ccloud-api-access+networking-v1-early-access@confluent.io?subject=Request%20to%20join%20networking/v1%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Early%20Access%20for%20networking/v1%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to create a DNS record.
 
@@ -321,7 +321,7 @@ func (r ApiDeleteNetworkingV1DnsRecordRequest) Execute() (*_nethttp.Response, er
 /*
 DeleteNetworkingV1DnsRecord Delete a DNS Record
 
-[![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Networking v1](https://img.shields.io/badge/-Request%20Access%20To%20Networking%20v1-%23bc8540)](mailto:ccloud-api-access+networking-v1-early-access@confluent.io?subject=Request%20to%20join%20networking/v1%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Early%20Access%20for%20networking/v1%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to delete a DNS record.
 
@@ -477,7 +477,7 @@ func (r ApiGetNetworkingV1DnsRecordRequest) Execute() (NetworkingV1DnsRecord, *_
 /*
 GetNetworkingV1DnsRecord Read a DNS Record
 
-[![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Networking v1](https://img.shields.io/badge/-Request%20Access%20To%20Networking%20v1-%23bc8540)](mailto:ccloud-api-access+networking-v1-early-access@confluent.io?subject=Request%20to%20join%20networking/v1%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Early%20Access%20for%20networking/v1%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to read a DNS record.
 
@@ -686,7 +686,7 @@ func (r ApiListNetworkingV1DnsRecordsRequest) Execute() (NetworkingV1DnsRecordLi
 /*
 ListNetworkingV1DnsRecords List of DNS Records
 
-[![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Networking v1](https://img.shields.io/badge/-Request%20Access%20To%20Networking%20v1-%23bc8540)](mailto:ccloud-api-access+networking-v1-early-access@confluent.io?subject=Request%20to%20join%20networking/v1%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Early%20Access%20for%20networking/v1%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Retrieve a sorted, filtered, paginated list of all DNS records.
 
@@ -890,7 +890,7 @@ func (r ApiUpdateNetworkingV1DnsRecordRequest) Execute() (NetworkingV1DnsRecord,
 /*
 UpdateNetworkingV1DnsRecord Update a DNS Record
 
-[![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To Networking v1](https://img.shields.io/badge/-Request%20Access%20To%20Networking%20v1-%23bc8540)](mailto:ccloud-api-access+networking-v1-early-access@confluent.io?subject=Request%20to%20join%20networking/v1%20API%20Early%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Early%20Access%20for%20networking/v1%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to update a DNS record.
 

--- a/networking-access-point/v1/configuration.go
+++ b/networking-access-point/v1/configuration.go
@@ -123,6 +123,14 @@ func NewConfiguration() *Configuration {
 				URL:         "https://api.confluent.cloud",
 				Description: "Confluent Cloud production",
 			},
+			{
+				URL:         "https://api.stag.cpdev.cloud",
+				Description: "Confluent Cloud staging",
+			},
+			{
+				URL:         "https://api.devel.cpdev.cloud",
+				Description: "Confluent Cloud development",
+			},
 		},
 		OperationServers: map[string]ServerConfigurations{},
 	}

--- a/networking-access-point/v1/docs/NetworkingV1AccessPointStatus.md
+++ b/networking-access-point/v1/docs/NetworkingV1AccessPointStatus.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Phase** | **string** | The lifecycle phase of the access point:    PROVISIONING: Access point provisioning is in progress;    PENDING_ACCEPT: Access point connection request is pending acceptance by the customer;    READY:  Access point is ready;    FAILED: Access point is in a failed state;    DEPROVISIONING: Access point deprovisioning is in progress;  | [readonly] 
+**Phase** | **string** | The lifecycle phase of the access point:    PROVISIONING: Access point provisioning is in progress;    PENDING_ACCEPT: Access point connection request is pending acceptance by the customer;    READY:  Access point is ready;    FAILED: Access point is in a failed state;    DEPROVISIONING: Access point deprovisioning is in progress;    DISCONNECTED: Access Point has been disconnected in the cloud provider by the customer;  | [readonly] 
 **ErrorCode** | Pointer to **string** | Error code if access point is in a failed state. May be used for programmatic error checking. | [optional] [readonly] 
 **ErrorMessage** | Pointer to **string** | Displayable error message if access point is in a failed state. | [optional] [readonly] 
 **Config** | Pointer to [**NetworkingV1AccessPointStatusConfigOneOf**](NetworkingV1AccessPointStatusConfigOneOf.md) | Cloud specific status of the access point. | [optional] [readonly] 

--- a/networking-access-point/v1/docs/NetworkingV1AzureEgressPrivateLinkEndpointStatus.md
+++ b/networking-access-point/v1/docs/NetworkingV1AzureEgressPrivateLinkEndpointStatus.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 **PrivateEndpointResourceId** | **string** | Resource ID of the Private Endpoint (if any) that is connected to the Private Link service. | [readonly] 
 **PrivateEndpointDomain** | Pointer to **string** | Domain of the Private Endpoint (if any) that is connected to the Private Link service. | [optional] [readonly] 
 **PrivateEndpointIpAddress** | **string** | IP address of the Private Endpoint (if any) that is connected to the Private Link service. | [readonly] 
+**PrivateEndpointCustomDnsConfigDomains** | Pointer to **[]string** | Domains of the Private Endpoint (if any) based off FQDNs in Azure custom DNS configs, which are required in your private DNS setup. | [optional] [readonly] 
 
 ## Methods
 
@@ -112,6 +113,31 @@ and a boolean to check if the value has been set.
 
 SetPrivateEndpointIpAddress sets PrivateEndpointIpAddress field to given value.
 
+
+### GetPrivateEndpointCustomDnsConfigDomains
+
+`func (o *NetworkingV1AzureEgressPrivateLinkEndpointStatus) GetPrivateEndpointCustomDnsConfigDomains() []string`
+
+GetPrivateEndpointCustomDnsConfigDomains returns the PrivateEndpointCustomDnsConfigDomains field if non-nil, zero value otherwise.
+
+### GetPrivateEndpointCustomDnsConfigDomainsOk
+
+`func (o *NetworkingV1AzureEgressPrivateLinkEndpointStatus) GetPrivateEndpointCustomDnsConfigDomainsOk() (*[]string, bool)`
+
+GetPrivateEndpointCustomDnsConfigDomainsOk returns a tuple with the PrivateEndpointCustomDnsConfigDomains field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetPrivateEndpointCustomDnsConfigDomains
+
+`func (o *NetworkingV1AzureEgressPrivateLinkEndpointStatus) SetPrivateEndpointCustomDnsConfigDomains(v []string)`
+
+SetPrivateEndpointCustomDnsConfigDomains sets PrivateEndpointCustomDnsConfigDomains field to given value.
+
+### HasPrivateEndpointCustomDnsConfigDomains
+
+`func (o *NetworkingV1AzureEgressPrivateLinkEndpointStatus) HasPrivateEndpointCustomDnsConfigDomains() bool`
+
+HasPrivateEndpointCustomDnsConfigDomains returns a boolean if a field has been set.
 
 
 ### AsNetworkingV1AccessPointStatusConfigOneOf

--- a/networking-access-point/v1/model_networking_v1_access_point_status.go
+++ b/networking-access-point/v1/model_networking_v1_access_point_status.go
@@ -36,7 +36,7 @@ import (
 
 // NetworkingV1AccessPointStatus The status of the Access Point
 type NetworkingV1AccessPointStatus struct {
-	// The lifecycle phase of the access point:    PROVISIONING: Access point provisioning is in progress;    PENDING_ACCEPT: Access point connection request is pending acceptance by the customer;    READY:  Access point is ready;    FAILED: Access point is in a failed state;    DEPROVISIONING: Access point deprovisioning is in progress;
+	// The lifecycle phase of the access point:    PROVISIONING: Access point provisioning is in progress;    PENDING_ACCEPT: Access point connection request is pending acceptance by the customer;    READY:  Access point is ready;    FAILED: Access point is in a failed state;    DEPROVISIONING: Access point deprovisioning is in progress;    DISCONNECTED: Access Point has been disconnected in the cloud provider by the customer;
 	Phase string `json:"phase,omitempty"`
 	// Error code if access point is in a failed state. May be used for programmatic error checking.
 	ErrorCode *string `json:"error_code,omitempty"`

--- a/networking-access-point/v1/model_networking_v1_azure_egress_private_link_endpoint_status.go
+++ b/networking-access-point/v1/model_networking_v1_azure_egress_private_link_endpoint_status.go
@@ -44,6 +44,8 @@ type NetworkingV1AzureEgressPrivateLinkEndpointStatus struct {
 	PrivateEndpointDomain *string `json:"private_endpoint_domain,omitempty"`
 	// IP address of the Private Endpoint (if any) that is connected to the Private Link service.
 	PrivateEndpointIpAddress string `json:"private_endpoint_ip_address,omitempty"`
+	// Domains of the Private Endpoint (if any) based off FQDNs in Azure custom DNS configs, which are required in your private DNS setup.
+	PrivateEndpointCustomDnsConfigDomains *[]string `json:"private_endpoint_custom_dns_config_domains,omitempty"`
 }
 
 // NewNetworkingV1AzureEgressPrivateLinkEndpointStatus instantiates a new NetworkingV1AzureEgressPrivateLinkEndpointStatus object
@@ -170,12 +172,45 @@ func (o *NetworkingV1AzureEgressPrivateLinkEndpointStatus) SetPrivateEndpointIpA
 	o.PrivateEndpointIpAddress = v
 }
 
+// GetPrivateEndpointCustomDnsConfigDomains returns the PrivateEndpointCustomDnsConfigDomains field value if set, zero value otherwise.
+func (o *NetworkingV1AzureEgressPrivateLinkEndpointStatus) GetPrivateEndpointCustomDnsConfigDomains() []string {
+	if o == nil || o.PrivateEndpointCustomDnsConfigDomains == nil {
+		var ret []string
+		return ret
+	}
+	return *o.PrivateEndpointCustomDnsConfigDomains
+}
+
+// GetPrivateEndpointCustomDnsConfigDomainsOk returns a tuple with the PrivateEndpointCustomDnsConfigDomains field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *NetworkingV1AzureEgressPrivateLinkEndpointStatus) GetPrivateEndpointCustomDnsConfigDomainsOk() (*[]string, bool) {
+	if o == nil || o.PrivateEndpointCustomDnsConfigDomains == nil {
+		return nil, false
+	}
+	return o.PrivateEndpointCustomDnsConfigDomains, true
+}
+
+// HasPrivateEndpointCustomDnsConfigDomains returns a boolean if a field has been set.
+func (o *NetworkingV1AzureEgressPrivateLinkEndpointStatus) HasPrivateEndpointCustomDnsConfigDomains() bool {
+	if o != nil && o.PrivateEndpointCustomDnsConfigDomains != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetPrivateEndpointCustomDnsConfigDomains gets a reference to the given []string and assigns it to the PrivateEndpointCustomDnsConfigDomains field.
+func (o *NetworkingV1AzureEgressPrivateLinkEndpointStatus) SetPrivateEndpointCustomDnsConfigDomains(v []string) {
+	o.PrivateEndpointCustomDnsConfigDomains = &v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *NetworkingV1AzureEgressPrivateLinkEndpointStatus) Redact() {
 	o.recurseRedact(&o.Kind)
 	o.recurseRedact(&o.PrivateEndpointResourceId)
 	o.recurseRedact(o.PrivateEndpointDomain)
 	o.recurseRedact(&o.PrivateEndpointIpAddress)
+	o.recurseRedact(o.PrivateEndpointCustomDnsConfigDomains)
 }
 
 func (o *NetworkingV1AzureEgressPrivateLinkEndpointStatus) recurseRedact(v interface{}) {
@@ -221,6 +256,9 @@ func (o NetworkingV1AzureEgressPrivateLinkEndpointStatus) MarshalJSON() ([]byte,
 	}
 	if true {
 		toSerialize["private_endpoint_ip_address"] = o.PrivateEndpointIpAddress
+	}
+	if o.PrivateEndpointCustomDnsConfigDomains != nil {
+		toSerialize["private_endpoint_custom_dns_config_domains"] = o.PrivateEndpointCustomDnsConfigDomains
 	}
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)


### PR DESCRIPTION
```
go vet -v
unicode/utf8
internal/itoa
encoding
math/bits
cmp
slices
unicode/utf16
crypto/internal/alias
internal/coverage/rtcov
crypto/internal/boring/sig
crypto/subtle
internal/nettrace
vendor/golang.org/x/crypto/cryptobyte/asn1
container/list
vendor/golang.org/x/crypto/internal/alias
log/internal
internal/cpu
internal/bytealg
math
internal/goexperiment
internal/goarch
runtime/internal/math
internal/chacha8rand
internal/abi
internal/race
internal/godebugs
sync/atomic
internal/unsafeheader
unicode
runtime/internal/atomic
internal/goos
runtime/internal/sys
runtime
internal/reflectlite
sync
errors
internal/testlog
sort
internal/singleflight
internal/bisect
internal/oserror
io
path
internal/safefilepath
internal/godebug
vendor/golang.org/x/net/dns/dnsmessage
crypto/internal/randutil
hash
internal/intern
bytes
math/rand
strconv
strings
hash/crc32
vendor/golang.org/x/text/transform
crypto/internal/nistec/fiat
net/http/internal/ascii
bufio
crypto
crypto/rc4
net/netip
regexp/syntax
reflect
syscall
regexp
internal/fmtsort
internal/syscall/execenv
encoding/binary
encoding/base64
vendor/golang.org/x/crypto/internal/poly1305
time
crypto/md5
crypto/internal/edwards25519/field
internal/syscall/unix
crypto/cipher
encoding/pem
context
crypto/x509/internal/macos
crypto/des
vendor/golang.org/x/crypto/chacha20
crypto/internal/boring
crypto/internal/edwards25519
io/fs
crypto/hmac
embed
crypto/sha1
crypto/sha256
crypto/sha512
internal/poll
crypto/aes
vendor/golang.org/x/crypto/hkdf
crypto/internal/nistec
crypto/ecdh
os
io/ioutil
path/filepath
fmt
vendor/golang.org/x/sys/cpu
net/url
vendor/golang.org/x/net/route
encoding/hex
log
encoding/xml
vendor/golang.org/x/crypto/chacha20poly1305
net/http/internal
compress/flate
vendor/golang.org/x/net/http2/hpack
encoding/json
mime/quotedprintable
mime
vendor/golang.org/x/text/unicode/bidi
vendor/golang.org/x/text/unicode/norm
compress/gzip
math/big
vendor/golang.org/x/text/secure/bidirule
crypto/internal/boring/bbig
crypto/internal/bigmod
crypto/dsa
crypto/rand
crypto/elliptic
encoding/asn1
vendor/golang.org/x/net/idna
crypto/ed25519
crypto/x509/pkix
crypto/rsa
vendor/golang.org/x/crypto/cryptobyte
crypto/ecdsa
runtime/cgo
net
vendor/golang.org/x/net/http/httpproxy
net/textproto
vendor/golang.org/x/net/http/httpguts
mime/multipart
crypto/x509
crypto/tls
net/http/httptrace
net/http
golang.org/x/net/context/ctxhttp
net/http/httputil
golang.org/x/oauth2/internal
golang.org/x/oauth2
github.com/confluentinc/ccloud-sdk-go-v2/networking-access-point/v1
```