### PR TITLE
certificate authority: downgrade go version

### DIFF
--- a/certificate-authority/go.mod
+++ b/certificate-authority/go.mod
@@ -1,5 +1,5 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority
 
-go 1.22.12
+go 1.22.7
 
 require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99


### PR DESCRIPTION
downgrade go version for compatibility with CLI changes