### PR TITLE
Downgrade golang version to fips compliant version

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,7 +24,7 @@ queue:
 global_job_config:
   prologue:
     commands:
-      - sem-version go 1.22.10
+      - sem-version go 1.22.7
       - export "GOPATH=$(go env GOPATH)"
       - export "SEMAPHORE_GIT_DIR=${GOPATH}/src/github.com/confluentinc/${SEMAPHORE_PROJECT_NAME}"
       - export "PATH=${GOPATH}/bin:${PATH}"

--- a/ai/go.mod
+++ b/ai/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/ai
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/apikeys/go.mod
+++ b/apikeys/go.mod
@@ -1,5 +1,5 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/apikeys
 
-go 1.22.10
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/billing/go.mod
+++ b/billing/go.mod
@@ -1,5 +1,5 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/billing
 
-go 1.22.10
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/byok/go.mod
+++ b/byok/go.mod
@@ -1,5 +1,5 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/byok
 
-go 1.22.10
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/ccl/go.mod
+++ b/ccl/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/ccl
 
-go 1.22.10
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99
 

--- a/cdx/go.mod
+++ b/cdx/go.mod
@@ -1,5 +1,5 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/cdx
 
-go 1.22.10
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/certificate-authority/go.mod
+++ b/certificate-authority/go.mod
@@ -1,5 +1,5 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority
 
-go 1.22.10
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,5 +1,5 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/cli
 
-go 1.22.10
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558

--- a/cmk/go.mod
+++ b/cmk/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/cmk
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/connect-custom-plugin/go.mod
+++ b/connect-custom-plugin/go.mod
@@ -1,5 +1,5 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/connect/go.mod
+++ b/connect/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/connect
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/data-catalog/go.mod
+++ b/data-catalog/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/data-catalog
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/flink-artifact/go.mod
+++ b/flink-artifact/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact
 
-go 1.22.10
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99
 

--- a/flink-gateway/go.mod
+++ b/flink-gateway/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/flink/go.mod
+++ b/flink/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/flink
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/iam-ip-filtering/go.mod
+++ b/iam-ip-filtering/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/iam-ip-filtering
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/iam/go.mod
+++ b/iam/go.mod
@@ -1,5 +1,5 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/iam
 
-go 1.22.10
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558

--- a/identity-provider/go.mod
+++ b/identity-provider/go.mod
@@ -1,5 +1,5 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/identity-provider
 
-go 1.22.10
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/kafka-quotas/go.mod
+++ b/kafka-quotas/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/kafkarest/go.mod
+++ b/kafkarest/go.mod
@@ -1,5 +1,5 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/kafkarest
 
-go 1.22.10
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/ksql/go.mod
+++ b/ksql/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/ksql
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/mds/go.mod
+++ b/mds/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/mds
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/metrics/go.mod
+++ b/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/metrics
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558

--- a/networking-access-point/go.mod
+++ b/networking-access-point/go.mod
@@ -1,5 +1,5 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/networking-access-point
 
-go 1.22.10
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/networking-dnsforwarder/go.mod
+++ b/networking-dnsforwarder/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/networking-dnsforwarder
 
-go 1.22.10
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99
 

--- a/networking-gateway/go.mod
+++ b/networking-gateway/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/networking-gateway
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/networking-ip/go.mod
+++ b/networking-ip/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/networking-ip
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/networking-privatelink/go.mod
+++ b/networking-privatelink/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/networking/go.mod
+++ b/networking/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/networking
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/org/go.mod
+++ b/org/go.mod
@@ -1,5 +1,5 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/org
 
-go 1.22.10
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558

--- a/provider-integration/go.mod
+++ b/provider-integration/go.mod
@@ -1,5 +1,5 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/provider-integration
 
-go 1.22.10
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/schema-registry/go.mod
+++ b/schema-registry/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/schema-registry
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/service-quota/go.mod
+++ b/service-quota/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/service-quota
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,6 @@
 name: ccloud-sdk-go-v2
 lang: go
-lang_version: 1.22.10
+lang_version: 1.22.7
 git:
   enable: true
 github:

--- a/srcm/go.mod
+++ b/srcm/go.mod
@@ -1,5 +1,5 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/srcm
 
-go 1.22.10
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/srcmv3access/go.mod
+++ b/srcmv3access/go.mod
@@ -1,5 +1,5 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/srcmv3access
 
-go 1.22.10
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/sso/go.mod
+++ b/sso/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/sso
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/stream-designer/go.mod
+++ b/stream-designer/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/stream-designer
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/stream-governance/go.mod
+++ b/stream-governance/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/stream-governance
 
-go 1.22.10
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99


### PR DESCRIPTION
Revert golang version bump introduced by https://github.com/confluentinc/ccloud-sdk-go-v2/pull/244/files and https://github.com/confluentinc/ccloud-sdk-go-v2/pull/250

> It's an unfortunate consequence of the FIPS compliant builds for CLI and TF.
> The FIPS builds depend on golang-fips/go, which doesn't have a release for every go version: https://github.com/golang-fips/go/releases
> So if we wanted to update, we would have to update the CLI version to 1.23.2 since that's the next version with a golang-fips release.

Similar past PR: https://github.com/confluentinc/ccloud-sdk-go-v2/pull/243