### PR TITLE
Update golang version for networking SDK.

### DIFF
--- a/networking/go.mod
+++ b/networking/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/ccloud-sdk-go-v2/networking
 
-go 1.23.6
+go 1.22.7
 
 require (
 	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99


### PR DESCRIPTION
### What
This is a follow-up to [this PR](https://github.com/confluentinc/ccloud-sdk-go-v2/pull/264) to update the Go version of the Networking SDK to match the Go version used in the Confluent CLI.

### Note
This is required to avoid the following output in CLI / TF Provider:
```
➜  terraform-provider-confluent git:(add-endpoint-suffix) ✗ go mod download
go: module github.com/confluentinc/ccloud-sdk-go-v2/networking@v0.13.0 requires go >= 1.23.6; switching to go1.23.6

```