### PR TITLE
Add CRL to `certificate-authority`

### DIFF
--- a/certificate-authority/v2/api/openapi.yaml
+++ b/certificate-authority/v2/api/openapi.yaml
@@ -14,10 +14,6 @@ info:
 servers:
 - description: Confluent Cloud production
   url: https://api.confluent.cloud
-- description: Confluent Cloud staging
-  url: https://api.stag.cpdev.cloud
-- description: Confluent Cloud development
-  url: https://api.devel.cpdev.cloud
 tags:
 - description: |-
     [![Early Access](https://img.shields.io/badge/Lifecycle%20Stage-Early%20Access-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To mTLS for Dedicated Kafka](https://img.shields.io/badge/-Request%20Access%20To%20mTLS%20for%20Dedicated%20Kafka-%23bc8540)](mailto:ccloud-api-access+iam-v2-early-access@confluent.io?subject=Request%20to%20join%20mTLS%20API%20Limited%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Early%20Access%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
@@ -654,7 +650,20 @@ paths:
           j/8N7yy5Y0b2qvzfvGn9LhJIZJrglfCm7ymPAbEVtQwdpf5pLGkkeB6zpxxxYu7KyJesF12KwvhH
           hm4qxFYxldBniYUr+WymXUadDKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveC
           X4XSQRjbgbMEHMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==
-          -----END CERTIFICATE-----","certificate_chain_filename":"certificate.pem"}'
+          -----END CERTIFICATE-----","certificate_chain_filename":"certificate.pem","crl_url":"http://example.com","crl_chain":"-----BEGIN X509 CRL-----
+          MIICNTCCAR0CAQEwDQYJKoZIhvcNAQELBQAwgbExCzAJBgNVBAYTAlVTMQswCQYD
+          VQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzESMBAGA1UECgwJQ29uZmx1
+          ZW50MRMwEQYDVQQLDApzZWN1cml0eS0xMSYwJAYDVQQDDB1tdGxzMS5zZWN1cml0
+          eS0xLmNvbmZsdWVudC5pbzEsMCoGCSqGSIb3DQEJARYdbXRsczFAc2VjdXJpdHkt
+          MS5jb25mbHVlbnQuaW8XDTI0MDgyNTE3NTYyNloXDTI0MTEyMzE3NTYyNlowJzAl
+          AhQERu3UxH2q3eUglbdeQY8y0vT7rRcNMjQwODI1MTc1NTE2WqAOMAwwCgYDVR0U
+          BAMCAQEwDQYJKoZIhvcNAQELBQADggEBAGvmflwxVAnqZbRx8njb2t6yXqeIOBaX
+          CKhMq5CUWrWhMX/JrV5NhVfzeB2tgCCfM4J7gbKSArOKqjYpQBFL+r5eCjPBBcG4
+          xqh1J60l5DDsiUcXQM5FtlWTBBZFxvvvWsLP4qA/0meYRY69YQNqgEQgQ65l0Ehl
+          gIUx8WkEo82A8MDY/t91PaFHufnffPKu4CxFtcpGwuvA2n9mpxB2TsSTiV8THsfE
+          jatuFwYgumI6t5wIWb71j/1oqQDYtbgpgUvX9gD+g7HlCC4u6Dynd0q8lsimrbf6
+          cGf5Vs3JfMcr1kYNruT7kg4f4hc3p4CcuWtxYmHOcWNyZbi+W9Fdakg=
+          -----END X509 CRL-----"}'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
@@ -677,7 +686,20 @@ paths:
           j/8N7yy5Y0b2qvzfvGn9LhJIZJrglfCm7ymPAbEVtQwdpf5pLGkkeB6zpxxxYu7KyJesF12KwvhH\
           hm4qxFYxldBniYUr+WymXUadDKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveC\
           X4XSQRjbgbMEHMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==\
-          -----END CERTIFICATE-----\",\"certificate_chain_filename\":\"certificate.pem\"}");
+          -----END CERTIFICATE-----\",\"certificate_chain_filename\":\"certificate.pem\",\"crl_url\":\"http://example.com\",\"crl_chain\":\"-----BEGIN X509 CRL-----\
+          MIICNTCCAR0CAQEwDQYJKoZIhvcNAQELBQAwgbExCzAJBgNVBAYTAlVTMQswCQYD\
+          VQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzESMBAGA1UECgwJQ29uZmx1\
+          ZW50MRMwEQYDVQQLDApzZWN1cml0eS0xMSYwJAYDVQQDDB1tdGxzMS5zZWN1cml0\
+          eS0xLmNvbmZsdWVudC5pbzEsMCoGCSqGSIb3DQEJARYdbXRsczFAc2VjdXJpdHkt\
+          MS5jb25mbHVlbnQuaW8XDTI0MDgyNTE3NTYyNloXDTI0MTEyMzE3NTYyNlowJzAl\
+          AhQERu3UxH2q3eUglbdeQY8y0vT7rRcNMjQwODI1MTc1NTE2WqAOMAwwCgYDVR0U\
+          BAMCAQEwDQYJKoZIhvcNAQELBQADggEBAGvmflwxVAnqZbRx8njb2t6yXqeIOBaX\
+          CKhMq5CUWrWhMX/JrV5NhVfzeB2tgCCfM4J7gbKSArOKqjYpQBFL+r5eCjPBBcG4\
+          xqh1J60l5DDsiUcXQM5FtlWTBBZFxvvvWsLP4qA/0meYRY69YQNqgEQgQ65l0Ehl\
+          gIUx8WkEo82A8MDY/t91PaFHufnffPKu4CxFtcpGwuvA2n9mpxB2TsSTiV8THsfE\
+          jatuFwYgumI6t5wIWb71j/1oqQDYtbgpgUvX9gD+g7HlCC4u6Dynd0q8lsimrbf6\
+          cGf5Vs3JfMcr1kYNruT7kg4f4hc3p4CcuWtxYmHOcWNyZbi+W9Fdakg=\
+          -----END X509 CRL-----\"}");
           Request request = new Request.Builder()
             .url("https://api.confluent.cloud/iam/v2/certificate-authorities")
             .post(body)
@@ -707,12 +729,20 @@ paths:
           \nj/8N7yy5Y0b2qvzfvGn9LhJIZJrglfCm7ymPAbEVtQwdpf5pLGkkeB6zpxxxYu7KyJesF12KwvhH\\\
           \nhm4qxFYxldBniYUr+WymXUadDKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveC\\\
           \nX4XSQRjbgbMEHMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==\\\n-----END CERTIFICATE-----\\\
-          \",\\\"certificate_chain_filename\\\":\\\"certificate.pem\\\"}\")\n\n\t\
-          req, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"\
-          Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\treq.Header.Add(\"content-type\"\
-          , \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\t\
-          defer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\
-          \tfmt.Println(string(body))\n\n}"
+          \",\\\"certificate_chain_filename\\\":\\\"certificate.pem\\\",\\\"crl_url\\\
+          \":\\\"http://example.com\\\",\\\"crl_chain\\\":\\\"-----BEGIN X509 CRL-----\\\
+          \nMIICNTCCAR0CAQEwDQYJKoZIhvcNAQELBQAwgbExCzAJBgNVBAYTAlVTMQswCQYD\\\nVQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzESMBAGA1UECgwJQ29uZmx1\\\
+          \nZW50MRMwEQYDVQQLDApzZWN1cml0eS0xMSYwJAYDVQQDDB1tdGxzMS5zZWN1cml0\\\neS0xLmNvbmZsdWVudC5pbzEsMCoGCSqGSIb3DQEJARYdbXRsczFAc2VjdXJpdHkt\\\
+          \nMS5jb25mbHVlbnQuaW8XDTI0MDgyNTE3NTYyNloXDTI0MTEyMzE3NTYyNlowJzAl\\\nAhQERu3UxH2q3eUglbdeQY8y0vT7rRcNMjQwODI1MTc1NTE2WqAOMAwwCgYDVR0U\\\
+          \nBAMCAQEwDQYJKoZIhvcNAQELBQADggEBAGvmflwxVAnqZbRx8njb2t6yXqeIOBaX\\\nCKhMq5CUWrWhMX/JrV5NhVfzeB2tgCCfM4J7gbKSArOKqjYpQBFL+r5eCjPBBcG4\\\
+          \nxqh1J60l5DDsiUcXQM5FtlWTBBZFxvvvWsLP4qA/0meYRY69YQNqgEQgQ65l0Ehl\\\ngIUx8WkEo82A8MDY/t91PaFHufnffPKu4CxFtcpGwuvA2n9mpxB2TsSTiV8THsfE\\\
+          \njatuFwYgumI6t5wIWb71j/1oqQDYtbgpgUvX9gD+g7HlCC4u6Dynd0q8lsimrbf6\\\ncGf5Vs3JfMcr1kYNruT7kg4f4hc3p4CcuWtxYmHOcWNyZbi+W9Fdakg=\\\
+          \n-----END X509 CRL-----\\\"}\")\n\n\treq, _ := http.NewRequest(\"POST\"\
+          , url, payload)\n\n\treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\"\
+          )\n\treq.Header.Add(\"content-type\", \"application/json\")\n\n\tres, _\
+          \ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ :=\
+          \ ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
+          \n}"
       - lang: Python
         source: |-
           import http.client
@@ -736,7 +766,20 @@ paths:
           j/8N7yy5Y0b2qvzfvGn9LhJIZJrglfCm7ymPAbEVtQwdpf5pLGkkeB6zpxxxYu7KyJesF12KwvhH\
           hm4qxFYxldBniYUr+WymXUadDKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveC\
           X4XSQRjbgbMEHMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==\
-          -----END CERTIFICATE-----\",\"certificate_chain_filename\":\"certificate.pem\"}"
+          -----END CERTIFICATE-----\",\"certificate_chain_filename\":\"certificate.pem\",\"crl_url\":\"http://example.com\",\"crl_chain\":\"-----BEGIN X509 CRL-----\
+          MIICNTCCAR0CAQEwDQYJKoZIhvcNAQELBQAwgbExCzAJBgNVBAYTAlVTMQswCQYD\
+          VQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzESMBAGA1UECgwJQ29uZmx1\
+          ZW50MRMwEQYDVQQLDApzZWN1cml0eS0xMSYwJAYDVQQDDB1tdGxzMS5zZWN1cml0\
+          eS0xLmNvbmZsdWVudC5pbzEsMCoGCSqGSIb3DQEJARYdbXRsczFAc2VjdXJpdHkt\
+          MS5jb25mbHVlbnQuaW8XDTI0MDgyNTE3NTYyNloXDTI0MTEyMzE3NTYyNlowJzAl\
+          AhQERu3UxH2q3eUglbdeQY8y0vT7rRcNMjQwODI1MTc1NTE2WqAOMAwwCgYDVR0U\
+          BAMCAQEwDQYJKoZIhvcNAQELBQADggEBAGvmflwxVAnqZbRx8njb2t6yXqeIOBaX\
+          CKhMq5CUWrWhMX/JrV5NhVfzeB2tgCCfM4J7gbKSArOKqjYpQBFL+r5eCjPBBcG4\
+          xqh1J60l5DDsiUcXQM5FtlWTBBZFxvvvWsLP4qA/0meYRY69YQNqgEQgQ65l0Ehl\
+          gIUx8WkEo82A8MDY/t91PaFHufnffPKu4CxFtcpGwuvA2n9mpxB2TsSTiV8THsfE\
+          jatuFwYgumI6t5wIWb71j/1oqQDYtbgpgUvX9gD+g7HlCC4u6Dynd0q8lsimrbf6\
+          cGf5Vs3JfMcr1kYNruT7kg4f4hc3p4CcuWtxYmHOcWNyZbi+W9Fdakg=\
+          -----END X509 CRL-----\"}"
 
           headers = {
               'Authorization': "Basic REPLACE_BASIC_AUTH",
@@ -798,7 +841,22 @@ paths:
           hm4qxFYxldBniYUr+WymXUadDKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveC
           X4XSQRjbgbMEHMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==
           -----END CERTIFICATE-----',
-            certificate_chain_filename: 'certificate.pem'
+            certificate_chain_filename: 'certificate.pem',
+            crl_url: 'http://example.com',
+            crl_chain: '-----BEGIN X509 CRL-----
+          MIICNTCCAR0CAQEwDQYJKoZIhvcNAQELBQAwgbExCzAJBgNVBAYTAlVTMQswCQYD
+          VQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzESMBAGA1UECgwJQ29uZmx1
+          ZW50MRMwEQYDVQQLDApzZWN1cml0eS0xMSYwJAYDVQQDDB1tdGxzMS5zZWN1cml0
+          eS0xLmNvbmZsdWVudC5pbzEsMCoGCSqGSIb3DQEJARYdbXRsczFAc2VjdXJpdHkt
+          MS5jb25mbHVlbnQuaW8XDTI0MDgyNTE3NTYyNloXDTI0MTEyMzE3NTYyNlowJzAl
+          AhQERu3UxH2q3eUglbdeQY8y0vT7rRcNMjQwODI1MTc1NTE2WqAOMAwwCgYDVR0U
+          BAMCAQEwDQYJKoZIhvcNAQELBQADggEBAGvmflwxVAnqZbRx8njb2t6yXqeIOBaX
+          CKhMq5CUWrWhMX/JrV5NhVfzeB2tgCCfM4J7gbKSArOKqjYpQBFL+r5eCjPBBcG4
+          xqh1J60l5DDsiUcXQM5FtlWTBBZFxvvvWsLP4qA/0meYRY69YQNqgEQgQ65l0Ehl
+          gIUx8WkEo82A8MDY/t91PaFHufnffPKu4CxFtcpGwuvA2n9mpxB2TsSTiV8THsfE
+          jatuFwYgumI6t5wIWb71j/1oqQDYtbgpgUvX9gD+g7HlCC4u6Dynd0q8lsimrbf6
+          cGf5Vs3JfMcr1kYNruT7kg4f4hc3p4CcuWtxYmHOcWNyZbi+W9Fdakg=
+          -----END X509 CRL-----'
           }));
           req.end();
       - lang: C
@@ -830,7 +888,20 @@ paths:
           j/8N7yy5Y0b2qvzfvGn9LhJIZJrglfCm7ymPAbEVtQwdpf5pLGkkeB6zpxxxYu7KyJesF12KwvhH\
           hm4qxFYxldBniYUr+WymXUadDKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveC\
           X4XSQRjbgbMEHMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==\
-          -----END CERTIFICATE-----\",\"certificate_chain_filename\":\"certificate.pem\"}");
+          -----END CERTIFICATE-----\",\"certificate_chain_filename\":\"certificate.pem\",\"crl_url\":\"http://example.com\",\"crl_chain\":\"-----BEGIN X509 CRL-----\
+          MIICNTCCAR0CAQEwDQYJKoZIhvcNAQELBQAwgbExCzAJBgNVBAYTAlVTMQswCQYD\
+          VQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzESMBAGA1UECgwJQ29uZmx1\
+          ZW50MRMwEQYDVQQLDApzZWN1cml0eS0xMSYwJAYDVQQDDB1tdGxzMS5zZWN1cml0\
+          eS0xLmNvbmZsdWVudC5pbzEsMCoGCSqGSIb3DQEJARYdbXRsczFAc2VjdXJpdHkt\
+          MS5jb25mbHVlbnQuaW8XDTI0MDgyNTE3NTYyNloXDTI0MTEyMzE3NTYyNlowJzAl\
+          AhQERu3UxH2q3eUglbdeQY8y0vT7rRcNMjQwODI1MTc1NTE2WqAOMAwwCgYDVR0U\
+          BAMCAQEwDQYJKoZIhvcNAQELBQADggEBAGvmflwxVAnqZbRx8njb2t6yXqeIOBaX\
+          CKhMq5CUWrWhMX/JrV5NhVfzeB2tgCCfM4J7gbKSArOKqjYpQBFL+r5eCjPBBcG4\
+          xqh1J60l5DDsiUcXQM5FtlWTBBZFxvvvWsLP4qA/0meYRY69YQNqgEQgQ65l0Ehl\
+          gIUx8WkEo82A8MDY/t91PaFHufnffPKu4CxFtcpGwuvA2n9mpxB2TsSTiV8THsfE\
+          jatuFwYgumI6t5wIWb71j/1oqQDYtbgpgUvX9gD+g7HlCC4u6Dynd0q8lsimrbf6\
+          cGf5Vs3JfMcr1kYNruT7kg4f4hc3p4CcuWtxYmHOcWNyZbi+W9Fdakg=\
+          -----END X509 CRL-----\"}");
 
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
@@ -856,7 +927,20 @@ paths:
           j/8N7yy5Y0b2qvzfvGn9LhJIZJrglfCm7ymPAbEVtQwdpf5pLGkkeB6zpxxxYu7KyJesF12KwvhH\
           hm4qxFYxldBniYUr+WymXUadDKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveC\
           X4XSQRjbgbMEHMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==\
-          -----END CERTIFICATE-----\",\"certificate_chain_filename\":\"certificate.pem\"}", ParameterType.RequestBody);
+          -----END CERTIFICATE-----\",\"certificate_chain_filename\":\"certificate.pem\",\"crl_url\":\"http://example.com\",\"crl_chain\":\"-----BEGIN X509 CRL-----\
+          MIICNTCCAR0CAQEwDQYJKoZIhvcNAQELBQAwgbExCzAJBgNVBAYTAlVTMQswCQYD\
+          VQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzESMBAGA1UECgwJQ29uZmx1\
+          ZW50MRMwEQYDVQQLDApzZWN1cml0eS0xMSYwJAYDVQQDDB1tdGxzMS5zZWN1cml0\
+          eS0xLmNvbmZsdWVudC5pbzEsMCoGCSqGSIb3DQEJARYdbXRsczFAc2VjdXJpdHkt\
+          MS5jb25mbHVlbnQuaW8XDTI0MDgyNTE3NTYyNloXDTI0MTEyMzE3NTYyNlowJzAl\
+          AhQERu3UxH2q3eUglbdeQY8y0vT7rRcNMjQwODI1MTc1NTE2WqAOMAwwCgYDVR0U\
+          BAMCAQEwDQYJKoZIhvcNAQELBQADggEBAGvmflwxVAnqZbRx8njb2t6yXqeIOBaX\
+          CKhMq5CUWrWhMX/JrV5NhVfzeB2tgCCfM4J7gbKSArOKqjYpQBFL+r5eCjPBBcG4\
+          xqh1J60l5DDsiUcXQM5FtlWTBBZFxvvvWsLP4qA/0meYRY69YQNqgEQgQ65l0Ehl\
+          gIUx8WkEo82A8MDY/t91PaFHufnffPKu4CxFtcpGwuvA2n9mpxB2TsSTiV8THsfE\
+          jatuFwYgumI6t5wIWb71j/1oqQDYtbgpgUvX9gD+g7HlCC4u6Dynd0q8lsimrbf6\
+          cGf5Vs3JfMcr1kYNruT7kg4f4hc3p4CcuWtxYmHOcWNyZbi+W9Fdakg=\
+          -----END X509 CRL-----\"}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
     x-request-access-name: mTLS for Dedicated Kafka
   /iam/v2/certificate-authorities/{id}:
@@ -1807,7 +1891,20 @@ paths:
           j/8N7yy5Y0b2qvzfvGn9LhJIZJrglfCm7ymPAbEVtQwdpf5pLGkkeB6zpxxxYu7KyJesF12KwvhH
           hm4qxFYxldBniYUr+WymXUadDKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveC
           X4XSQRjbgbMEHMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==
-          -----END CERTIFICATE-----","certificate_chain_filename":"certificate.pem"}'
+          -----END CERTIFICATE-----","certificate_chain_filename":"certificate.pem","crl_url":"http://example.com","crl_chain":"-----BEGIN X509 CRL-----
+          MIICNTCCAR0CAQEwDQYJKoZIhvcNAQELBQAwgbExCzAJBgNVBAYTAlVTMQswCQYD
+          VQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzESMBAGA1UECgwJQ29uZmx1
+          ZW50MRMwEQYDVQQLDApzZWN1cml0eS0xMSYwJAYDVQQDDB1tdGxzMS5zZWN1cml0
+          eS0xLmNvbmZsdWVudC5pbzEsMCoGCSqGSIb3DQEJARYdbXRsczFAc2VjdXJpdHkt
+          MS5jb25mbHVlbnQuaW8XDTI0MDgyNTE3NTYyNloXDTI0MTEyMzE3NTYyNlowJzAl
+          AhQERu3UxH2q3eUglbdeQY8y0vT7rRcNMjQwODI1MTc1NTE2WqAOMAwwCgYDVR0U
+          BAMCAQEwDQYJKoZIhvcNAQELBQADggEBAGvmflwxVAnqZbRx8njb2t6yXqeIOBaX
+          CKhMq5CUWrWhMX/JrV5NhVfzeB2tgCCfM4J7gbKSArOKqjYpQBFL+r5eCjPBBcG4
+          xqh1J60l5DDsiUcXQM5FtlWTBBZFxvvvWsLP4qA/0meYRY69YQNqgEQgQ65l0Ehl
+          gIUx8WkEo82A8MDY/t91PaFHufnffPKu4CxFtcpGwuvA2n9mpxB2TsSTiV8THsfE
+          jatuFwYgumI6t5wIWb71j/1oqQDYtbgpgUvX9gD+g7HlCC4u6Dynd0q8lsimrbf6
+          cGf5Vs3JfMcr1kYNruT7kg4f4hc3p4CcuWtxYmHOcWNyZbi+W9Fdakg=
+          -----END X509 CRL-----"}'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
@@ -1830,7 +1927,20 @@ paths:
           j/8N7yy5Y0b2qvzfvGn9LhJIZJrglfCm7ymPAbEVtQwdpf5pLGkkeB6zpxxxYu7KyJesF12KwvhH\
           hm4qxFYxldBniYUr+WymXUadDKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveC\
           X4XSQRjbgbMEHMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==\
-          -----END CERTIFICATE-----\",\"certificate_chain_filename\":\"certificate.pem\"}");
+          -----END CERTIFICATE-----\",\"certificate_chain_filename\":\"certificate.pem\",\"crl_url\":\"http://example.com\",\"crl_chain\":\"-----BEGIN X509 CRL-----\
+          MIICNTCCAR0CAQEwDQYJKoZIhvcNAQELBQAwgbExCzAJBgNVBAYTAlVTMQswCQYD\
+          VQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzESMBAGA1UECgwJQ29uZmx1\
+          ZW50MRMwEQYDVQQLDApzZWN1cml0eS0xMSYwJAYDVQQDDB1tdGxzMS5zZWN1cml0\
+          eS0xLmNvbmZsdWVudC5pbzEsMCoGCSqGSIb3DQEJARYdbXRsczFAc2VjdXJpdHkt\
+          MS5jb25mbHVlbnQuaW8XDTI0MDgyNTE3NTYyNloXDTI0MTEyMzE3NTYyNlowJzAl\
+          AhQERu3UxH2q3eUglbdeQY8y0vT7rRcNMjQwODI1MTc1NTE2WqAOMAwwCgYDVR0U\
+          BAMCAQEwDQYJKoZIhvcNAQELBQADggEBAGvmflwxVAnqZbRx8njb2t6yXqeIOBaX\
+          CKhMq5CUWrWhMX/JrV5NhVfzeB2tgCCfM4J7gbKSArOKqjYpQBFL+r5eCjPBBcG4\
+          xqh1J60l5DDsiUcXQM5FtlWTBBZFxvvvWsLP4qA/0meYRY69YQNqgEQgQ65l0Ehl\
+          gIUx8WkEo82A8MDY/t91PaFHufnffPKu4CxFtcpGwuvA2n9mpxB2TsSTiV8THsfE\
+          jatuFwYgumI6t5wIWb71j/1oqQDYtbgpgUvX9gD+g7HlCC4u6Dynd0q8lsimrbf6\
+          cGf5Vs3JfMcr1kYNruT7kg4f4hc3p4CcuWtxYmHOcWNyZbi+W9Fdakg=\
+          -----END X509 CRL-----\"}");
           Request request = new Request.Builder()
             .url("https://api.confluent.cloud/iam/v2/certificate-authorities/%7Bid%7D")
             .put(body)
@@ -1860,12 +1970,20 @@ paths:
           \nj/8N7yy5Y0b2qvzfvGn9LhJIZJrglfCm7ymPAbEVtQwdpf5pLGkkeB6zpxxxYu7KyJesF12KwvhH\\\
           \nhm4qxFYxldBniYUr+WymXUadDKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveC\\\
           \nX4XSQRjbgbMEHMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==\\\n-----END CERTIFICATE-----\\\
-          \",\\\"certificate_chain_filename\\\":\\\"certificate.pem\\\"}\")\n\n\t\
-          req, _ := http.NewRequest(\"PUT\", url, payload)\n\n\treq.Header.Add(\"\
-          Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\treq.Header.Add(\"content-type\"\
-          , \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\t\
-          defer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\
-          \tfmt.Println(string(body))\n\n}"
+          \",\\\"certificate_chain_filename\\\":\\\"certificate.pem\\\",\\\"crl_url\\\
+          \":\\\"http://example.com\\\",\\\"crl_chain\\\":\\\"-----BEGIN X509 CRL-----\\\
+          \nMIICNTCCAR0CAQEwDQYJKoZIhvcNAQELBQAwgbExCzAJBgNVBAYTAlVTMQswCQYD\\\nVQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzESMBAGA1UECgwJQ29uZmx1\\\
+          \nZW50MRMwEQYDVQQLDApzZWN1cml0eS0xMSYwJAYDVQQDDB1tdGxzMS5zZWN1cml0\\\neS0xLmNvbmZsdWVudC5pbzEsMCoGCSqGSIb3DQEJARYdbXRsczFAc2VjdXJpdHkt\\\
+          \nMS5jb25mbHVlbnQuaW8XDTI0MDgyNTE3NTYyNloXDTI0MTEyMzE3NTYyNlowJzAl\\\nAhQERu3UxH2q3eUglbdeQY8y0vT7rRcNMjQwODI1MTc1NTE2WqAOMAwwCgYDVR0U\\\
+          \nBAMCAQEwDQYJKoZIhvcNAQELBQADggEBAGvmflwxVAnqZbRx8njb2t6yXqeIOBaX\\\nCKhMq5CUWrWhMX/JrV5NhVfzeB2tgCCfM4J7gbKSArOKqjYpQBFL+r5eCjPBBcG4\\\
+          \nxqh1J60l5DDsiUcXQM5FtlWTBBZFxvvvWsLP4qA/0meYRY69YQNqgEQgQ65l0Ehl\\\ngIUx8WkEo82A8MDY/t91PaFHufnffPKu4CxFtcpGwuvA2n9mpxB2TsSTiV8THsfE\\\
+          \njatuFwYgumI6t5wIWb71j/1oqQDYtbgpgUvX9gD+g7HlCC4u6Dynd0q8lsimrbf6\\\ncGf5Vs3JfMcr1kYNruT7kg4f4hc3p4CcuWtxYmHOcWNyZbi+W9Fdakg=\\\
+          \n-----END X509 CRL-----\\\"}\")\n\n\treq, _ := http.NewRequest(\"PUT\"\
+          , url, payload)\n\n\treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\"\
+          )\n\treq.Header.Add(\"content-type\", \"application/json\")\n\n\tres, _\
+          \ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ :=\
+          \ ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
+          \n}"
       - lang: Python
         source: |-
           import http.client
@@ -1889,7 +2007,20 @@ paths:
           j/8N7yy5Y0b2qvzfvGn9LhJIZJrglfCm7ymPAbEVtQwdpf5pLGkkeB6zpxxxYu7KyJesF12KwvhH\
           hm4qxFYxldBniYUr+WymXUadDKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveC\
           X4XSQRjbgbMEHMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==\
-          -----END CERTIFICATE-----\",\"certificate_chain_filename\":\"certificate.pem\"}"
+          -----END CERTIFICATE-----\",\"certificate_chain_filename\":\"certificate.pem\",\"crl_url\":\"http://example.com\",\"crl_chain\":\"-----BEGIN X509 CRL-----\
+          MIICNTCCAR0CAQEwDQYJKoZIhvcNAQELBQAwgbExCzAJBgNVBAYTAlVTMQswCQYD\
+          VQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzESMBAGA1UECgwJQ29uZmx1\
+          ZW50MRMwEQYDVQQLDApzZWN1cml0eS0xMSYwJAYDVQQDDB1tdGxzMS5zZWN1cml0\
+          eS0xLmNvbmZsdWVudC5pbzEsMCoGCSqGSIb3DQEJARYdbXRsczFAc2VjdXJpdHkt\
+          MS5jb25mbHVlbnQuaW8XDTI0MDgyNTE3NTYyNloXDTI0MTEyMzE3NTYyNlowJzAl\
+          AhQERu3UxH2q3eUglbdeQY8y0vT7rRcNMjQwODI1MTc1NTE2WqAOMAwwCgYDVR0U\
+          BAMCAQEwDQYJKoZIhvcNAQELBQADggEBAGvmflwxVAnqZbRx8njb2t6yXqeIOBaX\
+          CKhMq5CUWrWhMX/JrV5NhVfzeB2tgCCfM4J7gbKSArOKqjYpQBFL+r5eCjPBBcG4\
+          xqh1J60l5DDsiUcXQM5FtlWTBBZFxvvvWsLP4qA/0meYRY69YQNqgEQgQ65l0Ehl\
+          gIUx8WkEo82A8MDY/t91PaFHufnffPKu4CxFtcpGwuvA2n9mpxB2TsSTiV8THsfE\
+          jatuFwYgumI6t5wIWb71j/1oqQDYtbgpgUvX9gD+g7HlCC4u6Dynd0q8lsimrbf6\
+          cGf5Vs3JfMcr1kYNruT7kg4f4hc3p4CcuWtxYmHOcWNyZbi+W9Fdakg=\
+          -----END X509 CRL-----\"}"
 
           headers = {
               'Authorization': "Basic REPLACE_BASIC_AUTH",
@@ -1951,7 +2082,22 @@ paths:
           hm4qxFYxldBniYUr+WymXUadDKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveC
           X4XSQRjbgbMEHMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==
           -----END CERTIFICATE-----',
-            certificate_chain_filename: 'certificate.pem'
+            certificate_chain_filename: 'certificate.pem',
+            crl_url: 'http://example.com',
+            crl_chain: '-----BEGIN X509 CRL-----
+          MIICNTCCAR0CAQEwDQYJKoZIhvcNAQELBQAwgbExCzAJBgNVBAYTAlVTMQswCQYD
+          VQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzESMBAGA1UECgwJQ29uZmx1
+          ZW50MRMwEQYDVQQLDApzZWN1cml0eS0xMSYwJAYDVQQDDB1tdGxzMS5zZWN1cml0
+          eS0xLmNvbmZsdWVudC5pbzEsMCoGCSqGSIb3DQEJARYdbXRsczFAc2VjdXJpdHkt
+          MS5jb25mbHVlbnQuaW8XDTI0MDgyNTE3NTYyNloXDTI0MTEyMzE3NTYyNlowJzAl
+          AhQERu3UxH2q3eUglbdeQY8y0vT7rRcNMjQwODI1MTc1NTE2WqAOMAwwCgYDVR0U
+          BAMCAQEwDQYJKoZIhvcNAQELBQADggEBAGvmflwxVAnqZbRx8njb2t6yXqeIOBaX
+          CKhMq5CUWrWhMX/JrV5NhVfzeB2tgCCfM4J7gbKSArOKqjYpQBFL+r5eCjPBBcG4
+          xqh1J60l5DDsiUcXQM5FtlWTBBZFxvvvWsLP4qA/0meYRY69YQNqgEQgQ65l0Ehl
+          gIUx8WkEo82A8MDY/t91PaFHufnffPKu4CxFtcpGwuvA2n9mpxB2TsSTiV8THsfE
+          jatuFwYgumI6t5wIWb71j/1oqQDYtbgpgUvX9gD+g7HlCC4u6Dynd0q8lsimrbf6
+          cGf5Vs3JfMcr1kYNruT7kg4f4hc3p4CcuWtxYmHOcWNyZbi+W9Fdakg=
+          -----END X509 CRL-----'
           }));
           req.end();
       - lang: C
@@ -1983,7 +2129,20 @@ paths:
           j/8N7yy5Y0b2qvzfvGn9LhJIZJrglfCm7ymPAbEVtQwdpf5pLGkkeB6zpxxxYu7KyJesF12KwvhH\
           hm4qxFYxldBniYUr+WymXUadDKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveC\
           X4XSQRjbgbMEHMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==\
-          -----END CERTIFICATE-----\",\"certificate_chain_filename\":\"certificate.pem\"}");
+          -----END CERTIFICATE-----\",\"certificate_chain_filename\":\"certificate.pem\",\"crl_url\":\"http://example.com\",\"crl_chain\":\"-----BEGIN X509 CRL-----\
+          MIICNTCCAR0CAQEwDQYJKoZIhvcNAQELBQAwgbExCzAJBgNVBAYTAlVTMQswCQYD\
+          VQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzESMBAGA1UECgwJQ29uZmx1\
+          ZW50MRMwEQYDVQQLDApzZWN1cml0eS0xMSYwJAYDVQQDDB1tdGxzMS5zZWN1cml0\
+          eS0xLmNvbmZsdWVudC5pbzEsMCoGCSqGSIb3DQEJARYdbXRsczFAc2VjdXJpdHkt\
+          MS5jb25mbHVlbnQuaW8XDTI0MDgyNTE3NTYyNloXDTI0MTEyMzE3NTYyNlowJzAl\
+          AhQERu3UxH2q3eUglbdeQY8y0vT7rRcNMjQwODI1MTc1NTE2WqAOMAwwCgYDVR0U\
+          BAMCAQEwDQYJKoZIhvcNAQELBQADggEBAGvmflwxVAnqZbRx8njb2t6yXqeIOBaX\
+          CKhMq5CUWrWhMX/JrV5NhVfzeB2tgCCfM4J7gbKSArOKqjYpQBFL+r5eCjPBBcG4\
+          xqh1J60l5DDsiUcXQM5FtlWTBBZFxvvvWsLP4qA/0meYRY69YQNqgEQgQ65l0Ehl\
+          gIUx8WkEo82A8MDY/t91PaFHufnffPKu4CxFtcpGwuvA2n9mpxB2TsSTiV8THsfE\
+          jatuFwYgumI6t5wIWb71j/1oqQDYtbgpgUvX9gD+g7HlCC4u6Dynd0q8lsimrbf6\
+          cGf5Vs3JfMcr1kYNruT7kg4f4hc3p4CcuWtxYmHOcWNyZbi+W9Fdakg=\
+          -----END X509 CRL-----\"}");
 
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
@@ -2009,7 +2168,20 @@ paths:
           j/8N7yy5Y0b2qvzfvGn9LhJIZJrglfCm7ymPAbEVtQwdpf5pLGkkeB6zpxxxYu7KyJesF12KwvhH\
           hm4qxFYxldBniYUr+WymXUadDKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveC\
           X4XSQRjbgbMEHMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==\
-          -----END CERTIFICATE-----\",\"certificate_chain_filename\":\"certificate.pem\"}", ParameterType.RequestBody);
+          -----END CERTIFICATE-----\",\"certificate_chain_filename\":\"certificate.pem\",\"crl_url\":\"http://example.com\",\"crl_chain\":\"-----BEGIN X509 CRL-----\
+          MIICNTCCAR0CAQEwDQYJKoZIhvcNAQELBQAwgbExCzAJBgNVBAYTAlVTMQswCQYD\
+          VQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzESMBAGA1UECgwJQ29uZmx1\
+          ZW50MRMwEQYDVQQLDApzZWN1cml0eS0xMSYwJAYDVQQDDB1tdGxzMS5zZWN1cml0\
+          eS0xLmNvbmZsdWVudC5pbzEsMCoGCSqGSIb3DQEJARYdbXRsczFAc2VjdXJpdHkt\
+          MS5jb25mbHVlbnQuaW8XDTI0MDgyNTE3NTYyNloXDTI0MTEyMzE3NTYyNlowJzAl\
+          AhQERu3UxH2q3eUglbdeQY8y0vT7rRcNMjQwODI1MTc1NTE2WqAOMAwwCgYDVR0U\
+          BAMCAQEwDQYJKoZIhvcNAQELBQADggEBAGvmflwxVAnqZbRx8njb2t6yXqeIOBaX\
+          CKhMq5CUWrWhMX/JrV5NhVfzeB2tgCCfM4J7gbKSArOKqjYpQBFL+r5eCjPBBcG4\
+          xqh1J60l5DDsiUcXQM5FtlWTBBZFxvvvWsLP4qA/0meYRY69YQNqgEQgQ65l0Ehl\
+          gIUx8WkEo82A8MDY/t91PaFHufnffPKu4CxFtcpGwuvA2n9mpxB2TsSTiV8THsfE\
+          jatuFwYgumI6t5wIWb71j/1oqQDYtbgpgUvX9gD+g7HlCC4u6Dynd0q8lsimrbf6\
+          cGf5Vs3JfMcr1kYNruT7kg4f4hc3p4CcuWtxYmHOcWNyZbi+W9Fdakg=\
+          -----END X509 CRL-----\"}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
     x-request-access-name: mTLS for Dedicated Kafka
   /iam/v2/certificate-authorities/{certificate_authority_id}/identity-pools:
@@ -4082,6 +4254,28 @@ components:
           example: certificate.pem
           readOnly: true
           type: string
+        crl_source:
+          description: |-
+            The source specifies whether the Certificate Revocation List (CRL) is updated from
+            either local file uploaded (LOCAL) or from url of CRL (URL).
+          example: LOCAL
+          readOnly: true
+          type: string
+          x-extensible-enum:
+          - LOCAL
+          - URL
+        crl_url:
+          description: The url from which to fetch the CRL for the certificate authority
+            if crl_source is URL.
+          format: uri
+          readOnly: true
+          type: string
+        crl_updated_at:
+          description: The timestamp for when CRL was last updated.
+          example: 2017-07-21T17:32:28Z
+          format: date-time
+          readOnly: true
+          type: string
         state:
           description: The current state of the certificate authority.
           example: ENABLED
@@ -4247,6 +4441,31 @@ components:
           description: The name of the certificate file.
           example: certificate.pem
           type: string
+        crl_url:
+          description: The url from which to fetch the CRL for the certificate authority
+            if crl_source is URL.
+          format: uri
+          type: string
+        crl_chain:
+          description: |-
+            The Base64 encoded string containing the CRL for this certificate authority.
+            Defaults to this over `crl_url` if available.
+          example: |-
+            -----BEGIN X509 CRL-----
+            MIICNTCCAR0CAQEwDQYJKoZIhvcNAQELBQAwgbExCzAJBgNVBAYTAlVTMQswCQYD
+            VQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzESMBAGA1UECgwJQ29uZmx1
+            ZW50MRMwEQYDVQQLDApzZWN1cml0eS0xMSYwJAYDVQQDDB1tdGxzMS5zZWN1cml0
+            eS0xLmNvbmZsdWVudC5pbzEsMCoGCSqGSIb3DQEJARYdbXRsczFAc2VjdXJpdHkt
+            MS5jb25mbHVlbnQuaW8XDTI0MDgyNTE3NTYyNloXDTI0MTEyMzE3NTYyNlowJzAl
+            AhQERu3UxH2q3eUglbdeQY8y0vT7rRcNMjQwODI1MTc1NTE2WqAOMAwwCgYDVR0U
+            BAMCAQEwDQYJKoZIhvcNAQELBQADggEBAGvmflwxVAnqZbRx8njb2t6yXqeIOBaX
+            CKhMq5CUWrWhMX/JrV5NhVfzeB2tgCCfM4J7gbKSArOKqjYpQBFL+r5eCjPBBcG4
+            xqh1J60l5DDsiUcXQM5FtlWTBBZFxvvvWsLP4qA/0meYRY69YQNqgEQgQ65l0Ehl
+            gIUx8WkEo82A8MDY/t91PaFHufnffPKu4CxFtcpGwuvA2n9mpxB2TsSTiV8THsfE
+            jatuFwYgumI6t5wIWb71j/1oqQDYtbgpgUvX9gD+g7HlCC4u6Dynd0q8lsimrbf6
+            cGf5Vs3JfMcr1kYNruT7kg4f4hc3p4CcuWtxYmHOcWNyZbi+W9Fdakg=
+            -----END X509 CRL-----
+          type: string
       type: object
     iam.v2.UpdateCertRequest:
       description: This contains the form fields used to update a Certificate Authority
@@ -4318,6 +4537,31 @@ components:
           description: The name of the certificate file. Must be set if certificate
             is updated.
           example: certificate.pem
+          type: string
+        crl_url:
+          description: The url from which to fetch the CRL for the certificate authority
+            if crl_source is URL.
+          format: uri
+          type: string
+        crl_chain:
+          description: |-
+            The Base64 encoded string containing the CRL for this certificate authority.
+            Defaults to this over `crl_url` if available.
+          example: |-
+            -----BEGIN X509 CRL-----
+            MIICNTCCAR0CAQEwDQYJKoZIhvcNAQELBQAwgbExCzAJBgNVBAYTAlVTMQswCQYD
+            VQQIDAJDQTEWMBQGA1UEBwwNTW91bnRhaW4gVmlldzESMBAGA1UECgwJQ29uZmx1
+            ZW50MRMwEQYDVQQLDApzZWN1cml0eS0xMSYwJAYDVQQDDB1tdGxzMS5zZWN1cml0
+            eS0xLmNvbmZsdWVudC5pbzEsMCoGCSqGSIb3DQEJARYdbXRsczFAc2VjdXJpdHkt
+            MS5jb25mbHVlbnQuaW8XDTI0MDgyNTE3NTYyNloXDTI0MTEyMzE3NTYyNlowJzAl
+            AhQERu3UxH2q3eUglbdeQY8y0vT7rRcNMjQwODI1MTc1NTE2WqAOMAwwCgYDVR0U
+            BAMCAQEwDQYJKoZIhvcNAQELBQADggEBAGvmflwxVAnqZbRx8njb2t6yXqeIOBaX
+            CKhMq5CUWrWhMX/JrV5NhVfzeB2tgCCfM4J7gbKSArOKqjYpQBFL+r5eCjPBBcG4
+            xqh1J60l5DDsiUcXQM5FtlWTBBZFxvvvWsLP4qA/0meYRY69YQNqgEQgQ65l0Ehl
+            gIUx8WkEo82A8MDY/t91PaFHufnffPKu4CxFtcpGwuvA2n9mpxB2TsSTiV8THsfE
+            jatuFwYgumI6t5wIWb71j/1oqQDYtbgpgUvX9gD+g7HlCC4u6Dynd0q8lsimrbf6
+            cGf5Vs3JfMcr1kYNruT7kg4f4hc3p4CcuWtxYmHOcWNyZbi+W9Fdakg=
+            -----END X509 CRL-----
           type: string
       type: object
     iam.v2.CertificateAuthorityList:

--- a/certificate-authority/v2/configuration.go
+++ b/certificate-authority/v2/configuration.go
@@ -123,14 +123,6 @@ func NewConfiguration() *Configuration {
 				URL:         "https://api.confluent.cloud",
 				Description: "Confluent Cloud production",
 			},
-			{
-				URL:         "https://api.stag.cpdev.cloud",
-				Description: "Confluent Cloud staging",
-			},
-			{
-				URL:         "https://api.devel.cpdev.cloud",
-				Description: "Confluent Cloud development",
-			},
 		},
 		OperationServers: map[string]ServerConfigurations{},
 	}

--- a/certificate-authority/v2/docs/IamV2CertificateAuthority.md
+++ b/certificate-authority/v2/docs/IamV2CertificateAuthority.md
@@ -14,6 +14,9 @@ Name | Type | Description | Notes
 **ExpirationDates** | Pointer to [**[]time.Time**](time.Time.md) | The expiration dates of certificates in the chain. | [optional] [readonly] 
 **SerialNumbers** | Pointer to **[]string** | The serial numbers for each certificate in the certificate chain. | [optional] [readonly] 
 **CertificateChainFilename** | Pointer to **string** | The file name of the uploaded pem file for this certificate authority. | [optional] [readonly] 
+**CrlSource** | Pointer to **string** | The source specifies whether the Certificate Revocation List (CRL) is updated from either local file uploaded (LOCAL) or from url of CRL (URL). | [optional] [readonly] 
+**CrlUrl** | Pointer to **string** | The url from which to fetch the CRL for the certificate authority if crl_source is URL. | [optional] [readonly] 
+**CrlUpdatedAt** | Pointer to **time.Time** | The timestamp for when CRL was last updated. | [optional] [readonly] 
 **State** | Pointer to **string** | The current state of the certificate authority. | [optional] [readonly] 
 
 ## Methods
@@ -284,6 +287,81 @@ SetCertificateChainFilename sets CertificateChainFilename field to given value.
 `func (o *IamV2CertificateAuthority) HasCertificateChainFilename() bool`
 
 HasCertificateChainFilename returns a boolean if a field has been set.
+
+### GetCrlSource
+
+`func (o *IamV2CertificateAuthority) GetCrlSource() string`
+
+GetCrlSource returns the CrlSource field if non-nil, zero value otherwise.
+
+### GetCrlSourceOk
+
+`func (o *IamV2CertificateAuthority) GetCrlSourceOk() (*string, bool)`
+
+GetCrlSourceOk returns a tuple with the CrlSource field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetCrlSource
+
+`func (o *IamV2CertificateAuthority) SetCrlSource(v string)`
+
+SetCrlSource sets CrlSource field to given value.
+
+### HasCrlSource
+
+`func (o *IamV2CertificateAuthority) HasCrlSource() bool`
+
+HasCrlSource returns a boolean if a field has been set.
+
+### GetCrlUrl
+
+`func (o *IamV2CertificateAuthority) GetCrlUrl() string`
+
+GetCrlUrl returns the CrlUrl field if non-nil, zero value otherwise.
+
+### GetCrlUrlOk
+
+`func (o *IamV2CertificateAuthority) GetCrlUrlOk() (*string, bool)`
+
+GetCrlUrlOk returns a tuple with the CrlUrl field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetCrlUrl
+
+`func (o *IamV2CertificateAuthority) SetCrlUrl(v string)`
+
+SetCrlUrl sets CrlUrl field to given value.
+
+### HasCrlUrl
+
+`func (o *IamV2CertificateAuthority) HasCrlUrl() bool`
+
+HasCrlUrl returns a boolean if a field has been set.
+
+### GetCrlUpdatedAt
+
+`func (o *IamV2CertificateAuthority) GetCrlUpdatedAt() time.Time`
+
+GetCrlUpdatedAt returns the CrlUpdatedAt field if non-nil, zero value otherwise.
+
+### GetCrlUpdatedAtOk
+
+`func (o *IamV2CertificateAuthority) GetCrlUpdatedAtOk() (*time.Time, bool)`
+
+GetCrlUpdatedAtOk returns a tuple with the CrlUpdatedAt field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetCrlUpdatedAt
+
+`func (o *IamV2CertificateAuthority) SetCrlUpdatedAt(v time.Time)`
+
+SetCrlUpdatedAt sets CrlUpdatedAt field to given value.
+
+### HasCrlUpdatedAt
+
+`func (o *IamV2CertificateAuthority) HasCrlUpdatedAt() bool`
+
+HasCrlUpdatedAt returns a boolean if a field has been set.
 
 ### GetState
 

--- a/certificate-authority/v2/docs/IamV2CreateCertRequest.md
+++ b/certificate-authority/v2/docs/IamV2CreateCertRequest.md
@@ -12,6 +12,8 @@ Name | Type | Description | Notes
 **Description** | Pointer to **string** | A description of the certificate authority. | [optional] 
 **CertificateChain** | Pointer to **string** | The Base64 encoded string containing the signing certificate chain used to validate client certs. | [optional] 
 **CertificateChainFilename** | Pointer to **string** | The name of the certificate file. | [optional] 
+**CrlUrl** | Pointer to **string** | The url from which to fetch the CRL for the certificate authority if crl_source is URL. | [optional] 
+**CrlChain** | Pointer to **string** | The Base64 encoded string containing the CRL for this certificate authority. Defaults to this over &#x60;crl_url&#x60; if available. | [optional] 
 
 ## Methods
 
@@ -231,6 +233,56 @@ SetCertificateChainFilename sets CertificateChainFilename field to given value.
 `func (o *IamV2CreateCertRequest) HasCertificateChainFilename() bool`
 
 HasCertificateChainFilename returns a boolean if a field has been set.
+
+### GetCrlUrl
+
+`func (o *IamV2CreateCertRequest) GetCrlUrl() string`
+
+GetCrlUrl returns the CrlUrl field if non-nil, zero value otherwise.
+
+### GetCrlUrlOk
+
+`func (o *IamV2CreateCertRequest) GetCrlUrlOk() (*string, bool)`
+
+GetCrlUrlOk returns a tuple with the CrlUrl field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetCrlUrl
+
+`func (o *IamV2CreateCertRequest) SetCrlUrl(v string)`
+
+SetCrlUrl sets CrlUrl field to given value.
+
+### HasCrlUrl
+
+`func (o *IamV2CreateCertRequest) HasCrlUrl() bool`
+
+HasCrlUrl returns a boolean if a field has been set.
+
+### GetCrlChain
+
+`func (o *IamV2CreateCertRequest) GetCrlChain() string`
+
+GetCrlChain returns the CrlChain field if non-nil, zero value otherwise.
+
+### GetCrlChainOk
+
+`func (o *IamV2CreateCertRequest) GetCrlChainOk() (*string, bool)`
+
+GetCrlChainOk returns a tuple with the CrlChain field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetCrlChain
+
+`func (o *IamV2CreateCertRequest) SetCrlChain(v string)`
+
+SetCrlChain sets CrlChain field to given value.
+
+### HasCrlChain
+
+`func (o *IamV2CreateCertRequest) HasCrlChain() bool`
+
+HasCrlChain returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/certificate-authority/v2/docs/IamV2UpdateCertRequest.md
+++ b/certificate-authority/v2/docs/IamV2UpdateCertRequest.md
@@ -12,6 +12,8 @@ Name | Type | Description | Notes
 **Description** | Pointer to **string** | A description of the certificate authority. | [optional] 
 **CertificateChain** | Pointer to **string** | The Base64 encoded string containing the signing certificate chain used to validate client certs. | [optional] 
 **CertificateChainFilename** | Pointer to **string** | The name of the certificate file. Must be set if certificate is updated. | [optional] 
+**CrlUrl** | Pointer to **string** | The url from which to fetch the CRL for the certificate authority if crl_source is URL. | [optional] 
+**CrlChain** | Pointer to **string** | The Base64 encoded string containing the CRL for this certificate authority. Defaults to this over &#x60;crl_url&#x60; if available. | [optional] 
 
 ## Methods
 
@@ -231,6 +233,56 @@ SetCertificateChainFilename sets CertificateChainFilename field to given value.
 `func (o *IamV2UpdateCertRequest) HasCertificateChainFilename() bool`
 
 HasCertificateChainFilename returns a boolean if a field has been set.
+
+### GetCrlUrl
+
+`func (o *IamV2UpdateCertRequest) GetCrlUrl() string`
+
+GetCrlUrl returns the CrlUrl field if non-nil, zero value otherwise.
+
+### GetCrlUrlOk
+
+`func (o *IamV2UpdateCertRequest) GetCrlUrlOk() (*string, bool)`
+
+GetCrlUrlOk returns a tuple with the CrlUrl field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetCrlUrl
+
+`func (o *IamV2UpdateCertRequest) SetCrlUrl(v string)`
+
+SetCrlUrl sets CrlUrl field to given value.
+
+### HasCrlUrl
+
+`func (o *IamV2UpdateCertRequest) HasCrlUrl() bool`
+
+HasCrlUrl returns a boolean if a field has been set.
+
+### GetCrlChain
+
+`func (o *IamV2UpdateCertRequest) GetCrlChain() string`
+
+GetCrlChain returns the CrlChain field if non-nil, zero value otherwise.
+
+### GetCrlChainOk
+
+`func (o *IamV2UpdateCertRequest) GetCrlChainOk() (*string, bool)`
+
+GetCrlChainOk returns a tuple with the CrlChain field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetCrlChain
+
+`func (o *IamV2UpdateCertRequest) SetCrlChain(v string)`
+
+SetCrlChain sets CrlChain field to given value.
+
+### HasCrlChain
+
+`func (o *IamV2UpdateCertRequest) HasCrlChain() bool`
+
+HasCrlChain returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/certificate-authority/v2/model_iam_v2_certificate_authority.go
+++ b/certificate-authority/v2/model_iam_v2_certificate_authority.go
@@ -56,6 +56,12 @@ type IamV2CertificateAuthority struct {
 	SerialNumbers *[]string `json:"serial_numbers,omitempty"`
 	// The file name of the uploaded pem file for this certificate authority.
 	CertificateChainFilename *string `json:"certificate_chain_filename,omitempty"`
+	// The source specifies whether the Certificate Revocation List (CRL) is updated from either local file uploaded (LOCAL) or from url of CRL (URL).
+	CrlSource *string `json:"crl_source,omitempty"`
+	// The url from which to fetch the CRL for the certificate authority if crl_source is URL.
+	CrlUrl *string `json:"crl_url,omitempty"`
+	// The timestamp for when CRL was last updated.
+	CrlUpdatedAt *time.Time `json:"crl_updated_at,omitempty"`
 	// The current state of the certificate authority.
 	State *string `json:"state,omitempty"`
 }
@@ -397,6 +403,102 @@ func (o *IamV2CertificateAuthority) SetCertificateChainFilename(v string) {
 	o.CertificateChainFilename = &v
 }
 
+// GetCrlSource returns the CrlSource field value if set, zero value otherwise.
+func (o *IamV2CertificateAuthority) GetCrlSource() string {
+	if o == nil || o.CrlSource == nil {
+		var ret string
+		return ret
+	}
+	return *o.CrlSource
+}
+
+// GetCrlSourceOk returns a tuple with the CrlSource field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *IamV2CertificateAuthority) GetCrlSourceOk() (*string, bool) {
+	if o == nil || o.CrlSource == nil {
+		return nil, false
+	}
+	return o.CrlSource, true
+}
+
+// HasCrlSource returns a boolean if a field has been set.
+func (o *IamV2CertificateAuthority) HasCrlSource() bool {
+	if o != nil && o.CrlSource != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCrlSource gets a reference to the given string and assigns it to the CrlSource field.
+func (o *IamV2CertificateAuthority) SetCrlSource(v string) {
+	o.CrlSource = &v
+}
+
+// GetCrlUrl returns the CrlUrl field value if set, zero value otherwise.
+func (o *IamV2CertificateAuthority) GetCrlUrl() string {
+	if o == nil || o.CrlUrl == nil {
+		var ret string
+		return ret
+	}
+	return *o.CrlUrl
+}
+
+// GetCrlUrlOk returns a tuple with the CrlUrl field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *IamV2CertificateAuthority) GetCrlUrlOk() (*string, bool) {
+	if o == nil || o.CrlUrl == nil {
+		return nil, false
+	}
+	return o.CrlUrl, true
+}
+
+// HasCrlUrl returns a boolean if a field has been set.
+func (o *IamV2CertificateAuthority) HasCrlUrl() bool {
+	if o != nil && o.CrlUrl != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCrlUrl gets a reference to the given string and assigns it to the CrlUrl field.
+func (o *IamV2CertificateAuthority) SetCrlUrl(v string) {
+	o.CrlUrl = &v
+}
+
+// GetCrlUpdatedAt returns the CrlUpdatedAt field value if set, zero value otherwise.
+func (o *IamV2CertificateAuthority) GetCrlUpdatedAt() time.Time {
+	if o == nil || o.CrlUpdatedAt == nil {
+		var ret time.Time
+		return ret
+	}
+	return *o.CrlUpdatedAt
+}
+
+// GetCrlUpdatedAtOk returns a tuple with the CrlUpdatedAt field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *IamV2CertificateAuthority) GetCrlUpdatedAtOk() (*time.Time, bool) {
+	if o == nil || o.CrlUpdatedAt == nil {
+		return nil, false
+	}
+	return o.CrlUpdatedAt, true
+}
+
+// HasCrlUpdatedAt returns a boolean if a field has been set.
+func (o *IamV2CertificateAuthority) HasCrlUpdatedAt() bool {
+	if o != nil && o.CrlUpdatedAt != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCrlUpdatedAt gets a reference to the given time.Time and assigns it to the CrlUpdatedAt field.
+func (o *IamV2CertificateAuthority) SetCrlUpdatedAt(v time.Time) {
+	o.CrlUpdatedAt = &v
+}
+
 // GetState returns the State field value if set, zero value otherwise.
 func (o *IamV2CertificateAuthority) GetState() string {
 	if o == nil || o.State == nil {
@@ -441,6 +543,9 @@ func (o *IamV2CertificateAuthority) Redact() {
 	o.recurseRedact(o.ExpirationDates)
 	o.recurseRedact(o.SerialNumbers)
 	o.recurseRedact(o.CertificateChainFilename)
+	o.recurseRedact(o.CrlSource)
+	o.recurseRedact(o.CrlUrl)
+	o.recurseRedact(o.CrlUpdatedAt)
 	o.recurseRedact(o.State)
 }
 
@@ -505,6 +610,15 @@ func (o IamV2CertificateAuthority) MarshalJSON() ([]byte, error) {
 	}
 	if o.CertificateChainFilename != nil {
 		toSerialize["certificate_chain_filename"] = o.CertificateChainFilename
+	}
+	if o.CrlSource != nil {
+		toSerialize["crl_source"] = o.CrlSource
+	}
+	if o.CrlUrl != nil {
+		toSerialize["crl_url"] = o.CrlUrl
+	}
+	if o.CrlUpdatedAt != nil {
+		toSerialize["crl_updated_at"] = o.CrlUpdatedAt
 	}
 	if o.State != nil {
 		toSerialize["state"] = o.State

--- a/certificate-authority/v2/model_iam_v2_create_cert_request.go
+++ b/certificate-authority/v2/model_iam_v2_create_cert_request.go
@@ -51,6 +51,10 @@ type IamV2CreateCertRequest struct {
 	CertificateChain *string `json:"certificate_chain,omitempty"`
 	// The name of the certificate file.
 	CertificateChainFilename *string `json:"certificate_chain_filename,omitempty"`
+	// The url from which to fetch the CRL for the certificate authority if crl_source is URL.
+	CrlUrl *string `json:"crl_url,omitempty"`
+	// The Base64 encoded string containing the CRL for this certificate authority. Defaults to this over `crl_url` if available.
+	CrlChain *string `json:"crl_chain,omitempty"`
 }
 
 // NewIamV2CreateCertRequest instantiates a new IamV2CreateCertRequest object
@@ -326,6 +330,70 @@ func (o *IamV2CreateCertRequest) SetCertificateChainFilename(v string) {
 	o.CertificateChainFilename = &v
 }
 
+// GetCrlUrl returns the CrlUrl field value if set, zero value otherwise.
+func (o *IamV2CreateCertRequest) GetCrlUrl() string {
+	if o == nil || o.CrlUrl == nil {
+		var ret string
+		return ret
+	}
+	return *o.CrlUrl
+}
+
+// GetCrlUrlOk returns a tuple with the CrlUrl field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *IamV2CreateCertRequest) GetCrlUrlOk() (*string, bool) {
+	if o == nil || o.CrlUrl == nil {
+		return nil, false
+	}
+	return o.CrlUrl, true
+}
+
+// HasCrlUrl returns a boolean if a field has been set.
+func (o *IamV2CreateCertRequest) HasCrlUrl() bool {
+	if o != nil && o.CrlUrl != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCrlUrl gets a reference to the given string and assigns it to the CrlUrl field.
+func (o *IamV2CreateCertRequest) SetCrlUrl(v string) {
+	o.CrlUrl = &v
+}
+
+// GetCrlChain returns the CrlChain field value if set, zero value otherwise.
+func (o *IamV2CreateCertRequest) GetCrlChain() string {
+	if o == nil || o.CrlChain == nil {
+		var ret string
+		return ret
+	}
+	return *o.CrlChain
+}
+
+// GetCrlChainOk returns a tuple with the CrlChain field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *IamV2CreateCertRequest) GetCrlChainOk() (*string, bool) {
+	if o == nil || o.CrlChain == nil {
+		return nil, false
+	}
+	return o.CrlChain, true
+}
+
+// HasCrlChain returns a boolean if a field has been set.
+func (o *IamV2CreateCertRequest) HasCrlChain() bool {
+	if o != nil && o.CrlChain != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCrlChain gets a reference to the given string and assigns it to the CrlChain field.
+func (o *IamV2CreateCertRequest) SetCrlChain(v string) {
+	o.CrlChain = &v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *IamV2CreateCertRequest) Redact() {
 	o.recurseRedact(o.ApiVersion)
@@ -336,6 +404,8 @@ func (o *IamV2CreateCertRequest) Redact() {
 	o.recurseRedact(o.Description)
 	o.recurseRedact(o.CertificateChain)
 	o.recurseRedact(o.CertificateChainFilename)
+	o.recurseRedact(o.CrlUrl)
+	o.recurseRedact(o.CrlChain)
 }
 
 func (o *IamV2CreateCertRequest) recurseRedact(v interface{}) {
@@ -393,6 +463,12 @@ func (o IamV2CreateCertRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.CertificateChainFilename != nil {
 		toSerialize["certificate_chain_filename"] = o.CertificateChainFilename
+	}
+	if o.CrlUrl != nil {
+		toSerialize["crl_url"] = o.CrlUrl
+	}
+	if o.CrlChain != nil {
+		toSerialize["crl_chain"] = o.CrlChain
 	}
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)

--- a/certificate-authority/v2/model_iam_v2_update_cert_request.go
+++ b/certificate-authority/v2/model_iam_v2_update_cert_request.go
@@ -51,6 +51,10 @@ type IamV2UpdateCertRequest struct {
 	CertificateChain *string `json:"certificate_chain,omitempty"`
 	// The name of the certificate file. Must be set if certificate is updated.
 	CertificateChainFilename *string `json:"certificate_chain_filename,omitempty"`
+	// The url from which to fetch the CRL for the certificate authority if crl_source is URL.
+	CrlUrl *string `json:"crl_url,omitempty"`
+	// The Base64 encoded string containing the CRL for this certificate authority. Defaults to this over `crl_url` if available.
+	CrlChain *string `json:"crl_chain,omitempty"`
 }
 
 // NewIamV2UpdateCertRequest instantiates a new IamV2UpdateCertRequest object
@@ -326,6 +330,70 @@ func (o *IamV2UpdateCertRequest) SetCertificateChainFilename(v string) {
 	o.CertificateChainFilename = &v
 }
 
+// GetCrlUrl returns the CrlUrl field value if set, zero value otherwise.
+func (o *IamV2UpdateCertRequest) GetCrlUrl() string {
+	if o == nil || o.CrlUrl == nil {
+		var ret string
+		return ret
+	}
+	return *o.CrlUrl
+}
+
+// GetCrlUrlOk returns a tuple with the CrlUrl field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *IamV2UpdateCertRequest) GetCrlUrlOk() (*string, bool) {
+	if o == nil || o.CrlUrl == nil {
+		return nil, false
+	}
+	return o.CrlUrl, true
+}
+
+// HasCrlUrl returns a boolean if a field has been set.
+func (o *IamV2UpdateCertRequest) HasCrlUrl() bool {
+	if o != nil && o.CrlUrl != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCrlUrl gets a reference to the given string and assigns it to the CrlUrl field.
+func (o *IamV2UpdateCertRequest) SetCrlUrl(v string) {
+	o.CrlUrl = &v
+}
+
+// GetCrlChain returns the CrlChain field value if set, zero value otherwise.
+func (o *IamV2UpdateCertRequest) GetCrlChain() string {
+	if o == nil || o.CrlChain == nil {
+		var ret string
+		return ret
+	}
+	return *o.CrlChain
+}
+
+// GetCrlChainOk returns a tuple with the CrlChain field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *IamV2UpdateCertRequest) GetCrlChainOk() (*string, bool) {
+	if o == nil || o.CrlChain == nil {
+		return nil, false
+	}
+	return o.CrlChain, true
+}
+
+// HasCrlChain returns a boolean if a field has been set.
+func (o *IamV2UpdateCertRequest) HasCrlChain() bool {
+	if o != nil && o.CrlChain != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCrlChain gets a reference to the given string and assigns it to the CrlChain field.
+func (o *IamV2UpdateCertRequest) SetCrlChain(v string) {
+	o.CrlChain = &v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *IamV2UpdateCertRequest) Redact() {
 	o.recurseRedact(o.ApiVersion)
@@ -336,6 +404,8 @@ func (o *IamV2UpdateCertRequest) Redact() {
 	o.recurseRedact(o.Description)
 	o.recurseRedact(o.CertificateChain)
 	o.recurseRedact(o.CertificateChainFilename)
+	o.recurseRedact(o.CrlUrl)
+	o.recurseRedact(o.CrlChain)
 }
 
 func (o *IamV2UpdateCertRequest) recurseRedact(v interface{}) {
@@ -393,6 +463,12 @@ func (o IamV2UpdateCertRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.CertificateChainFilename != nil {
 		toSerialize["certificate_chain_filename"] = o.CertificateChainFilename
+	}
+	if o.CrlUrl != nil {
+		toSerialize["crl_url"] = o.CrlUrl
+	}
+	if o.CrlChain != nil {
+		toSerialize["crl_chain"] = o.CrlChain
 	}
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)


### PR DESCRIPTION
go vet -v:
```
internal/godebugs
internal/itoa
encoding
math/bits
cmp
slices
unicode/utf16
crypto/internal/alias
internal/race
crypto/subtle
crypto/internal/boring/sig
vendor/golang.org/x/crypto/cryptobyte/asn1
internal/nettrace
container/list
vendor/golang.org/x/crypto/internal/alias
log/internal
internal/coverage/rtcov
internal/cpu
internal/bytealg
math
internal/goarch
internal/unsafeheader
sync/atomic
unicode/utf8
internal/goos
runtime/internal/atomic
runtime/internal/math
internal/goexperiment
internal/chacha8rand
unicode
internal/abi
runtime/internal/sys
runtime
internal/reflectlite
sync
errors
internal/singleflight
sort
internal/testlog
internal/bisect
internal/godebug
path
internal/oserror
io
internal/safefilepath
vendor/golang.org/x/net/dns/dnsmessage
crypto/internal/randutil
hash
internal/intern
math/rand
bytes
strconv
strings
crypto/internal/nistec/fiat
vendor/golang.org/x/text/transform
hash/crc32
crypto
crypto/rc4
net/http/internal/ascii
net/netip
bufio
regexp/syntax
reflect
syscall
regexp
internal/fmtsort
encoding/binary
internal/syscall/execenv
encoding/base64
internal/syscall/unix
vendor/golang.org/x/crypto/internal/poly1305
crypto/md5
time
crypto/internal/edwards25519/field
crypto/cipher
encoding/pem
context
crypto/x509/internal/macos
crypto/des
crypto/internal/boring
vendor/golang.org/x/crypto/chacha20
crypto/internal/edwards25519
io/fs
crypto/hmac
internal/poll
crypto/sha1
embed
crypto/sha512
crypto/sha256
crypto/aes
vendor/golang.org/x/crypto/hkdf
crypto/internal/nistec
crypto/ecdh
os
io/ioutil
fmt
path/filepath
vendor/golang.org/x/sys/cpu
vendor/golang.org/x/net/route
log
net/url
encoding/hex
vendor/golang.org/x/net/http2/hpack
vendor/golang.org/x/crypto/chacha20poly1305
mime
compress/flate
encoding/xml
net/http/internal
encoding/json
mime/quotedprintable
vendor/golang.org/x/text/unicode/norm
compress/gzip
vendor/golang.org/x/text/unicode/bidi
math/big
vendor/golang.org/x/text/secure/bidirule
crypto/internal/bigmod
vendor/golang.org/x/net/idna
crypto/internal/boring/bbig
crypto/rand
crypto/dsa
crypto/elliptic
encoding/asn1
crypto/ed25519
crypto/rsa
crypto/x509/pkix
vendor/golang.org/x/crypto/cryptobyte
crypto/ecdsa
runtime/cgo
net
vendor/golang.org/x/net/http/httpproxy
net/textproto
crypto/x509
vendor/golang.org/x/net/http/httpguts
mime/multipart
crypto/tls
net/http/httptrace
net/http
golang.org/x/net/context/ctxhttp
net/http/httputil
golang.org/x/oauth2/internal
golang.org/x/oauth2
github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority/v2
```