### PR TITLE
Reduce go requirement for flink artifact SDK from 1.22.8 to 1.22.7

### DIFF
--- a/flink-artifact/go.mod
+++ b/flink-artifact/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact
 
-go 1.22.8
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99
 


### PR DESCRIPTION
go vet -v:
```
internal/goarch
internal/abi
internal/chacha8rand
internal/cpu
runtime/internal/math
internal/bytealg
internal/itoa
encoding
math/bits
cmp
slices
unicode/utf16
math
crypto/internal/alias
crypto/subtle
crypto/internal/boring/sig
vendor/golang.org/x/crypto/cryptobyte/asn1
internal/nettrace
container/list
vendor/golang.org/x/crypto/internal/alias
log/internal
runtime/internal/atomic
internal/race
sync/atomic
internal/goos
internal/godebugs
unicode/utf8
internal/unsafeheader
internal/goexperiment
internal/coverage/rtcov
runtime/internal/sys
unicode
runtime
internal/reflectlite
sync
internal/testlog
internal/bisect
internal/singleflight
errors
sort
internal/godebug
path
internal/oserror
internal/safefilepath
io
vendor/golang.org/x/net/dns/dnsmessage
strconv
hash
internal/intern
crypto/internal/randutil
math/rand
crypto/internal/nistec/fiat
bytes
crypto/rc4
strings
crypto
hash/crc32
vendor/golang.org/x/text/transform
net/netip
reflect
net/http/internal/ascii
bufio
syscall
regexp/syntax
internal/fmtsort
internal/syscall/execenv
encoding/binary
regexp
time
internal/syscall/unix
encoding/base64
vendor/golang.org/x/crypto/internal/poly1305
crypto/md5
crypto/internal/edwards25519/field
crypto/cipher
context
encoding/pem
crypto/x509/internal/macos
crypto/des
crypto/internal/boring
vendor/golang.org/x/crypto/chacha20
io/fs
crypto/internal/edwards25519
crypto/hmac
embed
internal/poll
crypto/sha1
crypto/sha512
crypto/sha256
crypto/aes
vendor/golang.org/x/crypto/hkdf
crypto/internal/nistec
crypto/ecdh
os
io/ioutil
fmt
path/filepath
vendor/golang.org/x/sys/cpu
vendor/golang.org/x/net/route
encoding/hex
net/url
log
encoding/xml
vendor/golang.org/x/net/http2/hpack
vendor/golang.org/x/crypto/chacha20poly1305
compress/flate
encoding/json
net/http/internal
mime
mime/quotedprintable
vendor/golang.org/x/text/unicode/norm
vendor/golang.org/x/text/unicode/bidi
compress/gzip
math/big
vendor/golang.org/x/text/secure/bidirule
crypto/internal/bigmod
crypto/internal/boring/bbig
crypto/dsa
crypto/rand
crypto/elliptic
crypto/rsa
crypto/ed25519
encoding/asn1
crypto/x509/pkix
vendor/golang.org/x/net/idna
vendor/golang.org/x/crypto/cryptobyte
crypto/ecdsa
runtime/cgo
net
net/textproto
crypto/x509
vendor/golang.org/x/net/http/httpproxy
vendor/golang.org/x/net/http/httpguts
mime/multipart
crypto/tls
net/http/httptrace
net/http
golang.org/x/net/context/ctxhttp
net/http/httputil
golang.org/x/oauth2/internal
golang.org/x/oauth2
github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact/v1
```