### PR TITLE
Update connect-custom-plugin

### DIFF
--- a/connect-custom-plugin/v1/api/openapi.yaml
+++ b/connect-custom-plugin/v1/api/openapi.yaml
@@ -14,6 +14,10 @@ info:
 servers:
 - description: Confluent Cloud production
   url: https://api.confluent.cloud
+- description: Confluent Cloud staging
+  url: https://api.stag.cpdev.cloud
+- description: Confluent Cloud development
+  url: https://api.devel.cpdev.cloud
 tags:
 - description: |-
     [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
@@ -625,13 +629,13 @@ paths:
             --url https://api.confluent.cloud/connect/v1/custom-connector-plugins \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
             --header 'content-type: application/json' \
-            --data '{"display_name":"string","description":"string","documentation_link":"https://github.com/confluentinc/kafka-connect-datagen","connector_class":"io.confluent.kafka.connect.datagen.DatagenConnector","connector_type":"SOURCE","cloud":"AWS","sensitive_config_properties":["passwords","keys","tokens"],"upload_source":{"location":"PRESIGNED_URL_LOCATION","upload_id":"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66"},"runtime_language":"JAVA","version":"0.0.0"}'
+            --data '{"display_name":"string","description":"string","documentation_link":"https://github.com/confluentinc/kafka-connect-datagen","connector_class":"io.confluent.kafka.connect.datagen.DatagenConnector","connector_type":"SOURCE","cloud":"AWS","sensitive_config_properties":["passwords","keys","tokens"],"upload_source":{"location":"PRESIGNED_URL_LOCATION","upload_id":"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66"},"runtime_language":"JAVA","initial_plugin_version":"0.0.0"}'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           MediaType mediaType = MediaType.parse("application/json");
-          RequestBody body = RequestBody.create(mediaType, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\"}");
+          RequestBody body = RequestBody.create(mediaType, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"initial_plugin_version\":\"0.0.0\"}");
           Request request = new Request.Builder()
             .url("https://api.confluent.cloud/connect/v1/custom-connector-plugins")
             .post(body)
@@ -650,8 +654,8 @@ paths:
           sensitive_config_properties\\\":[\\\"passwords\\\",\\\"keys\\\",\\\"tokens\\\
           \"],\\\"upload_source\\\":{\\\"location\\\":\\\"PRESIGNED_URL_LOCATION\\\
           \",\\\"upload_id\\\":\\\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\\\"},\\\"\
-          runtime_language\\\":\\\"JAVA\\\",\\\"version\\\":\\\"0.0.0\\\"}\")\n\n\t\
-          req, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"\
+          runtime_language\\\":\\\"JAVA\\\",\\\"initial_plugin_version\\\":\\\"0.0.0\\\
+          \"}\")\n\n\treq, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"\
           content-type\", \"application/json\")\n\treq.Header.Add(\"Authorization\"\
           , \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
           \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
@@ -662,7 +666,7 @@ paths:
 
           conn = http.client.HTTPSConnection("api.confluent.cloud")
 
-          payload = "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\"}"
+          payload = "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"initial_plugin_version\":\"0.0.0\"}"
 
           headers = {
               'content-type': "application/json",
@@ -716,7 +720,7 @@ paths:
               upload_id: 'e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66'
             },
             runtime_language: 'JAVA',
-            version: '0.0.0'
+            initial_plugin_version: '0.0.0'
           }));
           req.end();
       - lang: C
@@ -731,7 +735,7 @@ paths:
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\"}");
+          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"initial_plugin_version\":\"0.0.0\"}");
 
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
@@ -740,7 +744,7 @@ paths:
           var request = new RestRequest(Method.POST);
           request.AddHeader("content-type", "application/json");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("application/json", "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\"}", ParameterType.RequestBody);
+          request.AddParameter("application/json", "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"initial_plugin_version\":\"0.0.0\"}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /connect/v1/custom-connector-plugins/{id}:
     delete:
@@ -1626,13 +1630,13 @@ paths:
             --url 'https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
             --header 'content-type: application/json' \
-            --data '{"display_name":"string","description":"string","documentation_link":"https://github.com/confluentinc/kafka-connect-datagen","connector_class":"io.confluent.kafka.connect.datagen.DatagenConnector","connector_type":"SOURCE","cloud":"AWS","sensitive_config_properties":["passwords","keys","tokens"],"upload_source":{"location":"PRESIGNED_URL_LOCATION","upload_id":"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66"},"runtime_language":"JAVA","version":"0.0.0"}'
+            --data '{"display_name":"string","description":"string","documentation_link":"https://github.com/confluentinc/kafka-connect-datagen","connector_class":"io.confluent.kafka.connect.datagen.DatagenConnector","connector_type":"SOURCE","cloud":"AWS","sensitive_config_properties":["passwords","keys","tokens"],"upload_source":{"location":"PRESIGNED_URL_LOCATION","upload_id":"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66"},"runtime_language":"JAVA","initial_plugin_version":"0.0.0"}'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           MediaType mediaType = MediaType.parse("application/json");
-          RequestBody body = RequestBody.create(mediaType, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\"}");
+          RequestBody body = RequestBody.create(mediaType, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"initial_plugin_version\":\"0.0.0\"}");
           Request request = new Request.Builder()
             .url("https://api.confluent.cloud/connect/v1/custom-connector-plugins/{id}")
             .patch(body)
@@ -1651,8 +1655,8 @@ paths:
           sensitive_config_properties\\\":[\\\"passwords\\\",\\\"keys\\\",\\\"tokens\\\
           \"],\\\"upload_source\\\":{\\\"location\\\":\\\"PRESIGNED_URL_LOCATION\\\
           \",\\\"upload_id\\\":\\\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\\\"},\\\"\
-          runtime_language\\\":\\\"JAVA\\\",\\\"version\\\":\\\"0.0.0\\\"}\")\n\n\t\
-          req, _ := http.NewRequest(\"PATCH\", url, payload)\n\n\treq.Header.Add(\"\
+          runtime_language\\\":\\\"JAVA\\\",\\\"initial_plugin_version\\\":\\\"0.0.0\\\
+          \"}\")\n\n\treq, _ := http.NewRequest(\"PATCH\", url, payload)\n\n\treq.Header.Add(\"\
           content-type\", \"application/json\")\n\treq.Header.Add(\"Authorization\"\
           , \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
           \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
@@ -1663,7 +1667,7 @@ paths:
 
           conn = http.client.HTTPSConnection("api.confluent.cloud")
 
-          payload = "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\"}"
+          payload = "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"initial_plugin_version\":\"0.0.0\"}"
 
           headers = {
               'content-type': "application/json",
@@ -1717,7 +1721,7 @@ paths:
               upload_id: 'e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66'
             },
             runtime_language: 'JAVA',
-            version: '0.0.0'
+            initial_plugin_version: '0.0.0'
           }));
           req.end();
       - lang: C
@@ -1732,7 +1736,7 @@ paths:
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\"}");
+          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"initial_plugin_version\":\"0.0.0\"}");
 
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
@@ -1741,7 +1745,7 @@ paths:
           var request = new RestRequest(Method.PATCH);
           request.AddHeader("content-type", "application/json");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("application/json", "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"version\":\"0.0.0\"}", ParameterType.RequestBody);
+          request.AddParameter("application/json", "{\"display_name\":\"string\",\"description\":\"string\",\"documentation_link\":\"https://github.com/confluentinc/kafka-connect-datagen\",\"connector_class\":\"io.confluent.kafka.connect.datagen.DatagenConnector\",\"connector_type\":\"SOURCE\",\"cloud\":\"AWS\",\"sensitive_config_properties\":[\"passwords\",\"keys\",\"tokens\"],\"upload_source\":{\"location\":\"PRESIGNED_URL_LOCATION\",\"upload_id\":\"e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66\"},\"runtime_language\":\"JAVA\",\"initial_plugin_version\":\"0.0.0\"}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /connect/v1/presigned-upload-url:
     post:
@@ -4111,7 +4115,7 @@ components:
           x-extensible-enum:
           - JAVA
           - PYTHON
-        version:
+        initial_plugin_version:
           default: 0.0.0
           description: |
             Initial Version of the Custom Connector Plugin.

--- a/connect-custom-plugin/v1/api/openapi.yaml
+++ b/connect-custom-plugin/v1/api/openapi.yaml
@@ -14,10 +14,6 @@ info:
 servers:
 - description: Confluent Cloud production
   url: https://api.confluent.cloud
-- description: Confluent Cloud staging
-  url: https://api.stag.cpdev.cloud
-- description: Confluent Cloud development
-  url: https://api.devel.cpdev.cloud
 tags:
 - description: |-
     [![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)

--- a/connect-custom-plugin/v1/configuration.go
+++ b/connect-custom-plugin/v1/configuration.go
@@ -123,6 +123,14 @@ func NewConfiguration() *Configuration {
 				URL:         "https://api.confluent.cloud",
 				Description: "Confluent Cloud production",
 			},
+			{
+				URL:         "https://api.stag.cpdev.cloud",
+				Description: "Confluent Cloud staging",
+			},
+			{
+				URL:         "https://api.devel.cpdev.cloud",
+				Description: "Confluent Cloud development",
+			},
 		},
 		OperationServers: map[string]ServerConfigurations{},
 	}

--- a/connect-custom-plugin/v1/configuration.go
+++ b/connect-custom-plugin/v1/configuration.go
@@ -123,14 +123,6 @@ func NewConfiguration() *Configuration {
 				URL:         "https://api.confluent.cloud",
 				Description: "Confluent Cloud production",
 			},
-			{
-				URL:         "https://api.stag.cpdev.cloud",
-				Description: "Confluent Cloud staging",
-			},
-			{
-				URL:         "https://api.devel.cpdev.cloud",
-				Description: "Confluent Cloud development",
-			},
 		},
 		OperationServers: map[string]ServerConfigurations{},
 	}

--- a/connect-custom-plugin/v1/docs/ConnectV1CustomConnectorPlugin.md
+++ b/connect-custom-plugin/v1/docs/ConnectV1CustomConnectorPlugin.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **SensitiveConfigProperties** | Pointer to **[]string** | A sensitive property is a connector configuration property that must be hidden after a user enters property value when setting up connector. - If the plugin has **only one version**, these properties apply to that version. - If the plugin has **multiple versions**, each version maintains its own set of sensitive properties and does not inherit or use the &#x60;sensitive_config_properties&#x60; of the plugin.  | [optional] 
 **UploadSource** | Pointer to [**ConnectV1CustomConnectorPluginUploadSourceOneOf**](ConnectV1CustomConnectorPluginUploadSourceOneOf.md) | Upload source of Custom Connector Plugin. Only required in &#x60;create&#x60; request, will be ignored in &#x60;read&#x60;, &#x60;update&#x60; or &#x60;list&#x60;. | [optional] 
 **RuntimeLanguage** | Pointer to **string** | Runtime language of Custom Connector Plugin. | [optional] [default to "JAVA"]
-**Version** | Pointer to **string** | Initial Version of the Custom Connector Plugin. The version must comply with SemVer (e.g., &#x60;1.2.3&#x60;, &#x60;1.2.3-beta&#x60;, &#x60;1.2.3-rc.123&#x60;, &#x60;1.2.3-rc.123+build.456&#x60;).  | [optional] [default to "0.0.0"]
+**InitialPluginVersion** | Pointer to **string** | Initial Version of the Custom Connector Plugin. The version must comply with SemVer (e.g., &#x60;1.2.3&#x60;, &#x60;1.2.3-beta&#x60;, &#x60;1.2.3-rc.123&#x60;, &#x60;1.2.3-rc.123+build.456&#x60;).  | [optional] [default to "0.0.0"]
 
 ## Methods
 
@@ -389,30 +389,30 @@ SetRuntimeLanguage sets RuntimeLanguage field to given value.
 
 HasRuntimeLanguage returns a boolean if a field has been set.
 
-### GetVersion
+### GetInitialPluginVersion
 
-`func (o *ConnectV1CustomConnectorPlugin) GetVersion() string`
+`func (o *ConnectV1CustomConnectorPlugin) GetInitialPluginVersion() string`
 
-GetVersion returns the Version field if non-nil, zero value otherwise.
+GetInitialPluginVersion returns the InitialPluginVersion field if non-nil, zero value otherwise.
 
-### GetVersionOk
+### GetInitialPluginVersionOk
 
-`func (o *ConnectV1CustomConnectorPlugin) GetVersionOk() (*string, bool)`
+`func (o *ConnectV1CustomConnectorPlugin) GetInitialPluginVersionOk() (*string, bool)`
 
-GetVersionOk returns a tuple with the Version field if it's non-nil, zero value otherwise
+GetInitialPluginVersionOk returns a tuple with the InitialPluginVersion field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
-### SetVersion
+### SetInitialPluginVersion
 
-`func (o *ConnectV1CustomConnectorPlugin) SetVersion(v string)`
+`func (o *ConnectV1CustomConnectorPlugin) SetInitialPluginVersion(v string)`
 
-SetVersion sets Version field to given value.
+SetInitialPluginVersion sets InitialPluginVersion field to given value.
 
-### HasVersion
+### HasInitialPluginVersion
 
-`func (o *ConnectV1CustomConnectorPlugin) HasVersion() bool`
+`func (o *ConnectV1CustomConnectorPlugin) HasInitialPluginVersion() bool`
 
-HasVersion returns a boolean if a field has been set.
+HasInitialPluginVersion returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/connect-custom-plugin/v1/model_connect_v1_custom_connector_plugin.go
+++ b/connect-custom-plugin/v1/model_connect_v1_custom_connector_plugin.go
@@ -64,7 +64,7 @@ type ConnectV1CustomConnectorPlugin struct {
 	// Runtime language of Custom Connector Plugin.
 	RuntimeLanguage *string `json:"runtime_language,omitempty"`
 	// Initial Version of the Custom Connector Plugin. The version must comply with SemVer (e.g., `1.2.3`, `1.2.3-beta`, `1.2.3-rc.123`, `1.2.3-rc.123+build.456`).
-	Version *string `json:"version,omitempty"`
+	InitialPluginVersion *string `json:"initial_plugin_version,omitempty"`
 }
 
 // NewConnectV1CustomConnectorPlugin instantiates a new ConnectV1CustomConnectorPlugin object
@@ -77,8 +77,8 @@ func NewConnectV1CustomConnectorPlugin() *ConnectV1CustomConnectorPlugin {
 	this.Cloud = &cloud
 	var runtimeLanguage string = "JAVA"
 	this.RuntimeLanguage = &runtimeLanguage
-	var version string = "0.0.0"
-	this.Version = &version
+	var initialPluginVersion string = "0.0.0"
+	this.InitialPluginVersion = &initialPluginVersion
 	return &this
 }
 
@@ -91,8 +91,8 @@ func NewConnectV1CustomConnectorPluginWithDefaults() *ConnectV1CustomConnectorPl
 	this.Cloud = &cloud
 	var runtimeLanguage string = "JAVA"
 	this.RuntimeLanguage = &runtimeLanguage
-	var version string = "0.0.0"
-	this.Version = &version
+	var initialPluginVersion string = "0.0.0"
+	this.InitialPluginVersion = &initialPluginVersion
 	return &this
 }
 
@@ -544,36 +544,36 @@ func (o *ConnectV1CustomConnectorPlugin) SetRuntimeLanguage(v string) {
 	o.RuntimeLanguage = &v
 }
 
-// GetVersion returns the Version field value if set, zero value otherwise.
-func (o *ConnectV1CustomConnectorPlugin) GetVersion() string {
-	if o == nil || o.Version == nil {
+// GetInitialPluginVersion returns the InitialPluginVersion field value if set, zero value otherwise.
+func (o *ConnectV1CustomConnectorPlugin) GetInitialPluginVersion() string {
+	if o == nil || o.InitialPluginVersion == nil {
 		var ret string
 		return ret
 	}
-	return *o.Version
+	return *o.InitialPluginVersion
 }
 
-// GetVersionOk returns a tuple with the Version field value if set, nil otherwise
+// GetInitialPluginVersionOk returns a tuple with the InitialPluginVersion field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ConnectV1CustomConnectorPlugin) GetVersionOk() (*string, bool) {
-	if o == nil || o.Version == nil {
+func (o *ConnectV1CustomConnectorPlugin) GetInitialPluginVersionOk() (*string, bool) {
+	if o == nil || o.InitialPluginVersion == nil {
 		return nil, false
 	}
-	return o.Version, true
+	return o.InitialPluginVersion, true
 }
 
-// HasVersion returns a boolean if a field has been set.
-func (o *ConnectV1CustomConnectorPlugin) HasVersion() bool {
-	if o != nil && o.Version != nil {
+// HasInitialPluginVersion returns a boolean if a field has been set.
+func (o *ConnectV1CustomConnectorPlugin) HasInitialPluginVersion() bool {
+	if o != nil && o.InitialPluginVersion != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetVersion gets a reference to the given string and assigns it to the Version field.
-func (o *ConnectV1CustomConnectorPlugin) SetVersion(v string) {
-	o.Version = &v
+// SetInitialPluginVersion gets a reference to the given string and assigns it to the InitialPluginVersion field.
+func (o *ConnectV1CustomConnectorPlugin) SetInitialPluginVersion(v string) {
+	o.InitialPluginVersion = &v
 }
 
 // Redact resets all sensitive fields to their zero value.
@@ -592,7 +592,7 @@ func (o *ConnectV1CustomConnectorPlugin) Redact() {
 	o.recurseRedact(o.SensitiveConfigProperties)
 	o.recurseRedact(o.UploadSource)
 	o.recurseRedact(o.RuntimeLanguage)
-	o.recurseRedact(o.Version)
+	o.recurseRedact(o.InitialPluginVersion)
 }
 
 func (o *ConnectV1CustomConnectorPlugin) recurseRedact(v interface{}) {
@@ -669,8 +669,8 @@ func (o ConnectV1CustomConnectorPlugin) MarshalJSON() ([]byte, error) {
 	if o.RuntimeLanguage != nil {
 		toSerialize["runtime_language"] = o.RuntimeLanguage
 	}
-	if o.Version != nil {
-		toSerialize["version"] = o.Version
+	if o.InitialPluginVersion != nil {
+		toSerialize["initial_plugin_version"] = o.InitialPluginVersion
 	}
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)


### PR DESCRIPTION
```
> go vet -v
internal/goarch
internal/abi
runtime/internal/math
unicode/utf8
internal/asan
internal/itoa
internal/msan
cmp
encoding
math/bits
math
unicode/utf16
crypto/internal/alias
crypto/subtle
crypto/internal/boring/sig
vendor/golang.org/x/crypto/cryptobyte/asn1
internal/nettrace
container/list
vendor/golang.org/x/crypto/internal/alias
log/internal
internal/unsafeheader
internal/byteorder
unicode
internal/profilerecord
internal/goos
internal/godebugs
internal/coverage/rtcov
sync/atomic
internal/race
internal/cpu
internal/chacha8rand
internal/goexperiment
runtime/internal/sys
internal/bytealg
internal/runtime/atomic
internal/stringslite
internal/runtime/exithook
runtime
internal/weak
iter
internal/reflectlite
maps
sync
slices
errors
internal/bisect
internal/testlog
internal/singleflight
path
internal/oserror
io
vendor/golang.org/x/net/dns/dnsmessage
internal/godebug
crypto/internal/edwards25519/field
sort
math/rand/v2
hash
crypto/internal/randutil
bytes
internal/concurrent
math/rand
strings
crypto/internal/edwards25519
crypto/internal/nistec/fiat
strconv
vendor/golang.org/x/text/transform
hash/crc32
unique
net/http/internal/ascii
bufio
crypto
crypto/rc4
crypto/cipher
net/netip
regexp/syntax
crypto/md5
crypto/internal/boring
crypto/des
reflect
crypto/hmac
crypto/sha256
crypto/sha1
crypto/sha512
regexp
crypto/aes
syscall
internal/fmtsort
vendor/golang.org/x/crypto/hkdf
encoding/binary
internal/syscall/execenv
encoding/base64
vendor/golang.org/x/crypto/chacha20
vendor/golang.org/x/crypto/internal/poly1305
time
encoding/pem
internal/syscall/unix
vendor/golang.org/x/crypto/chacha20poly1305
context
crypto/x509/internal/macos
io/fs
embed
internal/filepathlite
internal/poll
crypto/internal/nistec
crypto/ecdh
os
io/ioutil
path/filepath
fmt
vendor/golang.org/x/net/route
vendor/golang.org/x/sys/cpu
encoding/hex
net/url
log
encoding/xml
mime
vendor/golang.org/x/net/http2/hpack
compress/flate
encoding/json
net/http/internal
vendor/golang.org/x/text/unicode/norm
mime/quotedprintable
vendor/golang.org/x/crypto/sha3
vendor/golang.org/x/text/unicode/bidi
compress/gzip
vendor/golang.org/x/text/secure/bidirule
math/big
crypto/internal/boring/bbig
crypto/dsa
crypto/internal/bigmod
crypto/rand
vendor/golang.org/x/net/idna
encoding/asn1
crypto/elliptic
crypto/ed25519
crypto/internal/hpke
crypto/internal/mlkem768
crypto/x509/pkix
crypto/rsa
vendor/golang.org/x/crypto/cryptobyte
crypto/ecdsa
net
vendor/golang.org/x/net/http/httpproxy
net/textproto
vendor/golang.org/x/net/http/httpguts
mime/multipart
crypto/x509
crypto/tls
net/http/httptrace
net/http
golang.org/x/net/context/ctxhttp
net/http/httputil
golang.org/x/oauth2/internal
golang.org/x/oauth2
github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin/v1

```