### PR TITLE
Update cluster link config field names to match API changes

### DIFF
--- a/kafkarest/v3/model_list_link_configs_response_data.go
+++ b/kafkarest/v3/model_list_link_configs_response_data.go
@@ -36,29 +36,31 @@ import (
 
 // ListLinkConfigsResponseData struct for ListLinkConfigsResponseData
 type ListLinkConfigsResponseData struct {
-	Kind      string           `json:"kind,omitempty"`
-	Metadata  ResourceMetadata `json:"metadata,omitempty"`
-	ClusterId string           `json:"cluster_id,omitempty"`
-	Name      string           `json:"name,omitempty"`
-	Value     string           `json:"value,omitempty"`
-	IsReadOnly  bool           `json:"is_read_only,omitempty"`
-	IsSensitive bool           `json:"is_sensitive,omitempty"`
-	Source    string           `json:"source,omitempty"`
-	Synonyms  []string         `json:"synonyms,omitempty"`
-	LinkName  string           `json:"link_name,omitempty"`
+	Kind        string           `json:"kind,omitempty"`
+	Metadata    ResourceMetadata `json:"metadata,omitempty"`
+	ClusterId   string           `json:"cluster_id,omitempty"`
+	Name        string           `json:"name,omitempty"`
+	Value       string           `json:"value,omitempty"`
+	IsDefault   bool             `json:"is_default,omitempty"`
+	IsReadOnly  bool             `json:"is_read_only,omitempty"`
+	IsSensitive bool             `json:"is_sensitive,omitempty"`
+	Source      string           `json:"source,omitempty"`
+	Synonyms    []string         `json:"synonyms,omitempty"`
+	LinkName    string           `json:"link_name,omitempty"`
 }
 
 // NewListLinkConfigsResponseData instantiates a new ListLinkConfigsResponseData object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewListLinkConfigsResponseData(kind string, metadata ResourceMetadata, clusterId string, name string, value string, readOnly bool, sensitive bool, source string, synonyms []string, linkName string) *ListLinkConfigsResponseData {
+func NewListLinkConfigsResponseData(kind string, metadata ResourceMetadata, clusterId string, name string, value string, isDefault bool, readOnly bool, sensitive bool, source string, synonyms []string, linkName string) *ListLinkConfigsResponseData {
 	this := ListLinkConfigsResponseData{}
 	this.Kind = kind
 	this.Metadata = metadata
 	this.ClusterId = clusterId
 	this.Name = name
 	this.Value = value
+	this.IsDefault = isDefault
 	this.IsReadOnly = readOnly
 	this.IsSensitive = sensitive
 	this.Source = source
@@ -193,6 +195,30 @@ func (o *ListLinkConfigsResponseData) GetValueOk() (*string, bool) {
 // SetValue sets field value
 func (o *ListLinkConfigsResponseData) SetValue(v string) {
 	o.Value = v
+}
+
+// GetIsDefault returns the IsDefault field value
+func (o *ListLinkConfigsResponseData) GetIsDefault() bool {
+	if o == nil {
+		var ret bool
+		return ret
+	}
+
+	return o.IsDefault
+}
+
+// GetIsDefaultOk returns a tuple with the IsDefault field value
+// and a boolean to check if the value has been set.
+func (o *ListLinkConfigsResponseData) GetIsDefaultOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.IsDefault, true
+}
+
+// SetIsDefault sets field value
+func (o *ListLinkConfigsResponseData) SetIsDefault(v bool) {
+	o.IsDefault = v
 }
 
 // GetIsReadOnly returns the IsReadOnly field value
@@ -375,6 +401,9 @@ func (o ListLinkConfigsResponseData) MarshalJSON() ([]byte, error) {
 	}
 	if true {
 		toSerialize["value"] = o.Value
+	}
+	if true {
+		toSerialize["is_default"] = o.IsDefault
 	}
 	if true {
 		toSerialize["is_read_only"] = o.IsReadOnly

--- a/kafkarest/v3/model_list_link_configs_response_data.go
+++ b/kafkarest/v3/model_list_link_configs_response_data.go
@@ -41,8 +41,8 @@ type ListLinkConfigsResponseData struct {
 	ClusterId string           `json:"cluster_id,omitempty"`
 	Name      string           `json:"name,omitempty"`
 	Value     string           `json:"value,omitempty"`
-	ReadOnly  bool             `json:"read_only,omitempty"`
-	Sensitive bool             `json:"sensitive,omitempty"`
+	IsReadOnly  bool           `json:"is_read_only,omitempty"`
+	IsSensitive bool           `json:"is_sensitive,omitempty"`
 	Source    string           `json:"source,omitempty"`
 	Synonyms  []string         `json:"synonyms,omitempty"`
 	LinkName  string           `json:"link_name,omitempty"`
@@ -59,8 +59,8 @@ func NewListLinkConfigsResponseData(kind string, metadata ResourceMetadata, clus
 	this.ClusterId = clusterId
 	this.Name = name
 	this.Value = value
-	this.ReadOnly = readOnly
-	this.Sensitive = sensitive
+	this.IsReadOnly = readOnly
+	this.IsSensitive = sensitive
 	this.Source = source
 	this.Synonyms = synonyms
 	this.LinkName = linkName
@@ -195,52 +195,52 @@ func (o *ListLinkConfigsResponseData) SetValue(v string) {
 	o.Value = v
 }
 
-// GetReadOnly returns the ReadOnly field value
-func (o *ListLinkConfigsResponseData) GetReadOnly() bool {
+// GetIsReadOnly returns the IsReadOnly field value
+func (o *ListLinkConfigsResponseData) GetIsReadOnly() bool {
 	if o == nil {
 		var ret bool
 		return ret
 	}
 
-	return o.ReadOnly
+	return o.IsReadOnly
 }
 
-// GetReadOnlyOk returns a tuple with the ReadOnly field value
+// GetIsReadOnlyOk returns a tuple with the IsReadOnly field value
 // and a boolean to check if the value has been set.
-func (o *ListLinkConfigsResponseData) GetReadOnlyOk() (*bool, bool) {
+func (o *ListLinkConfigsResponseData) GetIsReadOnlyOk() (*bool, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.ReadOnly, true
+	return &o.IsReadOnly, true
 }
 
-// SetReadOnly sets field value
-func (o *ListLinkConfigsResponseData) SetReadOnly(v bool) {
-	o.ReadOnly = v
+// SetIsReadOnly sets field value
+func (o *ListLinkConfigsResponseData) SetIsReadOnly(v bool) {
+	o.IsReadOnly = v
 }
 
-// GetSensitive returns the Sensitive field value
-func (o *ListLinkConfigsResponseData) GetSensitive() bool {
+// GetIsSensitive returns the IsSensitive field value
+func (o *ListLinkConfigsResponseData) GetIsSensitive() bool {
 	if o == nil {
 		var ret bool
 		return ret
 	}
 
-	return o.Sensitive
+	return o.IsSensitive
 }
 
-// GetSensitiveOk returns a tuple with the Sensitive field value
+// GetIsSensitiveOk returns a tuple with the IsSensitive field value
 // and a boolean to check if the value has been set.
-func (o *ListLinkConfigsResponseData) GetSensitiveOk() (*bool, bool) {
+func (o *ListLinkConfigsResponseData) GetIsSensitiveOk() (*bool, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.Sensitive, true
+	return &o.IsSensitive, true
 }
 
-// SetSensitive sets field value
-func (o *ListLinkConfigsResponseData) SetSensitive(v bool) {
-	o.Sensitive = v
+// SetIsSensitive sets field value
+func (o *ListLinkConfigsResponseData) SetIsSensitive(v bool) {
+	o.IsSensitive = v
 }
 
 // GetSource returns the Source field value
@@ -322,8 +322,8 @@ func (o *ListLinkConfigsResponseData) Redact() {
 	o.recurseRedact(&o.ClusterId)
 	o.recurseRedact(&o.Name)
 	o.recurseRedact(&o.Value)
-	o.recurseRedact(&o.ReadOnly)
-	o.recurseRedact(&o.Sensitive)
+	o.recurseRedact(&o.IsReadOnly)
+	o.recurseRedact(&o.IsSensitive)
 	o.recurseRedact(&o.Source)
 	o.recurseRedact(&o.Synonyms)
 	o.recurseRedact(&o.LinkName)
@@ -377,10 +377,10 @@ func (o ListLinkConfigsResponseData) MarshalJSON() ([]byte, error) {
 		toSerialize["value"] = o.Value
 	}
 	if true {
-		toSerialize["read_only"] = o.ReadOnly
+		toSerialize["is_read_only"] = o.IsReadOnly
 	}
 	if true {
-		toSerialize["sensitive"] = o.Sensitive
+		toSerialize["is_sensitive"] = o.IsSensitive
 	}
 	if true {
 		toSerialize["source"] = o.Source

--- a/kafkarest/v3/model_list_link_configs_response_data_all_of.go
+++ b/kafkarest/v3/model_list_link_configs_response_data_all_of.go
@@ -36,14 +36,14 @@ import (
 
 // ListLinkConfigsResponseDataAllOf struct for ListLinkConfigsResponseDataAllOf
 type ListLinkConfigsResponseDataAllOf struct {
-	ClusterId string   `json:"cluster_id,omitempty"`
-	Name      string   `json:"name,omitempty"`
-	Value     string   `json:"value,omitempty"`
-	ReadOnly  bool     `json:"read_only,omitempty"`
-	Sensitive bool     `json:"sensitive,omitempty"`
-	Source    string   `json:"source,omitempty"`
-	Synonyms  []string `json:"synonyms,omitempty"`
-	LinkName  string   `json:"link_name,omitempty"`
+	ClusterId   string   `json:"cluster_id,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Value       string   `json:"value,omitempty"`
+	IsReadOnly  bool     `json:"is_read_only,omitempty"`
+	IsSensitive bool     `json:"is_sensitive,omitempty"`
+	Source      string   `json:"source,omitempty"`
+	Synonyms    []string `json:"synonyms,omitempty"`
+	LinkName    string   `json:"link_name,omitempty"`
 }
 
 // NewListLinkConfigsResponseDataAllOf instantiates a new ListLinkConfigsResponseDataAllOf object
@@ -55,8 +55,8 @@ func NewListLinkConfigsResponseDataAllOf(clusterId string, name string, value st
 	this.ClusterId = clusterId
 	this.Name = name
 	this.Value = value
-	this.ReadOnly = readOnly
-	this.Sensitive = sensitive
+	this.IsReadOnly = readOnly
+	this.IsSensitive = sensitive
 	this.Source = source
 	this.Synonyms = synonyms
 	this.LinkName = linkName
@@ -143,52 +143,52 @@ func (o *ListLinkConfigsResponseDataAllOf) SetValue(v string) {
 	o.Value = v
 }
 
-// GetReadOnly returns the ReadOnly field value
-func (o *ListLinkConfigsResponseDataAllOf) GetReadOnly() bool {
+// GetIsReadOnly returns the IsReadOnly field value
+func (o *ListLinkConfigsResponseDataAllOf) GetIsReadOnly() bool {
 	if o == nil {
 		var ret bool
 		return ret
 	}
 
-	return o.ReadOnly
+	return o.IsReadOnly
 }
 
-// GetReadOnlyOk returns a tuple with the ReadOnly field value
+// GetIsReadOnlyOk returns a tuple with the IsReadOnly field value
 // and a boolean to check if the value has been set.
-func (o *ListLinkConfigsResponseDataAllOf) GetReadOnlyOk() (*bool, bool) {
+func (o *ListLinkConfigsResponseDataAllOf) GetIsReadOnlyOk() (*bool, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.ReadOnly, true
+	return &o.IsReadOnly, true
 }
 
-// SetReadOnly sets field value
-func (o *ListLinkConfigsResponseDataAllOf) SetReadOnly(v bool) {
-	o.ReadOnly = v
+// SetIsReadOnly sets field value
+func (o *ListLinkConfigsResponseDataAllOf) SetIsReadOnly(v bool) {
+	o.IsReadOnly = v
 }
 
-// GetSensitive returns the Sensitive field value
-func (o *ListLinkConfigsResponseDataAllOf) GetSensitive() bool {
+// GetIsSensitive returns the IsSensitive field value
+func (o *ListLinkConfigsResponseDataAllOf) GetIsSensitive() bool {
 	if o == nil {
 		var ret bool
 		return ret
 	}
 
-	return o.Sensitive
+	return o.IsSensitive
 }
 
-// GetSensitiveOk returns a tuple with the Sensitive field value
+// GetIsSensitiveOk returns a tuple with the IsSensitive field value
 // and a boolean to check if the value has been set.
-func (o *ListLinkConfigsResponseDataAllOf) GetSensitiveOk() (*bool, bool) {
+func (o *ListLinkConfigsResponseDataAllOf) GetIsSensitiveOk() (*bool, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.Sensitive, true
+	return &o.IsSensitive, true
 }
 
-// SetSensitive sets field value
-func (o *ListLinkConfigsResponseDataAllOf) SetSensitive(v bool) {
-	o.Sensitive = v
+// SetIsSensitive sets field value
+func (o *ListLinkConfigsResponseDataAllOf) SetIsSensitive(v bool) {
+	o.IsSensitive = v
 }
 
 // GetSource returns the Source field value
@@ -268,8 +268,8 @@ func (o *ListLinkConfigsResponseDataAllOf) Redact() {
 	o.recurseRedact(&o.ClusterId)
 	o.recurseRedact(&o.Name)
 	o.recurseRedact(&o.Value)
-	o.recurseRedact(&o.ReadOnly)
-	o.recurseRedact(&o.Sensitive)
+	o.recurseRedact(&o.IsReadOnly)
+	o.recurseRedact(&o.IsSensitive)
 	o.recurseRedact(&o.Source)
 	o.recurseRedact(&o.Synonyms)
 	o.recurseRedact(&o.LinkName)
@@ -317,10 +317,10 @@ func (o ListLinkConfigsResponseDataAllOf) MarshalJSON() ([]byte, error) {
 		toSerialize["value"] = o.Value
 	}
 	if true {
-		toSerialize["read_only"] = o.ReadOnly
+		toSerialize["is_read_only"] = o.IsReadOnly
 	}
 	if true {
-		toSerialize["sensitive"] = o.Sensitive
+		toSerialize["is_sensitive"] = o.IsSensitive
 	}
 	if true {
 		toSerialize["source"] = o.Source

--- a/kafkarest/v3/model_list_link_configs_response_data_all_of.go
+++ b/kafkarest/v3/model_list_link_configs_response_data_all_of.go
@@ -39,6 +39,7 @@ type ListLinkConfigsResponseDataAllOf struct {
 	ClusterId   string   `json:"cluster_id,omitempty"`
 	Name        string   `json:"name,omitempty"`
 	Value       string   `json:"value,omitempty"`
+	IsDefault   bool     `json:"is_default,omitempty"`
 	IsReadOnly  bool     `json:"is_read_only,omitempty"`
 	IsSensitive bool     `json:"is_sensitive,omitempty"`
 	Source      string   `json:"source,omitempty"`
@@ -50,11 +51,12 @@ type ListLinkConfigsResponseDataAllOf struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewListLinkConfigsResponseDataAllOf(clusterId string, name string, value string, readOnly bool, sensitive bool, source string, synonyms []string, linkName string) *ListLinkConfigsResponseDataAllOf {
+func NewListLinkConfigsResponseDataAllOf(clusterId string, name string, value string, isDefault bool, readOnly bool, sensitive bool, source string, synonyms []string, linkName string) *ListLinkConfigsResponseDataAllOf {
 	this := ListLinkConfigsResponseDataAllOf{}
 	this.ClusterId = clusterId
 	this.Name = name
 	this.Value = value
+	this.IsDefault = isDefault
 	this.IsReadOnly = readOnly
 	this.IsSensitive = sensitive
 	this.Source = source
@@ -141,6 +143,30 @@ func (o *ListLinkConfigsResponseDataAllOf) GetValueOk() (*string, bool) {
 // SetValue sets field value
 func (o *ListLinkConfigsResponseDataAllOf) SetValue(v string) {
 	o.Value = v
+}
+
+// GetIsDefault returns the IsDefault field value
+func (o *ListLinkConfigsResponseDataAllOf) GetIsDefault() bool {
+	if o == nil {
+		var ret bool
+		return ret
+	}
+
+	return o.IsDefault
+}
+
+// GetIsDefaultOk returns a tuple with the IsDefault field value
+// and a boolean to check if the value has been set.
+func (o *ListLinkConfigsResponseDataAllOf) GetIsDefaultOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.IsDefault, true
+}
+
+// SetIsDefault sets field value
+func (o *ListLinkConfigsResponseDataAllOf) SetIsDefault(v bool) {
+	o.IsDefault = v
 }
 
 // GetIsReadOnly returns the IsReadOnly field value
@@ -315,6 +341,9 @@ func (o ListLinkConfigsResponseDataAllOf) MarshalJSON() ([]byte, error) {
 	}
 	if true {
 		toSerialize["value"] = o.Value
+	}
+	if true {
+		toSerialize["is_default"] = o.IsDefault
 	}
 	if true {
 		toSerialize["is_read_only"] = o.IsReadOnly


### PR DESCRIPTION
**What**
Update cluster link config field names to match API changes

**Test**
```
❯ go vet -v
internal/itoa
internal/msan
cmp
encoding
math/bits
internal/goos
internal/byteorder
internal/profilerecord
internal/goarch
internal/coverage/rtcov
internal/godebugs
internal/race
unicode/utf8
internal/asan
unicode/utf16
crypto/internal/alias
unicode
runtime/internal/math
internal/goexperiment
vendor/golang.org/x/crypto/cryptobyte/asn1
internal/nettrace
container/list
vendor/golang.org/x/crypto/internal/alias
runtime/internal/sys
log/internal
crypto/internal/boring/sig
crypto/subtle
sync/atomic
internal/chacha8rand
internal/cpu
internal/abi
internal/runtime/atomic
internal/bytealg
internal/runtime/exithook
internal/stringslite
math
runtime
internal/weak
iter
internal/reflectlite
sync
maps
slices
errors
internal/singleflight
internal/testlog
internal/bisect
sort
path
internal/oserror
internal/godebug
io
crypto/internal/edwards25519/field
vendor/golang.org/x/net/dns/dnsmessage
math/rand/v2
hash
crypto/internal/randutil
math/rand
strconv
internal/concurrent
strings
bytes
crypto/internal/edwards25519
crypto/internal/nistec/fiat
hash/crc32
crypto
vendor/golang.org/x/text/transform
crypto/rc4
net/http/internal/ascii
unique
bufio
crypto/cipher
regexp/syntax
crypto/md5
net/netip
reflect
crypto/des
crypto/internal/boring
syscall
internal/fmtsort
regexp
encoding/binary
crypto/hmac
crypto/sha512
crypto/sha256
internal/syscall/execenv
crypto/sha1
crypto/aes
encoding/base64
vendor/golang.org/x/crypto/hkdf
vendor/golang.org/x/crypto/internal/poly1305
vendor/golang.org/x/crypto/chacha20
time
internal/syscall/unix
encoding/pem
vendor/golang.org/x/crypto/chacha20poly1305
context
crypto/x509/internal/macos
io/fs
embed
internal/poll
internal/filepathlite
crypto/internal/nistec
crypto/ecdh
os
io/ioutil
path/filepath
fmt
vendor/golang.org/x/sys/cpu
vendor/golang.org/x/net/route
log
mime/quotedprintable
net/url
net/http/internal
mime
encoding/hex
vendor/golang.org/x/net/http2/hpack
encoding/xml
compress/flate
encoding/json
vendor/golang.org/x/crypto/sha3
vendor/golang.org/x/text/unicode/norm
vendor/golang.org/x/text/unicode/bidi
compress/gzip
math/big
vendor/golang.org/x/text/secure/bidirule
crypto/internal/bigmod
crypto/internal/boring/bbig
crypto/dsa
crypto/rand
crypto/elliptic
crypto/rsa
net
crypto/ed25519
encoding/asn1
crypto/internal/hpke
crypto/x509/pkix
vendor/golang.org/x/crypto/cryptobyte
crypto/internal/mlkem768
crypto/ecdsa
vendor/golang.org/x/net/idna
net/textproto
vendor/golang.org/x/net/http/httpproxy
vendor/golang.org/x/net/http/httpguts
crypto/x509
mime/multipart
crypto/tls
net/http/httptrace
net/http
golang.org/x/net/context/ctxhttp
net/http/httputil
golang.org/x/oauth2/internal
golang.org/x/oauth2
github.com/confluentinc/ccloud-sdk-go-v2/kafkarest/v3
```