### PR TITLE
Update connect-custom-plugin sdk

### DIFF
--- a/connect-custom-plugin/v1/README.md
+++ b/connect-custom-plugin/v1/README.md
@@ -101,6 +101,7 @@ Class | Method | HTTP request | Description
  - [ConnectV1CustomConnectorPluginUploadSourceOneOf](docs/ConnectV1CustomConnectorPluginUploadSourceOneOf.md)
  - [ConnectV1CustomConnectorPluginVersion](docs/ConnectV1CustomConnectorPluginVersion.md)
  - [ConnectV1CustomConnectorPluginVersionList](docs/ConnectV1CustomConnectorPluginVersionList.md)
+ - [ConnectV1CustomConnectorPluginVersionUpdate](docs/ConnectV1CustomConnectorPluginVersionUpdate.md)
  - [ConnectV1CustomConnectorPluginVersionUploadSourceOneOf](docs/ConnectV1CustomConnectorPluginVersionUploadSourceOneOf.md)
  - [ConnectV1PresignedUrl](docs/ConnectV1PresignedUrl.md)
  - [ConnectV1PresignedUrlRequest](docs/ConnectV1PresignedUrlRequest.md)

--- a/connect-custom-plugin/v1/api/openapi.yaml
+++ b/connect-custom-plugin/v1/api/openapi.yaml
@@ -625,13 +625,13 @@ paths:
             --url https://api.confluent.cloud/connect/v1/custom-connector-plugins \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
             --header 'content-type: application/json' \
-            --data '{"display_name":"string","description":"string","documentation_link":"https://github.com/confluentinc/kafka-connect-datagen","connector_class":"io.confluent.kafka.connect.datagen.DatagenConnector","connector_type":"SOURCE","cloud":"AWS","sensitive_config_properties":["passwords","keys","tokens"],"upload_source":{"location":"PRESIGNED_URL_LOCATION","upload_id":"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66"},"runtime_language":"JAVA","version":"0.0.0","release_notes":"string","is_beta":true}'
+            --data '{"display_name":"string","description":"string","documentation_link":"https://github.com/confluentinc/kafka-connect-datagen","connector_class":"io.confluent.kafka.connect.datagen.DatagenConnector","connector_type":"SOURCE","cloud":"AWS","sensitive_config_properties":["passwords","keys","tokens"],"upload_source":{"location":"PRESIGNED_URL_LOCATION","upload_id":"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66"},"runtime_language":"JAVA","version":"0.0.0"}'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           MediaType mediaType = MediaType.parse("application/json");
-          RequestBody body = RequestBody.create(mediaType, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\",\"release_notes\":\"string\",\"is_beta\":true}");
+          RequestBody body = RequestBody.create(mediaType, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\"}");
           Request request = new Request.Builder()
             .url("https://api.confluent.cloud/connect/v1/custom-connector-plugins")
             .post(body)
@@ -650,20 +650,19 @@ paths:
           sensitive_config_properties\\\":[\\\"passwords\\\",\\\"keys\\\",\\\"tokens\\\
           \"],\\\"upload_source\\\":{\\\"location\\\":\\\"PRESIGNED_URL_LOCATION\\\
           \",\\\"upload_id\\\":\\\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\\\"},\\\"\
-          runtime_language\\\":\\\"JAVA\\\",\\\"version\\\":\\\"0.0.0\\\",\\\"release_notes\\\
-          \":\\\"string\\\",\\\"is_beta\\\":true}\")\n\n\treq, _ := http.NewRequest(\"\
-          POST\", url, payload)\n\n\treq.Header.Add(\"content-type\", \"application/json\"\
-          )\n\treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\
-          \tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody,\
-          \ _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
-          \n}"
+          runtime_language\\\":\\\"JAVA\\\",\\\"version\\\":\\\"0.0.0\\\"}\")\n\n\t\
+          req, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"\
+          content-type\", \"application/json\")\n\treq.Header.Add(\"Authorization\"\
+          , \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
+          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
+          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
       - lang: Python
         source: |-
           import http.client
 
           conn = http.client.HTTPSConnection("api.confluent.cloud")
 
-          payload = "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\",\"release_notes\":\"string\",\"is_beta\":true}"
+          payload = "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\"}"
 
           headers = {
               'content-type': "application/json",
@@ -717,9 +716,7 @@ paths:
               upload_id: 'e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66'
             },
             runtime_language: 'JAVA',
-            version: '0.0.0',
-            release_notes: 'string',
-            is_beta: true
+            version: '0.0.0'
           }));
           req.end();
       - lang: C
@@ -734,7 +731,7 @@ paths:
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\",\"release_notes\":\"string\",\"is_beta\":true}");
+          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\"}");
 
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
@@ -743,7 +740,7 @@ paths:
           var request = new RestRequest(Method.POST);
           request.AddHeader("content-type", "application/json");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("application/json", "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\",\"release_notes\":\"string\",\"is_beta\":true}", ParameterType.RequestBody);
+          request.AddParameter("application/json", "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\"}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /connect/v1/custom-connector-plugins/{id}:
     delete:
@@ -1629,13 +1626,13 @@ paths:
             --url 'https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
             --header 'content-type: application/json' \
-            --data '{"display_name":"string","description":"string","documentation_link":"https://github.com/confluentinc/kafka-connect-datagen","connector_class":"io.confluent.kafka.connect.datagen.DatagenConnector","connector_type":"SOURCE","cloud":"AWS","sensitive_config_properties":["passwords","keys","tokens"],"upload_source":{"location":"PRESIGNED_URL_LOCATION","upload_id":"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66"},"runtime_language":"JAVA","version":"0.0.0","release_notes":"string","is_beta":true}'
+            --data '{"display_name":"string","description":"string","documentation_link":"https://github.com/confluentinc/kafka-connect-datagen","connector_class":"io.confluent.kafka.connect.datagen.DatagenConnector","connector_type":"SOURCE","cloud":"AWS","sensitive_config_properties":["passwords","keys","tokens"],"upload_source":{"location":"PRESIGNED_URL_LOCATION","upload_id":"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66"},"runtime_language":"JAVA","version":"0.0.0"}'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           MediaType mediaType = MediaType.parse("application/json");
-          RequestBody body = RequestBody.create(mediaType, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\",\"release_notes\":\"string\",\"is_beta\":true}");
+          RequestBody body = RequestBody.create(mediaType, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\"}");
           Request request = new Request.Builder()
             .url("https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}")
             .patch(body)
@@ -1654,20 +1651,19 @@ paths:
           sensitive_config_properties\\\":[\\\"passwords\\\",\\\"keys\\\",\\\"tokens\\\
           \"],\\\"upload_source\\\":{\\\"location\\\":\\\"PRESIGNED_URL_LOCATION\\\
           \",\\\"upload_id\\\":\\\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\\\"},\\\"\
-          runtime_language\\\":\\\"JAVA\\\",\\\"version\\\":\\\"0.0.0\\\",\\\"release_notes\\\
-          \":\\\"string\\\",\\\"is_beta\\\":true}\")\n\n\treq, _ := http.NewRequest(\"\
-          PATCH\", url, payload)\n\n\treq.Header.Add(\"content-type\", \"application/json\"\
-          )\n\treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\
-          \tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody,\
-          \ _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
-          \n}"
+          runtime_language\\\":\\\"JAVA\\\",\\\"version\\\":\\\"0.0.0\\\"}\")\n\n\t\
+          req, _ := http.NewRequest(\"PATCH\", url, payload)\n\n\treq.Header.Add(\"\
+          content-type\", \"application/json\")\n\treq.Header.Add(\"Authorization\"\
+          , \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
+          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
+          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
       - lang: Python
         source: |-
           import http.client
 
           conn = http.client.HTTPSConnection("api.confluent.cloud")
 
-          payload = "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\",\"release_notes\":\"string\",\"is_beta\":true}"
+          payload = "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\"}"
 
           headers = {
               'content-type': "application/json",
@@ -1721,9 +1717,7 @@ paths:
               upload_id: 'e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66'
             },
             runtime_language: 'JAVA',
-            version: '0.0.0',
-            release_notes: 'string',
-            is_beta: true
+            version: '0.0.0'
           }));
           req.end();
       - lang: C
@@ -1738,7 +1732,7 @@ paths:
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\",\"release_notes\":\"string\",\"is_beta\":true}");
+          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\"}");
 
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
@@ -1747,7 +1741,7 @@ paths:
           var request = new RestRequest(Method.PATCH);
           request.AddHeader("content-type", "application/json");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("application/json", "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\",\"release_notes\":\"string\",\"is_beta\":true}", ParameterType.RequestBody);
+          request.AddParameter("application/json", "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\"}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /connect/v1/presigned-upload-url:
     post:
@@ -2645,13 +2639,13 @@ paths:
             --url 'https://api.confluent.cloud/connect/v1/custom-connector-plugins/{plugin_id}/versions' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
             --header 'content-type: application/json' \
-            --data '{"version":"string","release_notes":"string","sensitive_config_properties":["passwords","keys","tokens"],"is_beta":true,"upload_source":{"location":"PRESIGNED_URL_LOCATION","upload_id":"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66"}}'
+            --data '{"version":"string","sensitive_config_properties":["passwords","keys","tokens"],"upload_source":{"location":"PRESIGNED_URL_LOCATION","upload_id":"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66"}}'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           MediaType mediaType = MediaType.parse("application/json");
-          RequestBody body = RequestBody.create(mediaType, "{\"version\":\"string\",\"release_notes\":\"string\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"is_beta\":true,\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}");
+          RequestBody body = RequestBody.create(mediaType, "{\"version\":\"string\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}");
           Request request = new Request.Builder()
             .url("https://api.confluent.cloud/connect/v1/custom-connector-plugins/{plugin_id}/versions")
             .post(body)
@@ -2664,22 +2658,21 @@ paths:
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\
           \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/connect/v1/custom-connector-plugins/{plugin_id}/versions\"\
           \n\n\tpayload := strings.NewReader(\"{\\\"version\\\":\\\"string\\\",\\\"\
-          release_notes\\\":\\\"string\\\",\\\"sensitive_config_properties\\\":[\\\
-          \"passwords\\\",\\\"keys\\\",\\\"tokens\\\"],\\\"is_beta\\\":true,\\\"upload_source\\\
-          \":{\\\"location\\\":\\\"PRESIGNED_URL_LOCATION\\\",\\\"upload_id\\\":\\\
-          \"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\\\"}}\")\n\n\treq, _ := http.NewRequest(\"\
-          POST\", url, payload)\n\n\treq.Header.Add(\"content-type\", \"application/json\"\
-          )\n\treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\
-          \tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody,\
-          \ _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
-          \n}"
+          sensitive_config_properties\\\":[\\\"passwords\\\",\\\"keys\\\",\\\"tokens\\\
+          \"],\\\"upload_source\\\":{\\\"location\\\":\\\"PRESIGNED_URL_LOCATION\\\
+          \",\\\"upload_id\\\":\\\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\\\"}}\")\n\
+          \n\treq, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"\
+          content-type\", \"application/json\")\n\treq.Header.Add(\"Authorization\"\
+          , \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
+          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
+          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
       - lang: Python
         source: |-
           import http.client
 
           conn = http.client.HTTPSConnection("api.confluent.cloud")
 
-          payload = "{\"version\":\"string\",\"release_notes\":\"string\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"is_beta\":true,\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}"
+          payload = "{\"version\":\"string\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}"
 
           headers = {
               'content-type': "application/json",
@@ -2722,9 +2715,7 @@ paths:
 
           req.write(JSON.stringify({
             version: 'string',
-            release_notes: 'string',
             sensitive_config_properties: ['passwords', 'keys', 'tokens'],
-            is_beta: true,
             upload_source: {
               location: 'PRESIGNED_URL_LOCATION',
               upload_id: 'e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66'
@@ -2743,7 +2734,7 @@ paths:
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"version\":\"string\",\"release_notes\":\"string\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"is_beta\":true,\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}");
+          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"version\":\"string\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}");
 
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
@@ -2752,7 +2743,7 @@ paths:
           var request = new RestRequest(Method.POST);
           request.AddHeader("content-type", "application/json");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("application/json", "{\"version\":\"string\",\"release_notes\":\"string\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"is_beta\":true,\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}", ParameterType.RequestBody);
+          request.AddParameter("application/json", "{\"version\":\"string\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
     x-request-access-name: Plugin Versioning APIs EA
   /connect/v1/custom-connector-plugins/{plugin_id}/versions/{id}:
@@ -3394,7 +3385,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/connect.v1.CustomConnectorPluginVersion'
+              $ref: '#/components/schemas/connect.v1.CustomConnectorPluginVersionUpdate'
       responses:
         "200":
           content:
@@ -3659,13 +3650,13 @@ paths:
             --url 'https://api.confluent.cloud/connect/v1/custom-connector-plugins/{plugin_id}/versions/{id}' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
             --header 'content-type: application/json' \
-            --data '{"version":"string","release_notes":"string","sensitive_config_properties":["passwords","keys","tokens"],"is_beta":true,"upload_source":{"location":"PRESIGNED_URL_LOCATION","upload_id":"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66"}}'
+            --data '{"version":"string","sensitive_config_properties":["passwords","keys","tokens"],"upload_source":{"location":"PRESIGNED_URL_LOCATION","upload_id":"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66"}}'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           MediaType mediaType = MediaType.parse("application/json");
-          RequestBody body = RequestBody.create(mediaType, "{\"version\":\"string\",\"release_notes\":\"string\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"is_beta\":true,\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}");
+          RequestBody body = RequestBody.create(mediaType, "{\"version\":\"string\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}");
           Request request = new Request.Builder()
             .url("https://api.confluent.cloud/connect/v1/custom-connector-plugins/{plugin_id}/versions/{id}")
             .patch(body)
@@ -3678,22 +3669,21 @@ paths:
         source: "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\
           \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/connect/v1/custom-connector-plugins/{plugin_id}/versions/{id}\"\
           \n\n\tpayload := strings.NewReader(\"{\\\"version\\\":\\\"string\\\",\\\"\
-          release_notes\\\":\\\"string\\\",\\\"sensitive_config_properties\\\":[\\\
-          \"passwords\\\",\\\"keys\\\",\\\"tokens\\\"],\\\"is_beta\\\":true,\\\"upload_source\\\
-          \":{\\\"location\\\":\\\"PRESIGNED_URL_LOCATION\\\",\\\"upload_id\\\":\\\
-          \"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\\\"}}\")\n\n\treq, _ := http.NewRequest(\"\
-          PATCH\", url, payload)\n\n\treq.Header.Add(\"content-type\", \"application/json\"\
-          )\n\treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\
-          \tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody,\
-          \ _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
-          \n}"
+          sensitive_config_properties\\\":[\\\"passwords\\\",\\\"keys\\\",\\\"tokens\\\
+          \"],\\\"upload_source\\\":{\\\"location\\\":\\\"PRESIGNED_URL_LOCATION\\\
+          \",\\\"upload_id\\\":\\\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\\\"}}\")\n\
+          \n\treq, _ := http.NewRequest(\"PATCH\", url, payload)\n\n\treq.Header.Add(\"\
+          content-type\", \"application/json\")\n\treq.Header.Add(\"Authorization\"\
+          , \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
+          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
+          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
       - lang: Python
         source: |-
           import http.client
 
           conn = http.client.HTTPSConnection("api.confluent.cloud")
 
-          payload = "{\"version\":\"string\",\"release_notes\":\"string\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"is_beta\":true,\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}"
+          payload = "{\"version\":\"string\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}"
 
           headers = {
               'content-type': "application/json",
@@ -3736,9 +3726,7 @@ paths:
 
           req.write(JSON.stringify({
             version: 'string',
-            release_notes: 'string',
             sensitive_config_properties: ['passwords', 'keys', 'tokens'],
-            is_beta: true,
             upload_source: {
               location: 'PRESIGNED_URL_LOCATION',
               upload_id: 'e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66'
@@ -3757,7 +3745,7 @@ paths:
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"version\":\"string\",\"release_notes\":\"string\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"is_beta\":true,\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}");
+          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"version\":\"string\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}");
 
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
@@ -3766,7 +3754,7 @@ paths:
           var request = new RestRequest(Method.PATCH);
           request.AddHeader("content-type", "application/json");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("application/json", "{\"version\":\"string\",\"release_notes\":\"string\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"is_beta\":true,\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}", ParameterType.RequestBody);
+          request.AddParameter("application/json", "{\"version\":\"string\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"}}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
     x-request-access-name: Plugin Versioning APIs EA
 components:
@@ -4089,9 +4077,12 @@ components:
           - AZURE
           x-immutable: true
         sensitive_config_properties:
-          description: A sensitive property is a connector configuration property
-            that must be hidden after a user enters property value when setting up
-            connector.
+          description: |
+            A sensitive property is a connector configuration property that must be hidden after a user enters property
+            value when setting up connector.
+            - If the plugin has **only one version**, these properties apply to that version.
+            - If the plugin has **multiple versions**, each version maintains its own set of sensitive properties and
+            does not inherit or use the `sensitive_config_properties` of the plugin.
           example:
           - passwords
           - keys
@@ -4122,23 +4113,11 @@ components:
           - PYTHON
         version:
           default: 0.0.0
-          description: Version of the Custom Connector Plugin.
+          description: |
+            Initial Version of the Custom Connector Plugin.
+            The version must comply with SemVer (e.g., `1.2.3`, `1.2.3-beta`, `1.2.3-rc.123`, `1.2.3-rc.123+build.456`).
           maxLength: 60
           type: string
-          x-immutable: true
-        release_notes:
-          description: Version release notes of the Custom Connector Plugin.
-          maxLength: 256
-          type: string
-          x-immutable: true
-        is_beta:
-          description: Flag showing stability for the version of the Custom Connector
-            Plugin.
-          example: "true"
-          type: string
-          x-extensible-enum:
-          - "TRUE"
-          - "FALSE"
           x-immutable: true
       type: object
     connect.v1.PresignedUrl:
@@ -4252,13 +4231,12 @@ components:
               resource_name:
                 example: crn://confluent.cloud/organization=9bb441c4-edef-46ac-8a41-c49e44a3fd9a/custom-connector-plugin-version=ccpv-12345
         version:
-          description: Version of the Custom Connector Plugin.
+          description: |
+            Version of the Custom Connector Plugin.
+            The version must comply with SemVer (e.g., `1.2.3`, `1.2.3-beta`, `1.2.3-rc.123`, `1.2.3-rc.123+build.456`).
           maxLength: 60
           type: string
-        release_notes:
-          description: Release Notes of the Custom Connector Plugin Version.
-          maxLength: 256
-          type: string
+          x-immutable: true
         sensitive_config_properties:
           description: A sensitive property is a connector configuration property
             that must be hidden after a user enters property value when setting up
@@ -4272,13 +4250,6 @@ components:
             pattern: ^[\w\+\.-]+$
             type: string
           type: array
-        is_beta:
-          description: Flag to specify stability of the version
-          example: "true"
-          type: string
-          x-extensible-enum:
-          - "TRUE"
-          - "FALSE"
         upload_source:
           description: Upload source of Custom Connector Plugin Version. Only required
             in `create` request, will be ignored in `read`, `update` or `list`.
@@ -4289,6 +4260,7 @@ components:
           oneOf:
           - $ref: '#/components/schemas/connect.v1.UploadSource.PresignedUrl'
           type: object
+          x-immutable: true
           x-one-of-name: ConnectV1CustomConnectorPluginVersionUploadSourceOneOf
       type: object
     connect.v1.PresignedUrlRequest:
@@ -4708,9 +4680,12 @@ components:
           pattern: ^$|^(http://|https://).+
           type: string
         sensitive_config_properties:
-          description: A sensitive property is a connector configuration property
-            that must be hidden after a user enters property value when setting up
-            connector.
+          description: |
+            A sensitive property is a connector configuration property that must be hidden after a user enters property
+            value when setting up connector.
+            - If the plugin has **only one version**, these properties apply to that version.
+            - If the plugin has **multiple versions**, each version maintains its own set of sensitive properties and
+            does not inherit or use the `sensitive_config_properties` of the plugin.
           example:
           - passwords
           - keys
@@ -4739,6 +4714,60 @@ components:
           x-extensible-enum:
           - JAVA
           - PYTHON
+      type: object
+    connect.v1.CustomConnectorPluginVersionUpdate:
+      description: |-
+        CustomConnectorPluginVersion objects represent Custom Connector Plugin Versions on Confluent Cloud.
+        The API allows you to list, create, read, update, and delete your Custom Connector Plugin Versions.
+
+
+        ## The Custom Connector Plugin Versions Model
+        <SchemaDefinition schemaRef="#/components/schemas/connect.v1.CustomConnectorPluginVersion" />
+      properties:
+        api_version:
+          description: APIVersion defines the schema version of this representation
+            of a resource.
+          enum:
+          - connect/v1
+          readOnly: true
+          type: string
+        kind:
+          description: Kind defines the object this REST resource represents.
+          enum:
+          - CustomConnectorPluginVersion
+          readOnly: true
+          type: string
+        id:
+          description: ID is the "natural identifier" for an object within its scope/namespace;
+            it is normally unique across time but not space. That is, you can assume
+            that the ID will not be reclaimed and reused after an object is deleted
+            ("time"); however, it may collide with IDs for other object `kinds` or
+            objects of the same `kind` within a different scope/namespace ("space").
+          example: dlz-f3a90de
+          maxLength: 255
+          readOnly: true
+          type: string
+        metadata:
+          allOf:
+          - $ref: '#/components/schemas/ObjectMeta'
+          - properties:
+              self:
+                example: https://api.confluent.cloud/connect/v1/custom-connector-plugin-versions/ccpv-12345
+              resource_name:
+                example: crn://confluent.cloud/organization=9bb441c4-edef-46ac-8a41-c49e44a3fd9a/custom-connector-plugin-version=ccpv-12345
+        sensitive_config_properties:
+          description: A sensitive property is a connector configuration property
+            that must be hidden after a user enters property value when setting up
+            connector.
+          example:
+          - passwords
+          - keys
+          - tokens
+          items:
+            maxLength: 150
+            pattern: ^[\w\+\.-]+$
+            type: string
+          type: array
       type: object
     Error_source:
       description: If this error was caused by a particular part of the API request,

--- a/connect-custom-plugin/v1/api_custom_connector_plugin_versions_connect_v1.go
+++ b/connect-custom-plugin/v1/api_custom_connector_plugin_versions_connect_v1.go
@@ -787,15 +787,15 @@ func (a *CustomConnectorPluginVersionsConnectV1ApiService) ListConnectV1CustomCo
 }
 
 type ApiUpdateConnectV1CustomConnectorPluginVersionRequest struct {
-	ctx                                   _context.Context
-	ApiService                            CustomConnectorPluginVersionsConnectV1Api
-	pluginId                              string
-	id                                    string
-	connectV1CustomConnectorPluginVersion *ConnectV1CustomConnectorPluginVersion
+	ctx                                         _context.Context
+	ApiService                                  CustomConnectorPluginVersionsConnectV1Api
+	pluginId                                    string
+	id                                          string
+	connectV1CustomConnectorPluginVersionUpdate *ConnectV1CustomConnectorPluginVersionUpdate
 }
 
-func (r ApiUpdateConnectV1CustomConnectorPluginVersionRequest) ConnectV1CustomConnectorPluginVersion(connectV1CustomConnectorPluginVersion ConnectV1CustomConnectorPluginVersion) ApiUpdateConnectV1CustomConnectorPluginVersionRequest {
-	r.connectV1CustomConnectorPluginVersion = &connectV1CustomConnectorPluginVersion
+func (r ApiUpdateConnectV1CustomConnectorPluginVersionRequest) ConnectV1CustomConnectorPluginVersionUpdate(connectV1CustomConnectorPluginVersionUpdate ConnectV1CustomConnectorPluginVersionUpdate) ApiUpdateConnectV1CustomConnectorPluginVersionRequest {
+	r.connectV1CustomConnectorPluginVersionUpdate = &connectV1CustomConnectorPluginVersionUpdate
 	return r
 }
 
@@ -868,7 +868,7 @@ func (a *CustomConnectorPluginVersionsConnectV1ApiService) UpdateConnectV1Custom
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = r.connectV1CustomConnectorPluginVersion
+	localVarPostBody = r.connectV1CustomConnectorPluginVersionUpdate
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/connect-custom-plugin/v1/docs/ConnectV1CustomConnectorPlugin.md
+++ b/connect-custom-plugin/v1/docs/ConnectV1CustomConnectorPlugin.md
@@ -15,12 +15,10 @@ Name | Type | Description | Notes
 **ConnectorClass** | Pointer to **string** | Java class or alias for connector. You can get connector class from connector documentation provided by developer. | [optional] 
 **ConnectorType** | Pointer to **string** | Custom Connector type.  | [optional] 
 **Cloud** | Pointer to **string** | Cloud provider where the Custom Connector Plugin archive is uploaded. | [optional] [default to "AWS"]
-**SensitiveConfigProperties** | Pointer to **[]string** | A sensitive property is a connector configuration property that must be hidden after a user enters property value when setting up connector. | [optional] 
+**SensitiveConfigProperties** | Pointer to **[]string** | A sensitive property is a connector configuration property that must be hidden after a user enters property value when setting up connector. - If the plugin has **only one version**, these properties apply to that version. - If the plugin has **multiple versions**, each version maintains its own set of sensitive properties and does not inherit or use the &#x60;sensitive_config_properties&#x60; of the plugin.  | [optional] 
 **UploadSource** | Pointer to [**ConnectV1CustomConnectorPluginUploadSourceOneOf**](ConnectV1CustomConnectorPluginUploadSourceOneOf.md) | Upload source of Custom Connector Plugin. Only required in &#x60;create&#x60; request, will be ignored in &#x60;read&#x60;, &#x60;update&#x60; or &#x60;list&#x60;. | [optional] 
 **RuntimeLanguage** | Pointer to **string** | Runtime language of Custom Connector Plugin. | [optional] [default to "JAVA"]
-**Version** | Pointer to **string** | Version of the Custom Connector Plugin. | [optional] [default to "0.0.0"]
-**ReleaseNotes** | Pointer to **string** | Version release notes of the Custom Connector Plugin. | [optional] 
-**IsBeta** | Pointer to **string** | Flag showing stability for the version of the Custom Connector Plugin. | [optional] 
+**Version** | Pointer to **string** | Initial Version of the Custom Connector Plugin. The version must comply with SemVer (e.g., &#x60;1.2.3&#x60;, &#x60;1.2.3-beta&#x60;, &#x60;1.2.3-rc.123&#x60;, &#x60;1.2.3-rc.123+build.456&#x60;).  | [optional] [default to "0.0.0"]
 
 ## Methods
 
@@ -415,56 +413,6 @@ SetVersion sets Version field to given value.
 `func (o *ConnectV1CustomConnectorPlugin) HasVersion() bool`
 
 HasVersion returns a boolean if a field has been set.
-
-### GetReleaseNotes
-
-`func (o *ConnectV1CustomConnectorPlugin) GetReleaseNotes() string`
-
-GetReleaseNotes returns the ReleaseNotes field if non-nil, zero value otherwise.
-
-### GetReleaseNotesOk
-
-`func (o *ConnectV1CustomConnectorPlugin) GetReleaseNotesOk() (*string, bool)`
-
-GetReleaseNotesOk returns a tuple with the ReleaseNotes field if it's non-nil, zero value otherwise
-and a boolean to check if the value has been set.
-
-### SetReleaseNotes
-
-`func (o *ConnectV1CustomConnectorPlugin) SetReleaseNotes(v string)`
-
-SetReleaseNotes sets ReleaseNotes field to given value.
-
-### HasReleaseNotes
-
-`func (o *ConnectV1CustomConnectorPlugin) HasReleaseNotes() bool`
-
-HasReleaseNotes returns a boolean if a field has been set.
-
-### GetIsBeta
-
-`func (o *ConnectV1CustomConnectorPlugin) GetIsBeta() string`
-
-GetIsBeta returns the IsBeta field if non-nil, zero value otherwise.
-
-### GetIsBetaOk
-
-`func (o *ConnectV1CustomConnectorPlugin) GetIsBetaOk() (*string, bool)`
-
-GetIsBetaOk returns a tuple with the IsBeta field if it's non-nil, zero value otherwise
-and a boolean to check if the value has been set.
-
-### SetIsBeta
-
-`func (o *ConnectV1CustomConnectorPlugin) SetIsBeta(v string)`
-
-SetIsBeta sets IsBeta field to given value.
-
-### HasIsBeta
-
-`func (o *ConnectV1CustomConnectorPlugin) HasIsBeta() bool`
-
-HasIsBeta returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/connect-custom-plugin/v1/docs/ConnectV1CustomConnectorPluginUpdate.md
+++ b/connect-custom-plugin/v1/docs/ConnectV1CustomConnectorPluginUpdate.md
@@ -12,7 +12,7 @@ Name | Type | Description | Notes
 **ContentFormat** | Pointer to **string** | Archive format of Custom Connector Plugin. | [optional] [readonly] 
 **Description** | Pointer to **string** | Description of Custom Connector Plugin. | [optional] 
 **DocumentationLink** | Pointer to **string** | Document link of Custom Connector Plugin. | [optional] 
-**SensitiveConfigProperties** | Pointer to **[]string** | A sensitive property is a connector configuration property that must be hidden after a user enters property value when setting up connector. | [optional] 
+**SensitiveConfigProperties** | Pointer to **[]string** | A sensitive property is a connector configuration property that must be hidden after a user enters property value when setting up connector. - If the plugin has **only one version**, these properties apply to that version. - If the plugin has **multiple versions**, each version maintains its own set of sensitive properties and does not inherit or use the &#x60;sensitive_config_properties&#x60; of the plugin.  | [optional] 
 **UploadSource** | Pointer to [**ConnectV1CustomConnectorPluginUpdateUploadSourceOneOf**](ConnectV1CustomConnectorPluginUpdateUploadSourceOneOf.md) | Upload source of Custom Connector Plugin. Only required in &#x60;create&#x60; request, will be ignored in &#x60;read&#x60;, &#x60;update&#x60; or &#x60;list&#x60;. | [optional] 
 **RuntimeLanguage** | Pointer to **string** | Runtime language of Custom Connector Plugin. | [optional] [default to "JAVA"]
 

--- a/connect-custom-plugin/v1/docs/ConnectV1CustomConnectorPluginVersion.md
+++ b/connect-custom-plugin/v1/docs/ConnectV1CustomConnectorPluginVersion.md
@@ -8,10 +8,8 @@ Name | Type | Description | Notes
 **Kind** | Pointer to **string** | Kind defines the object this REST resource represents. | [optional] [readonly] 
 **Id** | Pointer to **string** | ID is the \&quot;natural identifier\&quot; for an object within its scope/namespace; it is normally unique across time but not space. That is, you can assume that the ID will not be reclaimed and reused after an object is deleted (\&quot;time\&quot;); however, it may collide with IDs for other object &#x60;kinds&#x60; or objects of the same &#x60;kind&#x60; within a different scope/namespace (\&quot;space\&quot;). | [optional] [readonly] 
 **Metadata** | Pointer to [**ObjectMeta**](ObjectMeta.md) |  | [optional] 
-**Version** | Pointer to **string** | Version of the Custom Connector Plugin. | [optional] 
-**ReleaseNotes** | Pointer to **string** | Release Notes of the Custom Connector Plugin Version. | [optional] 
+**Version** | Pointer to **string** | Version of the Custom Connector Plugin. The version must comply with SemVer (e.g., &#x60;1.2.3&#x60;, &#x60;1.2.3-beta&#x60;, &#x60;1.2.3-rc.123&#x60;, &#x60;1.2.3-rc.123+build.456&#x60;).  | [optional] 
 **SensitiveConfigProperties** | Pointer to **[]string** | A sensitive property is a connector configuration property that must be hidden after a user enters property value when setting up connector. | [optional] 
-**IsBeta** | Pointer to **string** | Flag to specify stability of the version | [optional] 
 **UploadSource** | Pointer to [**ConnectV1CustomConnectorPluginVersionUploadSourceOneOf**](ConnectV1CustomConnectorPluginVersionUploadSourceOneOf.md) | Upload source of Custom Connector Plugin Version. Only required in &#x60;create&#x60; request, will be ignored in &#x60;read&#x60;, &#x60;update&#x60; or &#x60;list&#x60;. | [optional] 
 
 ## Methods
@@ -158,31 +156,6 @@ SetVersion sets Version field to given value.
 
 HasVersion returns a boolean if a field has been set.
 
-### GetReleaseNotes
-
-`func (o *ConnectV1CustomConnectorPluginVersion) GetReleaseNotes() string`
-
-GetReleaseNotes returns the ReleaseNotes field if non-nil, zero value otherwise.
-
-### GetReleaseNotesOk
-
-`func (o *ConnectV1CustomConnectorPluginVersion) GetReleaseNotesOk() (*string, bool)`
-
-GetReleaseNotesOk returns a tuple with the ReleaseNotes field if it's non-nil, zero value otherwise
-and a boolean to check if the value has been set.
-
-### SetReleaseNotes
-
-`func (o *ConnectV1CustomConnectorPluginVersion) SetReleaseNotes(v string)`
-
-SetReleaseNotes sets ReleaseNotes field to given value.
-
-### HasReleaseNotes
-
-`func (o *ConnectV1CustomConnectorPluginVersion) HasReleaseNotes() bool`
-
-HasReleaseNotes returns a boolean if a field has been set.
-
 ### GetSensitiveConfigProperties
 
 `func (o *ConnectV1CustomConnectorPluginVersion) GetSensitiveConfigProperties() []string`
@@ -207,31 +180,6 @@ SetSensitiveConfigProperties sets SensitiveConfigProperties field to given value
 `func (o *ConnectV1CustomConnectorPluginVersion) HasSensitiveConfigProperties() bool`
 
 HasSensitiveConfigProperties returns a boolean if a field has been set.
-
-### GetIsBeta
-
-`func (o *ConnectV1CustomConnectorPluginVersion) GetIsBeta() string`
-
-GetIsBeta returns the IsBeta field if non-nil, zero value otherwise.
-
-### GetIsBetaOk
-
-`func (o *ConnectV1CustomConnectorPluginVersion) GetIsBetaOk() (*string, bool)`
-
-GetIsBetaOk returns a tuple with the IsBeta field if it's non-nil, zero value otherwise
-and a boolean to check if the value has been set.
-
-### SetIsBeta
-
-`func (o *ConnectV1CustomConnectorPluginVersion) SetIsBeta(v string)`
-
-SetIsBeta sets IsBeta field to given value.
-
-### HasIsBeta
-
-`func (o *ConnectV1CustomConnectorPluginVersion) HasIsBeta() bool`
-
-HasIsBeta returns a boolean if a field has been set.
 
 ### GetUploadSource
 

--- a/connect-custom-plugin/v1/docs/ConnectV1CustomConnectorPluginVersionUpdate.md
+++ b/connect-custom-plugin/v1/docs/ConnectV1CustomConnectorPluginVersionUpdate.md
@@ -1,0 +1,160 @@
+# ConnectV1CustomConnectorPluginVersionUpdate
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**ApiVersion** | Pointer to **string** | APIVersion defines the schema version of this representation of a resource. | [optional] [readonly] 
+**Kind** | Pointer to **string** | Kind defines the object this REST resource represents. | [optional] [readonly] 
+**Id** | Pointer to **string** | ID is the \&quot;natural identifier\&quot; for an object within its scope/namespace; it is normally unique across time but not space. That is, you can assume that the ID will not be reclaimed and reused after an object is deleted (\&quot;time\&quot;); however, it may collide with IDs for other object &#x60;kinds&#x60; or objects of the same &#x60;kind&#x60; within a different scope/namespace (\&quot;space\&quot;). | [optional] [readonly] 
+**Metadata** | Pointer to [**ObjectMeta**](ObjectMeta.md) |  | [optional] 
+**SensitiveConfigProperties** | Pointer to **[]string** | A sensitive property is a connector configuration property that must be hidden after a user enters property value when setting up connector. | [optional] 
+
+## Methods
+
+### NewConnectV1CustomConnectorPluginVersionUpdate
+
+`func NewConnectV1CustomConnectorPluginVersionUpdate() *ConnectV1CustomConnectorPluginVersionUpdate`
+
+NewConnectV1CustomConnectorPluginVersionUpdate instantiates a new ConnectV1CustomConnectorPluginVersionUpdate object
+This constructor will assign default values to properties that have it defined,
+and makes sure properties required by API are set, but the set of arguments
+will change when the set of required properties is changed
+
+### NewConnectV1CustomConnectorPluginVersionUpdateWithDefaults
+
+`func NewConnectV1CustomConnectorPluginVersionUpdateWithDefaults() *ConnectV1CustomConnectorPluginVersionUpdate`
+
+NewConnectV1CustomConnectorPluginVersionUpdateWithDefaults instantiates a new ConnectV1CustomConnectorPluginVersionUpdate object
+This constructor will only assign default values to properties that have it defined,
+but it doesn't guarantee that properties required by API are set
+
+### GetApiVersion
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetApiVersion() string`
+
+GetApiVersion returns the ApiVersion field if non-nil, zero value otherwise.
+
+### GetApiVersionOk
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetApiVersionOk() (*string, bool)`
+
+GetApiVersionOk returns a tuple with the ApiVersion field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetApiVersion
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) SetApiVersion(v string)`
+
+SetApiVersion sets ApiVersion field to given value.
+
+### HasApiVersion
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) HasApiVersion() bool`
+
+HasApiVersion returns a boolean if a field has been set.
+
+### GetKind
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetKind() string`
+
+GetKind returns the Kind field if non-nil, zero value otherwise.
+
+### GetKindOk
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetKindOk() (*string, bool)`
+
+GetKindOk returns a tuple with the Kind field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetKind
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) SetKind(v string)`
+
+SetKind sets Kind field to given value.
+
+### HasKind
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) HasKind() bool`
+
+HasKind returns a boolean if a field has been set.
+
+### GetId
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetId() string`
+
+GetId returns the Id field if non-nil, zero value otherwise.
+
+### GetIdOk
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetIdOk() (*string, bool)`
+
+GetIdOk returns a tuple with the Id field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetId
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) SetId(v string)`
+
+SetId sets Id field to given value.
+
+### HasId
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) HasId() bool`
+
+HasId returns a boolean if a field has been set.
+
+### GetMetadata
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetMetadata() ObjectMeta`
+
+GetMetadata returns the Metadata field if non-nil, zero value otherwise.
+
+### GetMetadataOk
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetMetadataOk() (*ObjectMeta, bool)`
+
+GetMetadataOk returns a tuple with the Metadata field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetMetadata
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) SetMetadata(v ObjectMeta)`
+
+SetMetadata sets Metadata field to given value.
+
+### HasMetadata
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) HasMetadata() bool`
+
+HasMetadata returns a boolean if a field has been set.
+
+### GetSensitiveConfigProperties
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetSensitiveConfigProperties() []string`
+
+GetSensitiveConfigProperties returns the SensitiveConfigProperties field if non-nil, zero value otherwise.
+
+### GetSensitiveConfigPropertiesOk
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetSensitiveConfigPropertiesOk() (*[]string, bool)`
+
+GetSensitiveConfigPropertiesOk returns a tuple with the SensitiveConfigProperties field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetSensitiveConfigProperties
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) SetSensitiveConfigProperties(v []string)`
+
+SetSensitiveConfigProperties sets SensitiveConfigProperties field to given value.
+
+### HasSensitiveConfigProperties
+
+`func (o *ConnectV1CustomConnectorPluginVersionUpdate) HasSensitiveConfigProperties() bool`
+
+HasSensitiveConfigProperties returns a boolean if a field has been set.
+
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/connect-custom-plugin/v1/docs/CustomConnectorPluginVersionsConnectV1Api.md
+++ b/connect-custom-plugin/v1/docs/CustomConnectorPluginVersionsConnectV1Api.md
@@ -304,7 +304,7 @@ Name | Type | Description  | Notes
 
 ## UpdateConnectV1CustomConnectorPluginVersion
 
-> ConnectV1CustomConnectorPluginVersion UpdateConnectV1CustomConnectorPluginVersion(ctx, pluginId, id).ConnectV1CustomConnectorPluginVersion(connectV1CustomConnectorPluginVersion).Execute()
+> ConnectV1CustomConnectorPluginVersion UpdateConnectV1CustomConnectorPluginVersion(ctx, pluginId, id).ConnectV1CustomConnectorPluginVersionUpdate(connectV1CustomConnectorPluginVersionUpdate).Execute()
 
 Update a Custom Connector Plugin Version
 
@@ -325,11 +325,11 @@ import (
 func main() {
     pluginId := "pluginId_example" // string | The Plugin
     id := "id_example" // string | The unique identifier for the custom connector plugin version.
-    connectV1CustomConnectorPluginVersion := *openapiclient.NewConnectV1CustomConnectorPluginVersion() // ConnectV1CustomConnectorPluginVersion |  (optional)
+    connectV1CustomConnectorPluginVersionUpdate := *openapiclient.NewConnectV1CustomConnectorPluginVersionUpdate() // ConnectV1CustomConnectorPluginVersionUpdate |  (optional)
 
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
-    resp, r, err := api_client.CustomConnectorPluginVersionsConnectV1Api.UpdateConnectV1CustomConnectorPluginVersion(context.Background(), pluginId, id).ConnectV1CustomConnectorPluginVersion(connectV1CustomConnectorPluginVersion).Execute()
+    resp, r, err := api_client.CustomConnectorPluginVersionsConnectV1Api.UpdateConnectV1CustomConnectorPluginVersion(context.Background(), pluginId, id).ConnectV1CustomConnectorPluginVersionUpdate(connectV1CustomConnectorPluginVersionUpdate).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `CustomConnectorPluginVersionsConnectV1Api.UpdateConnectV1CustomConnectorPluginVersion``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -357,7 +357,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
 
- **connectV1CustomConnectorPluginVersion** | [**ConnectV1CustomConnectorPluginVersion**](ConnectV1CustomConnectorPluginVersion.md) |  | 
+ **connectV1CustomConnectorPluginVersionUpdate** | [**ConnectV1CustomConnectorPluginVersionUpdate**](ConnectV1CustomConnectorPluginVersionUpdate.md) |  | 
 
 ### Return type
 

--- a/connect-custom-plugin/v1/model_connect_v1_custom_connector_plugin.go
+++ b/connect-custom-plugin/v1/model_connect_v1_custom_connector_plugin.go
@@ -57,18 +57,14 @@ type ConnectV1CustomConnectorPlugin struct {
 	ConnectorType *string `json:"connector_type,omitempty"`
 	// Cloud provider where the Custom Connector Plugin archive is uploaded.
 	Cloud *string `json:"cloud,omitempty"`
-	// A sensitive property is a connector configuration property that must be hidden after a user enters property value when setting up connector.
+	// A sensitive property is a connector configuration property that must be hidden after a user enters property value when setting up connector. - If the plugin has **only one version**, these properties apply to that version. - If the plugin has **multiple versions**, each version maintains its own set of sensitive properties and does not inherit or use the `sensitive_config_properties` of the plugin.
 	SensitiveConfigProperties *[]string `json:"sensitive_config_properties,omitempty"`
 	// Upload source of Custom Connector Plugin. Only required in `create` request, will be ignored in `read`, `update` or `list`.
 	UploadSource *ConnectV1CustomConnectorPluginUploadSourceOneOf `json:"upload_source,omitempty"`
 	// Runtime language of Custom Connector Plugin.
 	RuntimeLanguage *string `json:"runtime_language,omitempty"`
-	// Version of the Custom Connector Plugin.
+	// Initial Version of the Custom Connector Plugin. The version must comply with SemVer (e.g., `1.2.3`, `1.2.3-beta`, `1.2.3-rc.123`, `1.2.3-rc.123+build.456`).
 	Version *string `json:"version,omitempty"`
-	// Version release notes of the Custom Connector Plugin.
-	ReleaseNotes *string `json:"release_notes,omitempty"`
-	// Flag showing stability for the version of the Custom Connector Plugin.
-	IsBeta *string `json:"is_beta,omitempty"`
 }
 
 // NewConnectV1CustomConnectorPlugin instantiates a new ConnectV1CustomConnectorPlugin object
@@ -580,70 +576,6 @@ func (o *ConnectV1CustomConnectorPlugin) SetVersion(v string) {
 	o.Version = &v
 }
 
-// GetReleaseNotes returns the ReleaseNotes field value if set, zero value otherwise.
-func (o *ConnectV1CustomConnectorPlugin) GetReleaseNotes() string {
-	if o == nil || o.ReleaseNotes == nil {
-		var ret string
-		return ret
-	}
-	return *o.ReleaseNotes
-}
-
-// GetReleaseNotesOk returns a tuple with the ReleaseNotes field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *ConnectV1CustomConnectorPlugin) GetReleaseNotesOk() (*string, bool) {
-	if o == nil || o.ReleaseNotes == nil {
-		return nil, false
-	}
-	return o.ReleaseNotes, true
-}
-
-// HasReleaseNotes returns a boolean if a field has been set.
-func (o *ConnectV1CustomConnectorPlugin) HasReleaseNotes() bool {
-	if o != nil && o.ReleaseNotes != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetReleaseNotes gets a reference to the given string and assigns it to the ReleaseNotes field.
-func (o *ConnectV1CustomConnectorPlugin) SetReleaseNotes(v string) {
-	o.ReleaseNotes = &v
-}
-
-// GetIsBeta returns the IsBeta field value if set, zero value otherwise.
-func (o *ConnectV1CustomConnectorPlugin) GetIsBeta() string {
-	if o == nil || o.IsBeta == nil {
-		var ret string
-		return ret
-	}
-	return *o.IsBeta
-}
-
-// GetIsBetaOk returns a tuple with the IsBeta field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *ConnectV1CustomConnectorPlugin) GetIsBetaOk() (*string, bool) {
-	if o == nil || o.IsBeta == nil {
-		return nil, false
-	}
-	return o.IsBeta, true
-}
-
-// HasIsBeta returns a boolean if a field has been set.
-func (o *ConnectV1CustomConnectorPlugin) HasIsBeta() bool {
-	if o != nil && o.IsBeta != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetIsBeta gets a reference to the given string and assigns it to the IsBeta field.
-func (o *ConnectV1CustomConnectorPlugin) SetIsBeta(v string) {
-	o.IsBeta = &v
-}
-
 // Redact resets all sensitive fields to their zero value.
 func (o *ConnectV1CustomConnectorPlugin) Redact() {
 	o.recurseRedact(o.ApiVersion)
@@ -661,8 +593,6 @@ func (o *ConnectV1CustomConnectorPlugin) Redact() {
 	o.recurseRedact(o.UploadSource)
 	o.recurseRedact(o.RuntimeLanguage)
 	o.recurseRedact(o.Version)
-	o.recurseRedact(o.ReleaseNotes)
-	o.recurseRedact(o.IsBeta)
 }
 
 func (o *ConnectV1CustomConnectorPlugin) recurseRedact(v interface{}) {
@@ -741,12 +671,6 @@ func (o ConnectV1CustomConnectorPlugin) MarshalJSON() ([]byte, error) {
 	}
 	if o.Version != nil {
 		toSerialize["version"] = o.Version
-	}
-	if o.ReleaseNotes != nil {
-		toSerialize["release_notes"] = o.ReleaseNotes
-	}
-	if o.IsBeta != nil {
-		toSerialize["is_beta"] = o.IsBeta
 	}
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)

--- a/connect-custom-plugin/v1/model_connect_v1_custom_connector_plugin_update.go
+++ b/connect-custom-plugin/v1/model_connect_v1_custom_connector_plugin_update.go
@@ -51,7 +51,7 @@ type ConnectV1CustomConnectorPluginUpdate struct {
 	Description *string `json:"description,omitempty"`
 	// Document link of Custom Connector Plugin.
 	DocumentationLink *string `json:"documentation_link,omitempty"`
-	// A sensitive property is a connector configuration property that must be hidden after a user enters property value when setting up connector.
+	// A sensitive property is a connector configuration property that must be hidden after a user enters property value when setting up connector. - If the plugin has **only one version**, these properties apply to that version. - If the plugin has **multiple versions**, each version maintains its own set of sensitive properties and does not inherit or use the `sensitive_config_properties` of the plugin.
 	SensitiveConfigProperties *[]string `json:"sensitive_config_properties,omitempty"`
 	// Upload source of Custom Connector Plugin. Only required in `create` request, will be ignored in `read`, `update` or `list`.
 	UploadSource *ConnectV1CustomConnectorPluginUpdateUploadSourceOneOf `json:"upload_source,omitempty"`

--- a/connect-custom-plugin/v1/model_connect_v1_custom_connector_plugin_version_update.go
+++ b/connect-custom-plugin/v1/model_connect_v1_custom_connector_plugin_version_update.go
@@ -34,8 +34,8 @@ import (
 	"reflect"
 )
 
-// ConnectV1CustomConnectorPluginVersion CustomConnectorPluginVersion objects represent Custom Connector Plugin Versions on Confluent Cloud. The API allows you to list, create, read, update, and delete your Custom Connector Plugin Versions.   ## The Custom Connector Plugin Versions Model <SchemaDefinition schemaRef=\"#/components/schemas/connect.v1.CustomConnectorPluginVersion\" />
-type ConnectV1CustomConnectorPluginVersion struct {
+// ConnectV1CustomConnectorPluginVersionUpdate CustomConnectorPluginVersion objects represent Custom Connector Plugin Versions on Confluent Cloud. The API allows you to list, create, read, update, and delete your Custom Connector Plugin Versions.   ## The Custom Connector Plugin Versions Model <SchemaDefinition schemaRef=\"#/components/schemas/connect.v1.CustomConnectorPluginVersion\" />
+type ConnectV1CustomConnectorPluginVersionUpdate struct {
 	// APIVersion defines the schema version of this representation of a resource.
 	ApiVersion *string `json:"api_version,omitempty"`
 	// Kind defines the object this REST resource represents.
@@ -43,33 +43,29 @@ type ConnectV1CustomConnectorPluginVersion struct {
 	// ID is the \"natural identifier\" for an object within its scope/namespace; it is normally unique across time but not space. That is, you can assume that the ID will not be reclaimed and reused after an object is deleted (\"time\"); however, it may collide with IDs for other object `kinds` or objects of the same `kind` within a different scope/namespace (\"space\").
 	Id       *string     `json:"id,omitempty"`
 	Metadata *ObjectMeta `json:"metadata,omitempty"`
-	// Version of the Custom Connector Plugin. The version must comply with SemVer (e.g., `1.2.3`, `1.2.3-beta`, `1.2.3-rc.123`, `1.2.3-rc.123+build.456`).
-	Version *string `json:"version,omitempty"`
 	// A sensitive property is a connector configuration property that must be hidden after a user enters property value when setting up connector.
 	SensitiveConfigProperties *[]string `json:"sensitive_config_properties,omitempty"`
-	// Upload source of Custom Connector Plugin Version. Only required in `create` request, will be ignored in `read`, `update` or `list`.
-	UploadSource *ConnectV1CustomConnectorPluginVersionUploadSourceOneOf `json:"upload_source,omitempty"`
 }
 
-// NewConnectV1CustomConnectorPluginVersion instantiates a new ConnectV1CustomConnectorPluginVersion object
+// NewConnectV1CustomConnectorPluginVersionUpdate instantiates a new ConnectV1CustomConnectorPluginVersionUpdate object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewConnectV1CustomConnectorPluginVersion() *ConnectV1CustomConnectorPluginVersion {
-	this := ConnectV1CustomConnectorPluginVersion{}
+func NewConnectV1CustomConnectorPluginVersionUpdate() *ConnectV1CustomConnectorPluginVersionUpdate {
+	this := ConnectV1CustomConnectorPluginVersionUpdate{}
 	return &this
 }
 
-// NewConnectV1CustomConnectorPluginVersionWithDefaults instantiates a new ConnectV1CustomConnectorPluginVersion object
+// NewConnectV1CustomConnectorPluginVersionUpdateWithDefaults instantiates a new ConnectV1CustomConnectorPluginVersionUpdate object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
-func NewConnectV1CustomConnectorPluginVersionWithDefaults() *ConnectV1CustomConnectorPluginVersion {
-	this := ConnectV1CustomConnectorPluginVersion{}
+func NewConnectV1CustomConnectorPluginVersionUpdateWithDefaults() *ConnectV1CustomConnectorPluginVersionUpdate {
+	this := ConnectV1CustomConnectorPluginVersionUpdate{}
 	return &this
 }
 
 // GetApiVersion returns the ApiVersion field value if set, zero value otherwise.
-func (o *ConnectV1CustomConnectorPluginVersion) GetApiVersion() string {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetApiVersion() string {
 	if o == nil || o.ApiVersion == nil {
 		var ret string
 		return ret
@@ -79,7 +75,7 @@ func (o *ConnectV1CustomConnectorPluginVersion) GetApiVersion() string {
 
 // GetApiVersionOk returns a tuple with the ApiVersion field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ConnectV1CustomConnectorPluginVersion) GetApiVersionOk() (*string, bool) {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetApiVersionOk() (*string, bool) {
 	if o == nil || o.ApiVersion == nil {
 		return nil, false
 	}
@@ -87,7 +83,7 @@ func (o *ConnectV1CustomConnectorPluginVersion) GetApiVersionOk() (*string, bool
 }
 
 // HasApiVersion returns a boolean if a field has been set.
-func (o *ConnectV1CustomConnectorPluginVersion) HasApiVersion() bool {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) HasApiVersion() bool {
 	if o != nil && o.ApiVersion != nil {
 		return true
 	}
@@ -96,12 +92,12 @@ func (o *ConnectV1CustomConnectorPluginVersion) HasApiVersion() bool {
 }
 
 // SetApiVersion gets a reference to the given string and assigns it to the ApiVersion field.
-func (o *ConnectV1CustomConnectorPluginVersion) SetApiVersion(v string) {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) SetApiVersion(v string) {
 	o.ApiVersion = &v
 }
 
 // GetKind returns the Kind field value if set, zero value otherwise.
-func (o *ConnectV1CustomConnectorPluginVersion) GetKind() string {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetKind() string {
 	if o == nil || o.Kind == nil {
 		var ret string
 		return ret
@@ -111,7 +107,7 @@ func (o *ConnectV1CustomConnectorPluginVersion) GetKind() string {
 
 // GetKindOk returns a tuple with the Kind field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ConnectV1CustomConnectorPluginVersion) GetKindOk() (*string, bool) {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetKindOk() (*string, bool) {
 	if o == nil || o.Kind == nil {
 		return nil, false
 	}
@@ -119,7 +115,7 @@ func (o *ConnectV1CustomConnectorPluginVersion) GetKindOk() (*string, bool) {
 }
 
 // HasKind returns a boolean if a field has been set.
-func (o *ConnectV1CustomConnectorPluginVersion) HasKind() bool {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) HasKind() bool {
 	if o != nil && o.Kind != nil {
 		return true
 	}
@@ -128,12 +124,12 @@ func (o *ConnectV1CustomConnectorPluginVersion) HasKind() bool {
 }
 
 // SetKind gets a reference to the given string and assigns it to the Kind field.
-func (o *ConnectV1CustomConnectorPluginVersion) SetKind(v string) {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) SetKind(v string) {
 	o.Kind = &v
 }
 
 // GetId returns the Id field value if set, zero value otherwise.
-func (o *ConnectV1CustomConnectorPluginVersion) GetId() string {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetId() string {
 	if o == nil || o.Id == nil {
 		var ret string
 		return ret
@@ -143,7 +139,7 @@ func (o *ConnectV1CustomConnectorPluginVersion) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ConnectV1CustomConnectorPluginVersion) GetIdOk() (*string, bool) {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetIdOk() (*string, bool) {
 	if o == nil || o.Id == nil {
 		return nil, false
 	}
@@ -151,7 +147,7 @@ func (o *ConnectV1CustomConnectorPluginVersion) GetIdOk() (*string, bool) {
 }
 
 // HasId returns a boolean if a field has been set.
-func (o *ConnectV1CustomConnectorPluginVersion) HasId() bool {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) HasId() bool {
 	if o != nil && o.Id != nil {
 		return true
 	}
@@ -160,12 +156,12 @@ func (o *ConnectV1CustomConnectorPluginVersion) HasId() bool {
 }
 
 // SetId gets a reference to the given string and assigns it to the Id field.
-func (o *ConnectV1CustomConnectorPluginVersion) SetId(v string) {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) SetId(v string) {
 	o.Id = &v
 }
 
 // GetMetadata returns the Metadata field value if set, zero value otherwise.
-func (o *ConnectV1CustomConnectorPluginVersion) GetMetadata() ObjectMeta {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetMetadata() ObjectMeta {
 	if o == nil || o.Metadata == nil {
 		var ret ObjectMeta
 		return ret
@@ -175,7 +171,7 @@ func (o *ConnectV1CustomConnectorPluginVersion) GetMetadata() ObjectMeta {
 
 // GetMetadataOk returns a tuple with the Metadata field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ConnectV1CustomConnectorPluginVersion) GetMetadataOk() (*ObjectMeta, bool) {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetMetadataOk() (*ObjectMeta, bool) {
 	if o == nil || o.Metadata == nil {
 		return nil, false
 	}
@@ -183,7 +179,7 @@ func (o *ConnectV1CustomConnectorPluginVersion) GetMetadataOk() (*ObjectMeta, bo
 }
 
 // HasMetadata returns a boolean if a field has been set.
-func (o *ConnectV1CustomConnectorPluginVersion) HasMetadata() bool {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) HasMetadata() bool {
 	if o != nil && o.Metadata != nil {
 		return true
 	}
@@ -192,44 +188,12 @@ func (o *ConnectV1CustomConnectorPluginVersion) HasMetadata() bool {
 }
 
 // SetMetadata gets a reference to the given ObjectMeta and assigns it to the Metadata field.
-func (o *ConnectV1CustomConnectorPluginVersion) SetMetadata(v ObjectMeta) {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) SetMetadata(v ObjectMeta) {
 	o.Metadata = &v
 }
 
-// GetVersion returns the Version field value if set, zero value otherwise.
-func (o *ConnectV1CustomConnectorPluginVersion) GetVersion() string {
-	if o == nil || o.Version == nil {
-		var ret string
-		return ret
-	}
-	return *o.Version
-}
-
-// GetVersionOk returns a tuple with the Version field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *ConnectV1CustomConnectorPluginVersion) GetVersionOk() (*string, bool) {
-	if o == nil || o.Version == nil {
-		return nil, false
-	}
-	return o.Version, true
-}
-
-// HasVersion returns a boolean if a field has been set.
-func (o *ConnectV1CustomConnectorPluginVersion) HasVersion() bool {
-	if o != nil && o.Version != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetVersion gets a reference to the given string and assigns it to the Version field.
-func (o *ConnectV1CustomConnectorPluginVersion) SetVersion(v string) {
-	o.Version = &v
-}
-
 // GetSensitiveConfigProperties returns the SensitiveConfigProperties field value if set, zero value otherwise.
-func (o *ConnectV1CustomConnectorPluginVersion) GetSensitiveConfigProperties() []string {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetSensitiveConfigProperties() []string {
 	if o == nil || o.SensitiveConfigProperties == nil {
 		var ret []string
 		return ret
@@ -239,7 +203,7 @@ func (o *ConnectV1CustomConnectorPluginVersion) GetSensitiveConfigProperties() [
 
 // GetSensitiveConfigPropertiesOk returns a tuple with the SensitiveConfigProperties field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ConnectV1CustomConnectorPluginVersion) GetSensitiveConfigPropertiesOk() (*[]string, bool) {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) GetSensitiveConfigPropertiesOk() (*[]string, bool) {
 	if o == nil || o.SensitiveConfigProperties == nil {
 		return nil, false
 	}
@@ -247,7 +211,7 @@ func (o *ConnectV1CustomConnectorPluginVersion) GetSensitiveConfigPropertiesOk()
 }
 
 // HasSensitiveConfigProperties returns a boolean if a field has been set.
-func (o *ConnectV1CustomConnectorPluginVersion) HasSensitiveConfigProperties() bool {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) HasSensitiveConfigProperties() bool {
 	if o != nil && o.SensitiveConfigProperties != nil {
 		return true
 	}
@@ -256,54 +220,20 @@ func (o *ConnectV1CustomConnectorPluginVersion) HasSensitiveConfigProperties() b
 }
 
 // SetSensitiveConfigProperties gets a reference to the given []string and assigns it to the SensitiveConfigProperties field.
-func (o *ConnectV1CustomConnectorPluginVersion) SetSensitiveConfigProperties(v []string) {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) SetSensitiveConfigProperties(v []string) {
 	o.SensitiveConfigProperties = &v
 }
 
-// GetUploadSource returns the UploadSource field value if set, zero value otherwise.
-func (o *ConnectV1CustomConnectorPluginVersion) GetUploadSource() ConnectV1CustomConnectorPluginVersionUploadSourceOneOf {
-	if o == nil || o.UploadSource == nil {
-		var ret ConnectV1CustomConnectorPluginVersionUploadSourceOneOf
-		return ret
-	}
-	return *o.UploadSource
-}
-
-// GetUploadSourceOk returns a tuple with the UploadSource field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *ConnectV1CustomConnectorPluginVersion) GetUploadSourceOk() (*ConnectV1CustomConnectorPluginVersionUploadSourceOneOf, bool) {
-	if o == nil || o.UploadSource == nil {
-		return nil, false
-	}
-	return o.UploadSource, true
-}
-
-// HasUploadSource returns a boolean if a field has been set.
-func (o *ConnectV1CustomConnectorPluginVersion) HasUploadSource() bool {
-	if o != nil && o.UploadSource != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetUploadSource gets a reference to the given ConnectV1CustomConnectorPluginVersionUploadSourceOneOf and assigns it to the UploadSource field.
-func (o *ConnectV1CustomConnectorPluginVersion) SetUploadSource(v ConnectV1CustomConnectorPluginVersionUploadSourceOneOf) {
-	o.UploadSource = &v
-}
-
 // Redact resets all sensitive fields to their zero value.
-func (o *ConnectV1CustomConnectorPluginVersion) Redact() {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) Redact() {
 	o.recurseRedact(o.ApiVersion)
 	o.recurseRedact(o.Kind)
 	o.recurseRedact(o.Id)
 	o.recurseRedact(o.Metadata)
-	o.recurseRedact(o.Version)
 	o.recurseRedact(o.SensitiveConfigProperties)
-	o.recurseRedact(o.UploadSource)
 }
 
-func (o *ConnectV1CustomConnectorPluginVersion) recurseRedact(v interface{}) {
+func (o *ConnectV1CustomConnectorPluginVersionUpdate) recurseRedact(v interface{}) {
 	type redactor interface {
 		Redact()
 	}
@@ -328,12 +258,12 @@ func (o *ConnectV1CustomConnectorPluginVersion) recurseRedact(v interface{}) {
 	}
 }
 
-func (o ConnectV1CustomConnectorPluginVersion) zeroField(v interface{}) {
+func (o ConnectV1CustomConnectorPluginVersionUpdate) zeroField(v interface{}) {
 	p := reflect.ValueOf(v).Elem()
 	p.Set(reflect.Zero(p.Type()))
 }
 
-func (o ConnectV1CustomConnectorPluginVersion) MarshalJSON() ([]byte, error) {
+func (o ConnectV1CustomConnectorPluginVersionUpdate) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.ApiVersion != nil {
 		toSerialize["api_version"] = o.ApiVersion
@@ -347,14 +277,8 @@ func (o ConnectV1CustomConnectorPluginVersion) MarshalJSON() ([]byte, error) {
 	if o.Metadata != nil {
 		toSerialize["metadata"] = o.Metadata
 	}
-	if o.Version != nil {
-		toSerialize["version"] = o.Version
-	}
 	if o.SensitiveConfigProperties != nil {
 		toSerialize["sensitive_config_properties"] = o.SensitiveConfigProperties
-	}
-	if o.UploadSource != nil {
-		toSerialize["upload_source"] = o.UploadSource
 	}
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)
@@ -363,34 +287,34 @@ func (o ConnectV1CustomConnectorPluginVersion) MarshalJSON() ([]byte, error) {
 	return buffer.Bytes(), err
 }
 
-type NullableConnectV1CustomConnectorPluginVersion struct {
-	value *ConnectV1CustomConnectorPluginVersion
+type NullableConnectV1CustomConnectorPluginVersionUpdate struct {
+	value *ConnectV1CustomConnectorPluginVersionUpdate
 	isSet bool
 }
 
-func (v NullableConnectV1CustomConnectorPluginVersion) Get() *ConnectV1CustomConnectorPluginVersion {
+func (v NullableConnectV1CustomConnectorPluginVersionUpdate) Get() *ConnectV1CustomConnectorPluginVersionUpdate {
 	return v.value
 }
 
-func (v *NullableConnectV1CustomConnectorPluginVersion) Set(val *ConnectV1CustomConnectorPluginVersion) {
+func (v *NullableConnectV1CustomConnectorPluginVersionUpdate) Set(val *ConnectV1CustomConnectorPluginVersionUpdate) {
 	v.value = val
 	v.isSet = true
 }
 
-func (v NullableConnectV1CustomConnectorPluginVersion) IsSet() bool {
+func (v NullableConnectV1CustomConnectorPluginVersionUpdate) IsSet() bool {
 	return v.isSet
 }
 
-func (v *NullableConnectV1CustomConnectorPluginVersion) Unset() {
+func (v *NullableConnectV1CustomConnectorPluginVersionUpdate) Unset() {
 	v.value = nil
 	v.isSet = false
 }
 
-func NewNullableConnectV1CustomConnectorPluginVersion(val *ConnectV1CustomConnectorPluginVersion) *NullableConnectV1CustomConnectorPluginVersion {
-	return &NullableConnectV1CustomConnectorPluginVersion{value: val, isSet: true}
+func NewNullableConnectV1CustomConnectorPluginVersionUpdate(val *ConnectV1CustomConnectorPluginVersionUpdate) *NullableConnectV1CustomConnectorPluginVersionUpdate {
+	return &NullableConnectV1CustomConnectorPluginVersionUpdate{value: val, isSet: true}
 }
 
-func (v NullableConnectV1CustomConnectorPluginVersion) MarshalJSON() ([]byte, error) {
+func (v NullableConnectV1CustomConnectorPluginVersionUpdate) MarshalJSON() ([]byte, error) {
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)
 	encoder.SetEscapeHTML(false)
@@ -398,7 +322,7 @@ func (v NullableConnectV1CustomConnectorPluginVersion) MarshalJSON() ([]byte, er
 	return buffer.Bytes(), err
 }
 
-func (v *NullableConnectV1CustomConnectorPluginVersion) UnmarshalJSON(src []byte) error {
+func (v *NullableConnectV1CustomConnectorPluginVersionUpdate) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }


### PR DESCRIPTION
go vet -v
```
internal/goarch
internal/abi
runtime/internal/math
unicode/utf8
internal/asan
internal/itoa
internal/msan
cmp
encoding
math/bits
math
unicode/utf16
crypto/internal/alias
crypto/subtle
crypto/internal/boring/sig
vendor/golang.org/x/crypto/cryptobyte/asn1
internal/nettrace
container/list
vendor/golang.org/x/crypto/internal/alias
log/internal
internal/profilerecord
internal/unsafeheader
internal/godebugs
internal/race
internal/goos
runtime/internal/sys
internal/cpu
sync/atomic
internal/runtime/atomic
internal/byteorder
unicode
internal/coverage/rtcov
internal/runtime/exithook
internal/bytealg
internal/chacha8rand
internal/stringslite
internal/goexperiment
runtime
internal/weak
iter
internal/reflectlite
maps
sync
slices
errors
internal/singleflight
internal/bisect
internal/testlog
internal/oserror
io
vendor/golang.org/x/net/dns/dnsmessage
path
sort
crypto/internal/edwards25519/field
internal/godebug
math/rand/v2
crypto/internal/randutil
hash
bytes
math/rand
strings
crypto/internal/nistec/fiat
crypto/internal/edwards25519
strconv
internal/concurrent
hash/crc32
vendor/golang.org/x/text/transform
net/http/internal/ascii
crypto
crypto/rc4
bufio
unique
crypto/cipher
crypto/md5
net/netip
crypto/internal/boring
regexp/syntax
crypto/des
reflect
crypto/hmac
crypto/sha1
crypto/sha256
crypto/sha512
regexp
crypto/aes
vendor/golang.org/x/crypto/hkdf
internal/fmtsort
encoding/binary
syscall
encoding/base64
vendor/golang.org/x/crypto/chacha20
vendor/golang.org/x/crypto/internal/poly1305
internal/syscall/execenv
encoding/pem
vendor/golang.org/x/crypto/chacha20poly1305
time
internal/syscall/unix
context
crypto/x509/internal/macos
io/fs
embed
internal/filepathlite
internal/poll
crypto/internal/nistec
crypto/ecdh
os
io/ioutil
path/filepath
fmt
vendor/golang.org/x/sys/cpu
vendor/golang.org/x/net/route
log
encoding/hex
net/url
vendor/golang.org/x/net/http2/hpack
mime
encoding/xml
net/http/internal
compress/flate
mime/quotedprintable
encoding/json
vendor/golang.org/x/crypto/sha3
vendor/golang.org/x/text/unicode/norm
vendor/golang.org/x/text/unicode/bidi
compress/gzip
math/big
vendor/golang.org/x/text/secure/bidirule
crypto/internal/boring/bbig
crypto/internal/bigmod
crypto/rand
crypto/dsa
crypto/elliptic
encoding/asn1
crypto/rsa
crypto/ed25519
crypto/internal/hpke
crypto/internal/mlkem768
crypto/x509/pkix
vendor/golang.org/x/crypto/cryptobyte
crypto/ecdsa
vendor/golang.org/x/net/idna
net
vendor/golang.org/x/net/http/httpproxy
net/textproto
vendor/golang.org/x/net/http/httpguts
crypto/x509
mime/multipart
crypto/tls
net/http/httptrace
net/http
golang.org/x/net/context/ctxhttp
net/http/httputil
golang.org/x/oauth2/internal
golang.org/x/oauth2
github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin/v1
```