### PR TITLE
feat: update sdk with parent-scopes

### DIFF
--- a/iam-ip-filtering/v2/api/openapi.yaml
+++ b/iam-ip-filtering/v2/api/openapi.yaml
@@ -19,7 +19,7 @@ servers:
   url: https://api.devel.cpdev.cloud
 tags:
 - description: |-
-    [![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Groups API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Groups%20API-%23bc8540)](mailto:cloud-support@confluent.io?subject=Request%20to%20join%20IP%20Filtering%20API%20Limited%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Access%20for%20IP%20Filtering.%0AMy%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.%0A)
+    [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
     Definitions of networks which can be named and referred by IP blocks, commonly used to attach to IP Filter rules.
 
@@ -28,7 +28,7 @@ tags:
     <SchemaDefinition schemaRef="#/components/schemas/iam.v2.IpGroup" />
   name: IP Groups (iam/v2)
 - description: |-
-    [![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filters API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filters%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+    [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
     `IP Filter` objects are bindings between IP Groups and Confluent resource(s).
     For example, a binding between "CorpNet" and "Management APIs" will enforce that
@@ -43,7 +43,7 @@ tags:
     <SchemaDefinition schemaRef="#/components/schemas/iam.v2.IpFilter" />
   name: IP Filters (iam/v2)
 - description: |-
-    [![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filter Summary API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filter%20Summary%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+    [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
     The IP Filter Summary endpoint returns an aggregation of the IP Filters across the system.
     This API can be queried in the context of an organization or an environment. It returns a
@@ -58,7 +58,7 @@ paths:
   /iam/v2/ip-groups:
     get:
       description: |-
-        [![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Groups API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Groups%20API-%23bc8540)](mailto:cloud-support@confluent.io?subject=Request%20to%20join%20IP%20Filtering%20API%20Limited%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Access%20for%20IP%20Filtering.%0AMy%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.%0A)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Retrieve a sorted, filtered, paginated list of all IP groups.
       operationId: listIamV2IpGroups
@@ -353,7 +353,7 @@ paths:
           IRestResponse response = client.Execute(request);
     post:
       description: |-
-        [![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Groups API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Groups%20API-%23bc8540)](mailto:cloud-support@confluent.io?subject=Request%20to%20join%20IP%20Filtering%20API%20Limited%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Access%20for%20IP%20Filtering.%0AMy%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.%0A)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Make a request to create an IP group.
       operationId: createIamV2IpGroup
@@ -720,7 +720,7 @@ paths:
   /iam/v2/ip-groups/{id}:
     delete:
       description: |-
-        [![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Groups API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Groups%20API-%23bc8540)](mailto:cloud-support@confluent.io?subject=Request%20to%20join%20IP%20Filtering%20API%20Limited%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Access%20for%20IP%20Filtering.%0AMy%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.%0A)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Make a request to delete an IP group.
       operationId: deleteIamV2IpGroup
@@ -1012,7 +1012,7 @@ paths:
           IRestResponse response = client.Execute(request);
     get:
       description: |-
-        [![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Groups API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Groups%20API-%23bc8540)](mailto:cloud-support@confluent.io?subject=Request%20to%20join%20IP%20Filtering%20API%20Limited%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Access%20for%20IP%20Filtering.%0AMy%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.%0A)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Make a request to read an IP group.
       operationId: getIamV2IpGroup
@@ -1316,7 +1316,7 @@ paths:
           IRestResponse response = client.Execute(request);
     patch:
       description: |+
-        [![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Groups API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Groups%20API-%23bc8540)](mailto:cloud-support@confluent.io?subject=Request%20to%20join%20IP%20Filtering%20API%20Limited%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Access%20for%20IP%20Filtering.%0AMy%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.%0A)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Make a request to update an IP group.
 
@@ -1701,7 +1701,7 @@ paths:
   /iam/v2/ip-filters:
     get:
       description: |-
-        [![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filters API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filters%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Retrieve a sorted, filtered, paginated list of all IP filters.
       operationId: listIamV2IpFilters
@@ -1714,20 +1714,11 @@ paths:
         schema:
           type: string
         style: form
-      - description: List all filters defined at the organization scope. This parameter
-          defaults to false.
-        explode: true
-        in: query
-        name: include_only_org_scope_filters
-        required: false
-        schema:
-          type: string
-        style: form
       - description: If set to true, this includes filters defined at the organization
           level. The resource scope must also be set to use this parameter.
         explode: true
         in: query
-        name: include_parent_scope
+        name: include_parent_scopes
         required: false
         schema:
           type: string
@@ -2022,7 +2013,7 @@ paths:
           IRestResponse response = client.Execute(request);
     post:
       description: |-
-        [![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filters API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filters%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Make a request to create an IP filter.
       operationId: createIamV2IpFilter
@@ -2400,7 +2391,7 @@ paths:
   /iam/v2/ip-filters/{id}:
     delete:
       description: |-
-        [![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filters API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filters%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Make a request to delete an IP filter.
       operationId: deleteIamV2IpFilter
@@ -2692,7 +2683,7 @@ paths:
           IRestResponse response = client.Execute(request);
     get:
       description: |-
-        [![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filters API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filters%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Make a request to read an IP filter.
       operationId: getIamV2IpFilter
@@ -2997,7 +2988,7 @@ paths:
           IRestResponse response = client.Execute(request);
     patch:
       description: |+
-        [![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filters API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filters%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Make a request to update an IP filter.
 
@@ -3392,7 +3383,7 @@ paths:
   /iam/v2/ip-filter-summary:
     get:
       description: |-
-        [![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filter Summary API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filter%20Summary%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+        [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
         Make a request to read an IP filter summary.
       operationId: getIamV2IpFilterSummary
@@ -3404,7 +3395,7 @@ paths:
         name: scope
         required: true
         schema:
-          $ref: '#/components/schemas/SearchFilter'
+          type: string
         style: form
       responses:
         "200":
@@ -3418,13 +3409,6 @@ paths:
                   - categories
                   - kind
                   - scope
-                  type: object
-                - properties:
-                    scope:
-                      example:
-                        id: crn://confluent.cloud/organization=org-123/environment=env-abc
-                        related: https://api.confluent.cloud/v2/ip-filter-summaries/crn://confluent.cloud/organization=org-123/environment=env-abc
-                        resource_name: https://api.confluent.cloud/organization=9bb441c4-edef-46ac-8a41-c49e44a3fd9a/ip-filter-summary=crn://confluent.cloud/organization=org-123/environment=env-abc
                   type: object
           description: IP Filter Summary.
           headers:
@@ -3621,14 +3605,14 @@ paths:
       - lang: Shell
         source: |-
           curl --request GET \
-            --url 'https://api.confluent.cloud/iam/v2/ip-filter-summary?scope=crn://confluent.cloud/organization=org-123/environment=env-abc' \
+            --url https://api.confluent.cloud/iam/v2/ip-filter-summary \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           Request request = new Request.Builder()
-            .url("https://api.confluent.cloud/iam/v2/ip-filter-summary?scope=crn://confluent.cloud/organization=org-123/environment=env-abc")
+            .url("https://api.confluent.cloud/iam/v2/ip-filter-summary")
             .get()
             .addHeader("Authorization", "Basic REPLACE_BASIC_AUTH")
             .build();
@@ -3636,7 +3620,7 @@ paths:
           Response response = client.newCall(request).execute();
       - lang: Go
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io/ioutil\"\
-          \n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/iam/v2/ip-filter-summary?scope=crn://confluent.cloud/organization=org-123/environment=env-abc\"\
+          \n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/iam/v2/ip-filter-summary\"\
           \n\n\treq, _ := http.NewRequest(\"GET\", url, nil)\n\n\treq.Header.Add(\"\
           Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
           \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
@@ -3649,7 +3633,7 @@ paths:
 
           headers = { 'Authorization': "Basic REPLACE_BASIC_AUTH" }
 
-          conn.request("GET", "/iam/v2/ip-filter-summary?scope=crn://confluent.cloud/organization=org-123/environment=env-abc", headers=headers)
+          conn.request("GET", "/iam/v2/ip-filter-summary", headers=headers)
 
           res = conn.getresponse()
           data = res.read()
@@ -3663,7 +3647,7 @@ paths:
             "method": "GET",
             "hostname": "api.confluent.cloud",
             "port": null,
-            "path": "/iam/v2/ip-filter-summary?scope=crn://confluent.cloud/organization=org-123/environment=env-abc",
+            "path": "/iam/v2/ip-filter-summary",
             "headers": {
               "Authorization": "Basic REPLACE_BASIC_AUTH"
             }
@@ -3688,7 +3672,7 @@ paths:
           CURL *hnd = curl_easy_init();
 
           curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "GET");
-          curl_easy_setopt(hnd, CURLOPT_URL, "https://api.confluent.cloud/iam/v2/ip-filter-summary?scope=crn://confluent.cloud/organization=org-123/environment=env-abc");
+          curl_easy_setopt(hnd, CURLOPT_URL, "https://api.confluent.cloud/iam/v2/ip-filter-summary");
 
           struct curl_slist *headers = NULL;
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
@@ -3697,7 +3681,7 @@ paths:
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
         source: |-
-          var client = new RestClient("https://api.confluent.cloud/iam/v2/ip-filter-summary?scope=crn://confluent.cloud/organization=org-123/environment=env-abc");
+          var client = new RestClient("https://api.confluent.cloud/iam/v2/ip-filter-summary");
           var request = new RestRequest(Method.GET);
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
           IRestResponse response = client.Execute(request);
@@ -4096,9 +4080,8 @@ components:
           readOnly: true
           type: string
         scope:
-          allOf:
-          - $ref: '#/components/schemas/ObjectReference'
           description: The scope associated with this object.
+          type: string
         categories:
           description: |
             Summary of the operation groups and IP filters created in those operation groups.

--- a/iam-ip-filtering/v2/api_ip_filter_summaries_iam_v2.go
+++ b/iam-ip-filtering/v2/api_ip_filter_summaries_iam_v2.go
@@ -43,7 +43,7 @@ type IPFilterSummariesIamV2Api interface {
 	/*
 	GetIamV2IpFilterSummary Read an IP Filter Summary
 
-	[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filter Summary API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filter%20Summary%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+	[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to read an IP filter summary.
 
@@ -79,7 +79,7 @@ func (r ApiGetIamV2IpFilterSummaryRequest) Execute() (IamV2IpFilterSummary, *_ne
 /*
 GetIamV2IpFilterSummary Read an IP Filter Summary
 
-[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filter Summary API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filter%20Summary%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to read an IP filter summary.
 

--- a/iam-ip-filtering/v2/api_ip_filters_iam_v2.go
+++ b/iam-ip-filtering/v2/api_ip_filters_iam_v2.go
@@ -44,7 +44,7 @@ type IPFiltersIamV2Api interface {
 	/*
 	CreateIamV2IpFilter Create an IP Filter
 
-	[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filters API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filters%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+	[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to create an IP filter.
 
@@ -60,7 +60,7 @@ Make a request to create an IP filter.
 	/*
 	DeleteIamV2IpFilter Delete an IP Filter
 
-	[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filters API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filters%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+	[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to delete an IP filter.
 
@@ -76,7 +76,7 @@ Make a request to delete an IP filter.
 	/*
 	GetIamV2IpFilter Read an IP Filter
 
-	[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filters API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filters%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+	[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to read an IP filter.
 
@@ -93,7 +93,7 @@ Make a request to read an IP filter.
 	/*
 	ListIamV2IpFilters List of IP Filters
 
-	[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filters API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filters%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+	[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Retrieve a sorted, filtered, paginated list of all IP filters.
 
@@ -109,7 +109,7 @@ Retrieve a sorted, filtered, paginated list of all IP filters.
 	/*
 	UpdateIamV2IpFilter Update an IP Filter
 
-	[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filters API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filters%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+	[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to update an IP filter.
 
@@ -147,7 +147,7 @@ func (r ApiCreateIamV2IpFilterRequest) Execute() (IamV2IpFilter, *_nethttp.Respo
 /*
 CreateIamV2IpFilter Create an IP Filter
 
-[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filters API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filters%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to create an IP filter.
 
@@ -313,7 +313,7 @@ func (r ApiDeleteIamV2IpFilterRequest) Execute() (*_nethttp.Response, error) {
 /*
 DeleteIamV2IpFilter Delete an IP Filter
 
-[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filters API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filters%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to delete an IP filter.
 
@@ -459,7 +459,7 @@ func (r ApiGetIamV2IpFilterRequest) Execute() (IamV2IpFilter, *_nethttp.Response
 /*
 GetIamV2IpFilter Read an IP Filter
 
-[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filters API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filters%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to read an IP filter.
 
@@ -606,8 +606,7 @@ type ApiListIamV2IpFiltersRequest struct {
 	ctx _context.Context
 	ApiService IPFiltersIamV2Api
 	resourceScope *string
-	includeOnlyOrgScopeFilters *string
-	includeParentScope *string
+	includeParentScopes *string
 	pageSize *int32
 	pageToken *string
 }
@@ -617,14 +616,9 @@ func (r ApiListIamV2IpFiltersRequest) ResourceScope(resourceScope string) ApiLis
 	r.resourceScope = &resourceScope
 	return r
 }
-// List all filters defined at the organization scope. This parameter defaults to false.
-func (r ApiListIamV2IpFiltersRequest) IncludeOnlyOrgScopeFilters(includeOnlyOrgScopeFilters string) ApiListIamV2IpFiltersRequest {
-	r.includeOnlyOrgScopeFilters = &includeOnlyOrgScopeFilters
-	return r
-}
 // If set to true, this includes filters defined at the organization level. The resource scope must also be set to use this parameter.
-func (r ApiListIamV2IpFiltersRequest) IncludeParentScope(includeParentScope string) ApiListIamV2IpFiltersRequest {
-	r.includeParentScope = &includeParentScope
+func (r ApiListIamV2IpFiltersRequest) IncludeParentScopes(includeParentScopes string) ApiListIamV2IpFiltersRequest {
+	r.includeParentScopes = &includeParentScopes
 	return r
 }
 // A pagination size for collection requests.
@@ -645,7 +639,7 @@ func (r ApiListIamV2IpFiltersRequest) Execute() (IamV2IpFilterList, *_nethttp.Re
 /*
 ListIamV2IpFilters List of IP Filters
 
-[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filters API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filters%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Retrieve a sorted, filtered, paginated list of all IP filters.
 
@@ -685,11 +679,8 @@ func (a *IPFiltersIamV2ApiService) ListIamV2IpFiltersExecute(r ApiListIamV2IpFil
 	if r.resourceScope != nil {
 		localVarQueryParams.Add("resource_scope", parameterToString(*r.resourceScope, ""))
 	}
-	if r.includeOnlyOrgScopeFilters != nil {
-		localVarQueryParams.Add("include_only_org_scope_filters", parameterToString(*r.includeOnlyOrgScopeFilters, ""))
-	}
-	if r.includeParentScope != nil {
-		localVarQueryParams.Add("include_parent_scope", parameterToString(*r.includeParentScope, ""))
+	if r.includeParentScopes != nil {
+		localVarQueryParams.Add("include_parent_scopes", parameterToString(*r.includeParentScopes, ""))
 	}
 	if r.pageSize != nil {
 		localVarQueryParams.Add("page_size", parameterToString(*r.pageSize, ""))
@@ -809,7 +800,7 @@ func (r ApiUpdateIamV2IpFilterRequest) Execute() (IamV2IpFilter, *_nethttp.Respo
 /*
 UpdateIamV2IpFilter Update an IP Filter
 
-[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Filters API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Filters%20API-%23bc8540)](mailto:ccloud-api-access+iam-v2-limited-availability@confluent.io?subject=Request%20to%20join%20iam/v2%20API%20Limited%20Availability&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Availability%20for%20iam/v2%20to%20provide%20early%20feedback%21%20My%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to update an IP filter.
 

--- a/iam-ip-filtering/v2/api_ip_groups_iam_v2.go
+++ b/iam-ip-filtering/v2/api_ip_groups_iam_v2.go
@@ -44,7 +44,7 @@ type IPGroupsIamV2Api interface {
 	/*
 	CreateIamV2IpGroup Create an IP Group
 
-	[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Groups API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Groups%20API-%23bc8540)](mailto:cloud-support@confluent.io?subject=Request%20to%20join%20IP%20Filtering%20API%20Limited%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Access%20for%20IP%20Filtering.%0AMy%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.%0A)
+	[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to create an IP group.
 
@@ -60,7 +60,7 @@ Make a request to create an IP group.
 	/*
 	DeleteIamV2IpGroup Delete an IP Group
 
-	[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Groups API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Groups%20API-%23bc8540)](mailto:cloud-support@confluent.io?subject=Request%20to%20join%20IP%20Filtering%20API%20Limited%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Access%20for%20IP%20Filtering.%0AMy%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.%0A)
+	[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to delete an IP group.
 
@@ -76,7 +76,7 @@ Make a request to delete an IP group.
 	/*
 	GetIamV2IpGroup Read an IP Group
 
-	[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Groups API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Groups%20API-%23bc8540)](mailto:cloud-support@confluent.io?subject=Request%20to%20join%20IP%20Filtering%20API%20Limited%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Access%20for%20IP%20Filtering.%0AMy%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.%0A)
+	[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to read an IP group.
 
@@ -93,7 +93,7 @@ Make a request to read an IP group.
 	/*
 	ListIamV2IpGroups List of IP Groups
 
-	[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Groups API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Groups%20API-%23bc8540)](mailto:cloud-support@confluent.io?subject=Request%20to%20join%20IP%20Filtering%20API%20Limited%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Access%20for%20IP%20Filtering.%0AMy%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.%0A)
+	[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Retrieve a sorted, filtered, paginated list of all IP groups.
 
@@ -109,7 +109,7 @@ Retrieve a sorted, filtered, paginated list of all IP groups.
 	/*
 	UpdateIamV2IpGroup Update an IP Group
 
-	[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Groups API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Groups%20API-%23bc8540)](mailto:cloud-support@confluent.io?subject=Request%20to%20join%20IP%20Filtering%20API%20Limited%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Access%20for%20IP%20Filtering.%0AMy%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.%0A)
+	[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to update an IP group.
 
@@ -147,7 +147,7 @@ func (r ApiCreateIamV2IpGroupRequest) Execute() (IamV2IpGroup, *_nethttp.Respons
 /*
 CreateIamV2IpGroup Create an IP Group
 
-[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Groups API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Groups%20API-%23bc8540)](mailto:cloud-support@confluent.io?subject=Request%20to%20join%20IP%20Filtering%20API%20Limited%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Access%20for%20IP%20Filtering.%0AMy%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.%0A)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to create an IP group.
 
@@ -313,7 +313,7 @@ func (r ApiDeleteIamV2IpGroupRequest) Execute() (*_nethttp.Response, error) {
 /*
 DeleteIamV2IpGroup Delete an IP Group
 
-[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Groups API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Groups%20API-%23bc8540)](mailto:cloud-support@confluent.io?subject=Request%20to%20join%20IP%20Filtering%20API%20Limited%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Access%20for%20IP%20Filtering.%0AMy%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.%0A)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to delete an IP group.
 
@@ -459,7 +459,7 @@ func (r ApiGetIamV2IpGroupRequest) Execute() (IamV2IpGroup, *_nethttp.Response, 
 /*
 GetIamV2IpGroup Read an IP Group
 
-[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Groups API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Groups%20API-%23bc8540)](mailto:cloud-support@confluent.io?subject=Request%20to%20join%20IP%20Filtering%20API%20Limited%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Access%20for%20IP%20Filtering.%0AMy%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.%0A)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to read an IP group.
 
@@ -627,7 +627,7 @@ func (r ApiListIamV2IpGroupsRequest) Execute() (IamV2IpGroupList, *_nethttp.Resp
 /*
 ListIamV2IpGroups List of IP Groups
 
-[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Groups API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Groups%20API-%23bc8540)](mailto:cloud-support@confluent.io?subject=Request%20to%20join%20IP%20Filtering%20API%20Limited%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Access%20for%20IP%20Filtering.%0AMy%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.%0A)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Retrieve a sorted, filtered, paginated list of all IP groups.
 
@@ -782,7 +782,7 @@ func (r ApiUpdateIamV2IpGroupRequest) Execute() (IamV2IpGroup, *_nethttp.Respons
 /*
 UpdateIamV2IpGroup Update an IP Group
 
-[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Request Access To IP Groups API](https://img.shields.io/badge/-Request%20Access%20To%20IP%20Groups%20API-%23bc8540)](mailto:cloud-support@confluent.io?subject=Request%20to%20join%20IP%20Filtering%20API%20Limited%20Access&body=I%E2%80%99d%20like%20to%20join%20the%20Confluent%20Cloud%20API%20Limited%20Access%20for%20IP%20Filtering.%0AMy%20Cloud%20Organization%20ID%20is%20%3Cretrieve%20from%20https%3A//confluent.cloud/settings/billing/payment%3E.%0A)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
 Make a request to update an IP group.
 

--- a/iam-ip-filtering/v2/docs/IPFiltersIamV2Api.md
+++ b/iam-ip-filtering/v2/docs/IPFiltersIamV2Api.md
@@ -218,7 +218,7 @@ Name | Type | Description  | Notes
 
 ## ListIamV2IpFilters
 
-> IamV2IpFilterList ListIamV2IpFilters(ctx).ResourceScope(resourceScope).IncludeOnlyOrgScopeFilters(includeOnlyOrgScopeFilters).IncludeParentScope(includeParentScope).PageSize(pageSize).PageToken(pageToken).Execute()
+> IamV2IpFilterList ListIamV2IpFilters(ctx).ResourceScope(resourceScope).IncludeParentScopes(includeParentScopes).PageSize(pageSize).PageToken(pageToken).Execute()
 
 List of IP Filters
 
@@ -238,14 +238,13 @@ import (
 
 func main() {
     resourceScope := "resourceScope_example" // string | Lists all filters belonging to the specified resource scope. (optional)
-    includeOnlyOrgScopeFilters := "includeOnlyOrgScopeFilters_example" // string | List all filters defined at the organization scope. This parameter defaults to false. (optional)
-    includeParentScope := "includeParentScope_example" // string | If set to true, this includes filters defined at the organization level. The resource scope must also be set to use this parameter. (optional)
+    includeParentScopes := "includeParentScopes_example" // string | If set to true, this includes filters defined at the organization level. The resource scope must also be set to use this parameter. (optional)
     pageSize := int32(56) // int32 | A pagination size for collection requests. (optional) (default to 25)
     pageToken := "pageToken_example" // string | An opaque pagination token for collection requests. (optional)
 
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
-    resp, r, err := api_client.IPFiltersIamV2Api.ListIamV2IpFilters(context.Background()).ResourceScope(resourceScope).IncludeOnlyOrgScopeFilters(includeOnlyOrgScopeFilters).IncludeParentScope(includeParentScope).PageSize(pageSize).PageToken(pageToken).Execute()
+    resp, r, err := api_client.IPFiltersIamV2Api.ListIamV2IpFilters(context.Background()).ResourceScope(resourceScope).IncludeParentScopes(includeParentScopes).PageSize(pageSize).PageToken(pageToken).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `IPFiltersIamV2Api.ListIamV2IpFilters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -267,8 +266,7 @@ Other parameters are passed through a pointer to a apiListIamV2IpFiltersRequest 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **resourceScope** | **string** | Lists all filters belonging to the specified resource scope. | 
- **includeOnlyOrgScopeFilters** | **string** | List all filters defined at the organization scope. This parameter defaults to false. | 
- **includeParentScope** | **string** | If set to true, this includes filters defined at the organization level. The resource scope must also be set to use this parameter. | 
+ **includeParentScopes** | **string** | If set to true, this includes filters defined at the organization level. The resource scope must also be set to use this parameter. | 
  **pageSize** | **int32** | A pagination size for collection requests. | [default to 25]
  **pageToken** | **string** | An opaque pagination token for collection requests. | 
 

--- a/iam-ip-filtering/v2/docs/IamV2IpFilterSummary.md
+++ b/iam-ip-filtering/v2/docs/IamV2IpFilterSummary.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ApiVersion** | Pointer to **string** | APIVersion defines the schema version of this representation of a resource. | [optional] [readonly] 
 **Kind** | Pointer to **string** | Kind defines the object this REST resource represents. | [optional] [readonly] 
-**Scope** | Pointer to [**ObjectReference**](ObjectReference.md) | The scope associated with this object. | [optional] 
+**Scope** | Pointer to **string** | The scope associated with this object. | [optional] 
 **Categories** | Pointer to [**[]IamV2IpFilterSummaryCategories**](IamV2IpFilterSummaryCategories.md) | Summary of the operation groups and IP filters created in those operation groups.  | [optional] 
 
 ## Methods
@@ -80,20 +80,20 @@ HasKind returns a boolean if a field has been set.
 
 ### GetScope
 
-`func (o *IamV2IpFilterSummary) GetScope() ObjectReference`
+`func (o *IamV2IpFilterSummary) GetScope() string`
 
 GetScope returns the Scope field if non-nil, zero value otherwise.
 
 ### GetScopeOk
 
-`func (o *IamV2IpFilterSummary) GetScopeOk() (*ObjectReference, bool)`
+`func (o *IamV2IpFilterSummary) GetScopeOk() (*string, bool)`
 
 GetScopeOk returns a tuple with the Scope field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetScope
 
-`func (o *IamV2IpFilterSummary) SetScope(v ObjectReference)`
+`func (o *IamV2IpFilterSummary) SetScope(v string)`
 
 SetScope sets Scope field to given value.
 

--- a/iam-ip-filtering/v2/model_iam_v2_ip_filter_summary.go
+++ b/iam-ip-filtering/v2/model_iam_v2_ip_filter_summary.go
@@ -41,7 +41,7 @@ type IamV2IpFilterSummary struct {
 	// Kind defines the object this REST resource represents.
 	Kind *string `json:"kind,omitempty"`
 	// The scope associated with this object.
-	Scope *ObjectReference `json:"scope,omitempty"`
+	Scope *string `json:"scope,omitempty"`
 	// Summary of the operation groups and IP filters created in those operation groups. 
 	Categories *[]IamV2IpFilterSummaryCategories `json:"categories,omitempty"`
 }
@@ -128,9 +128,9 @@ func (o *IamV2IpFilterSummary) SetKind(v string) {
 }
 
 // GetScope returns the Scope field value if set, zero value otherwise.
-func (o *IamV2IpFilterSummary) GetScope() ObjectReference {
+func (o *IamV2IpFilterSummary) GetScope() string {
 	if o == nil || o.Scope == nil {
-		var ret ObjectReference
+		var ret string
 		return ret
 	}
 	return *o.Scope
@@ -138,7 +138,7 @@ func (o *IamV2IpFilterSummary) GetScope() ObjectReference {
 
 // GetScopeOk returns a tuple with the Scope field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *IamV2IpFilterSummary) GetScopeOk() (*ObjectReference, bool) {
+func (o *IamV2IpFilterSummary) GetScopeOk() (*string, bool) {
 	if o == nil || o.Scope == nil {
 		return nil, false
 	}
@@ -154,8 +154,8 @@ func (o *IamV2IpFilterSummary) HasScope() bool {
 	return false
 }
 
-// SetScope gets a reference to the given ObjectReference and assigns it to the Scope field.
-func (o *IamV2IpFilterSummary) SetScope(v ObjectReference) {
+// SetScope gets a reference to the given string and assigns it to the Scope field.
+func (o *IamV2IpFilterSummary) SetScope(v string) {
 	o.Scope = &v
 }
 


### PR DESCRIPTION
Update the public ccloud-sdk-go-v2 repo with the include-parent-scopes parameter (renamed from include-parent-scope): follow up from this: https://github.com/confluentinc/ccloud-sdk-go-v2-internal/pull/552 

Additionally updates previous API changes which didn't get released -- i.e. summary api scope field etc. 

