### PR TITLE
Update kafkarest

### DIFF
--- a/kafkarest/go.mod
+++ b/kafkarest/go.mod
@@ -2,4 +2,4 @@ module github.com/confluentinc/ccloud-sdk-go-v2/kafkarest
 
 go 1.23.10
 
-require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99
+require golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558

--- a/kafkarest/go.sum
+++ b/kafkarest/go.sum
@@ -185,6 +185,7 @@ golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99 h1:5vD4XjIc0X5+kHZjx4UecYdjA6mJo+XXNoaW0EjU5Os=
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/kafkarest/v3/api/openapi.yaml
+++ b/kafkarest/v3/api/openapi.yaml
@@ -2306,6 +2306,8 @@ paths:
                   is_simple: false
                   partition_assignor: org.apache.kafka.clients.consumer.RoundRobinAssignor
                   state: STABLE
+                  type: CLASSIC
+                  is_mixed_consumer_group: false
                   coordinator:
                     related: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1
                   consumers:
@@ -2321,6 +2323,8 @@ paths:
                   is_simple: false
                   partition_assignor: org.apache.kafka.clients.consumer.StickyAssignor
                   state: PREPARING_REBALANCE
+                  type: CLASSIC
+                  is_mixed_consumer_group: false
                   coordinator:
                     related: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/2
                   consumers:
@@ -2336,6 +2340,8 @@ paths:
                   is_simple: false
                   partition_assignor: org.apache.kafka.clients.consumer.RangeAssignor
                   state: DEAD
+                  type: CLASSIC
+                  is_mixed_consumer_group: false
                   coordinator:
                     related: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/3
                   consumers:
@@ -2554,6 +2560,8 @@ paths:
                 is_simple: false
                 partition_assignor: org.apache.kafka.clients.consumer.RoundRobinAssignor
                 state: STABLE
+                type: CLASSIC
+                is_mixed_consumer_group: false
                 coordinator:
                   related: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1
                 consumers:
@@ -4878,7 +4886,8 @@ paths:
       description: |-
         [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-        Increase the number of partitions for a topic.
+        Increase the number of partitions for a topic. To update other topic
+        configurations, see https://docs.confluent.io/cloud/current/api.html#tag/Configs-(v3)/operation/updateKafkaTopicConfig.
       operationId: updatePartitionCountKafkaTopic
       parameters:
       - description: The Kafka cluster ID.
@@ -6111,7 +6120,9 @@ paths:
       description: |-
         [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-        Update the configuration parameter with given `name`.
+        Update the configuration parameter with given `name`. To update the
+        number of partitions, see
+        https://docs.confluent.io/cloud/current/api.html#tag/Topic-(v3)/operation/updatePartitionCountKafkaTopic.
       operationId: updateKafkaTopicConfig
       parameters:
       - description: The Kafka cluster ID.
@@ -8603,14 +8614,13 @@ paths:
                   cluster_id: 1Rh_4htxSuen7RYGvGmgNw
                   name: consumer.offset.sync.ms
                   value: "3825940"
-                  default: false
-                  read_only: false
-                  sensitive: false
+                  is_default: false
+                  is_read_only: false
+                  is_sensitive: false
                   source: DYNAMIC_CLUSTER_LINK_CONFIG
                   synonyms:
                   - cosm
                   link_name: link-db-1
-                  link_id: 7840644d-f7d8-4844-a577-a10ef3df31df
                 - kind: KafkaLinkConfigData
                   metadata:
                     self: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/1Rh_4htxSuen7RYGvGmgNw/links/my-new-link-1
@@ -8618,14 +8628,13 @@ paths:
                   cluster_id: 1Rh_4htxSuen7RYGvGmgNw
                   name: acl.sync.ms
                   value: "5000"
-                  default: false
-                  read_only: false
-                  sensitive: false
+                  is_default: false
+                  is_read_only: false
+                  is_sensitive: false
                   source: DYNAMIC_CLUSTER_LINK_CONFIG
                   synonyms:
                   - asm
                   link_name: link-db-1
-                  link_id: 7840644d-f7d8-4844-a577-a10ef3df31df
               schema:
                 $ref: '#/components/schemas/ListLinkConfigsResponseDataList'
           description: Config name and value
@@ -9017,17 +9026,13 @@ paths:
                 cluster_id: 1Rh_4htxSuen7RYGvGmgNw
                 name: consumer.offset.sync.ms
                 value: "3825940"
-                default: false
-                read_only: false
-                sensitive: false
+                is_default: false
+                is_read_only: false
+                is_sensitive: false
                 source: DYNAMIC_CLUSTER_LINK_CONFIG
                 synonyms:
                 - cosm
                 link_name: link-db-1
-                link_id: 7840644d-f7d8-4844-a577-a10ef3df31df
-                topics:
-                - topic-db-1
-                - topic-db-2
               schema:
                 $ref: '#/components/schemas/ListLinkConfigsResponseData'
           description: Config name and value
@@ -12923,7 +12928,7 @@ components:
                   value: "30000"
                 - name: sasl.mechanism
                   value: PLAIN
-                - name: sasl.protocol
+                - name: security.protocol
                   value: SASL_SSL
                 - name: sasl.jaas.config
                   value: sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule
@@ -12939,31 +12944,31 @@ components:
                   value: SOURCE
                 - name: sasl.mechanism
                   value: PLAIN
-                - name: sasl.protocol
+                - name: security.protocol
                   value: SASL_SSL
                 - name: sasl.jaas.config
                   value: sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule
-                    required username='<Kafka API Key>' password='<Kafka API Secret>';
+                    required username='<Remote Kafka API Key>' password='<Remote Kafka
+                    API Secret>';
+                - name: local.sasl.mechanism
+                  value: PLAIN
+                - name: local.security.protocol
+                  value: SASL_SSL
+                - name: local.sasl.jaas.config
+                  value: sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule
+                    required username='<Local Kafka API Key>' password='<Local Kafka
+                    API Secret>';
             source_initiated_link_at_destination_cluster:
               description: Create a source initiated cluster link at destination cluster
               value:
                 destination_cluster_id: cluster-1
                 configs:
-                - name: bootstrap.servers
-                  value: cluster-1-bootstrap-server
                 - name: link.mode
                   value: DESTINATION
                 - name: connection.mode
                   value: INBOUND
                 - name: acl.sync.enable
                   value: "false"
-                - name: sasl.mechanism
-                  value: PLAIN
-                - name: sasl.protocol
-                  value: SASL_SSL
-                - name: sasl.jaas.config
-                  value: sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule
-                    required username='<Kafka API Key>' password='<Kafka API Secret>';
             bidirectional_link_east:
               description: Create a bidirectional cluster link in east
               value:
@@ -12977,7 +12982,7 @@ components:
                   value: west.
                 - name: sasl.mechanism
                   value: PLAIN
-                - name: sasl.protocol
+                - name: security.protocol
                   value: SASL_SSL
                 - name: sasl.jaas.config
                   value: sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule
@@ -12996,7 +13001,7 @@ components:
                   value: east.
                 - name: sasl.mechanism
                   value: PLAIN
-                - name: sasl.protocol
+                - name: security.protocol
                   value: SASL_SSL
                 - name: sasl.jaas.config
                   value: sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule
@@ -13273,6 +13278,8 @@ components:
             is_simple: false
             partition_assignor: org.apache.kafka.clients.consumer.RoundRobinAssignor
             state: STABLE
+            type: CLASSIC
+            is_mixed_consumer_group: false
             coordinator:
               related: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1
             consumers:
@@ -13755,6 +13762,8 @@ components:
               is_simple: false
               partition_assignor: org.apache.kafka.clients.consumer.RoundRobinAssignor
               state: STABLE
+              type: CLASSIC
+              is_mixed_consumer_group: false
               coordinator:
                 related: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/1
               consumers:
@@ -13770,6 +13779,8 @@ components:
               is_simple: false
               partition_assignor: org.apache.kafka.clients.consumer.StickyAssignor
               state: PREPARING_REBALANCE
+              type: CLASSIC
+              is_mixed_consumer_group: false
               coordinator:
                 related: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/2
               consumers:
@@ -13785,6 +13796,8 @@ components:
               is_simple: false
               partition_assignor: org.apache.kafka.clients.consumer.RangeAssignor
               state: DEAD
+              type: CLASSIC
+              is_mixed_consumer_group: false
               coordinator:
                 related: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/3
               consumers:
@@ -15101,14 +15114,13 @@ components:
               cluster_id: 1Rh_4htxSuen7RYGvGmgNw
               name: consumer.offset.sync.ms
               value: "3825940"
-              default: false
-              read_only: false
-              sensitive: false
+              is_default: false
+              is_read_only: false
+              is_sensitive: false
               source: DYNAMIC_CLUSTER_LINK_CONFIG
               synonyms:
               - cosm
               link_name: link-db-1
-              link_id: 7840644d-f7d8-4844-a577-a10ef3df31df
             - kind: KafkaLinkConfigData
               metadata:
                 self: https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/1Rh_4htxSuen7RYGvGmgNw/links/my-new-link-1
@@ -15116,14 +15128,13 @@ components:
               cluster_id: 1Rh_4htxSuen7RYGvGmgNw
               name: acl.sync.ms
               value: "5000"
-              default: false
-              read_only: false
-              sensitive: false
+              is_default: false
+              is_read_only: false
+              is_sensitive: false
               source: DYNAMIC_CLUSTER_LINK_CONFIG
               synonyms:
               - asm
               link_name: link-db-1
-              link_id: 7840644d-f7d8-4844-a577-a10ef3df31df
           schema:
             $ref: '#/components/schemas/ListLinkConfigsResponseDataList'
       description: Config name and value
@@ -15138,17 +15149,13 @@ components:
             cluster_id: 1Rh_4htxSuen7RYGvGmgNw
             name: consumer.offset.sync.ms
             value: "3825940"
-            default: false
-            read_only: false
-            sensitive: false
+            is_default: false
+            is_read_only: false
+            is_sensitive: false
             source: DYNAMIC_CLUSTER_LINK_CONFIG
             synonyms:
             - cosm
             link_name: link-db-1
-            link_id: 7840644d-f7d8-4844-a577-a10ef3df31df
-            topics:
-            - topic-db-1
-            - topic-db-2
           schema:
             $ref: '#/components/schemas/ListLinkConfigsResponseData'
       description: Config name and value
@@ -15689,9 +15696,18 @@ components:
       - UNKNOWN
       - PREPARING_REBALANCE
       - COMPLETING_REBALANCE
+      - ASSIGNING
+      - RECONCILING
       - STABLE
       - DEAD
       - EMPTY
+    ConsumerGroupType:
+      type: string
+      x-extensible-enum:
+      - UNKNOWN
+      - CLASSIC
+      - CONSUMER
+      - SHARE
     ConsumerLagData:
       allOf:
       - $ref: '#/components/schemas/Resource'
@@ -16711,12 +16727,23 @@ components:
           - UNKNOWN
           - PREPARING_REBALANCE
           - COMPLETING_REBALANCE
+          - ASSIGNING
+          - RECONCILING
           - STABLE
           - DEAD
           - EMPTY
+        type:
+          type: string
+          x-extensible-enum:
+          - UNKNOWN
+          - CLASSIC
+          - CONSUMER
+          - SHARE
+        is_mixed_consumer_group:
+          type: boolean
         coordinator:
           $ref: '#/components/schemas/Relationship'
-        consumer:
+        consumers:
           $ref: '#/components/schemas/Relationship'
         lag_summary:
           $ref: '#/components/schemas/Relationship'
@@ -16725,10 +16752,12 @@ components:
       - consumer_group_id
       - consumers
       - coordinator
+      - is_mixed_consumer_group
       - is_simple
       - lag_summary
       - partition_assignor
       - state
+      - type
       type: object
     ConsumerGroupDataList_allOf:
       properties:
@@ -17405,9 +17434,11 @@ components:
           type: string
         value:
           type: string
-        read_only:
+        is_default:
           type: boolean
-        sensitive:
+        is_read_only:
+          type: boolean
+        is_sensitive:
           type: boolean
         source:
           type: string
@@ -17421,11 +17452,11 @@ components:
           type: string
       required:
       - cluster_id
-      - default
+      - is_default
+      - is_read_only
+      - is_sensitive
       - link_name
       - name
-      - read_only
-      - sensitive
       - source
       - synonyms
       - value

--- a/kafkarest/v3/api_aclv3.go
+++ b/kafkarest/v3/api_aclv3.go
@@ -42,15 +42,15 @@ var (
 type ACLV3Api interface {
 
 	/*
-	BatchCreateKafkaAcls Batch Create ACLs
+			BatchCreateKafkaAcls Batch Create ACLs
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Create ACLs.
+		Create ACLs.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @return ApiBatchCreateKafkaAclsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiBatchCreateKafkaAclsRequest
 	*/
 	BatchCreateKafkaAcls(ctx _context.Context, clusterId string) ApiBatchCreateKafkaAclsRequest
 
@@ -58,15 +58,15 @@ Create ACLs.
 	BatchCreateKafkaAclsExecute(r ApiBatchCreateKafkaAclsRequest) (*_nethttp.Response, error)
 
 	/*
-	CreateKafkaAcls Create an ACL
+			CreateKafkaAcls Create an ACL
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Create an ACL.
+		Create an ACL.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @return ApiCreateKafkaAclsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiCreateKafkaAclsRequest
 	*/
 	CreateKafkaAcls(ctx _context.Context, clusterId string) ApiCreateKafkaAclsRequest
 
@@ -74,15 +74,15 @@ Create an ACL.
 	CreateKafkaAclsExecute(r ApiCreateKafkaAclsRequest) (*_nethttp.Response, error)
 
 	/*
-	DeleteKafkaAcls Delete ACLs
+			DeleteKafkaAcls Delete ACLs
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Delete the ACLs that match the search criteria.
+		Delete the ACLs that match the search criteria.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @return ApiDeleteKafkaAclsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiDeleteKafkaAclsRequest
 	*/
 	DeleteKafkaAcls(ctx _context.Context, clusterId string) ApiDeleteKafkaAclsRequest
 
@@ -91,15 +91,15 @@ Delete the ACLs that match the search criteria.
 	DeleteKafkaAclsExecute(r ApiDeleteKafkaAclsRequest) (InlineResponse200, *_nethttp.Response, error)
 
 	/*
-	GetKafkaAcls List ACLs
+			GetKafkaAcls List ACLs
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return a list of ACLs that match the search criteria.
+		Return a list of ACLs that match the search criteria.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @return ApiGetKafkaAclsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiGetKafkaAclsRequest
 	*/
 	GetKafkaAcls(ctx _context.Context, clusterId string) ApiGetKafkaAclsRequest
 
@@ -112,9 +112,9 @@ Return a list of ACLs that match the search criteria.
 type ACLV3ApiService service
 
 type ApiBatchCreateKafkaAclsRequest struct {
-	ctx _context.Context
-	ApiService ACLV3Api
-	clusterId string
+	ctx                      _context.Context
+	ApiService               ACLV3Api
+	clusterId                string
 	createAclRequestDataList *CreateAclRequestDataList
 }
 
@@ -135,15 +135,15 @@ BatchCreateKafkaAcls Batch Create ACLs
 
 Create ACLs.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiBatchCreateKafkaAclsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiBatchCreateKafkaAclsRequest
 */
 func (a *ACLV3ApiService) BatchCreateKafkaAcls(ctx _context.Context, clusterId string) ApiBatchCreateKafkaAclsRequest {
 	return ApiBatchCreateKafkaAclsRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ctx:        ctx,
+		clusterId:  clusterId,
 	}
 }
 
@@ -266,9 +266,9 @@ func (a *ACLV3ApiService) BatchCreateKafkaAclsExecute(r ApiBatchCreateKafkaAclsR
 }
 
 type ApiCreateKafkaAclsRequest struct {
-	ctx _context.Context
-	ApiService ACLV3Api
-	clusterId string
+	ctx                  _context.Context
+	ApiService           ACLV3Api
+	clusterId            string
 	createAclRequestData *CreateAclRequestData
 }
 
@@ -289,15 +289,15 @@ CreateKafkaAcls Create an ACL
 
 Create an ACL.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiCreateKafkaAclsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiCreateKafkaAclsRequest
 */
 func (a *ACLV3ApiService) CreateKafkaAcls(ctx _context.Context, clusterId string) ApiCreateKafkaAclsRequest {
 	return ApiCreateKafkaAclsRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ctx:        ctx,
+		clusterId:  clusterId,
 	}
 }
 
@@ -420,16 +420,16 @@ func (a *ACLV3ApiService) CreateKafkaAclsExecute(r ApiCreateKafkaAclsRequest) (*
 }
 
 type ApiDeleteKafkaAclsRequest struct {
-	ctx _context.Context
-	ApiService ACLV3Api
-	clusterId string
+	ctx          _context.Context
+	ApiService   ACLV3Api
+	clusterId    string
 	resourceType *AclResourceType
-	patternType *string
-	operation *string
-	permission *string
+	patternType  *string
+	operation    *string
+	permission   *string
 	resourceName *string
-	principal *string
-	host *string
+	principal    *string
+	host         *string
 }
 
 // The ACL resource type.
@@ -437,31 +437,37 @@ func (r ApiDeleteKafkaAclsRequest) ResourceType(resourceType AclResourceType) Ap
 	r.resourceType = &resourceType
 	return r
 }
+
 // The ACL pattern type.
 func (r ApiDeleteKafkaAclsRequest) PatternType(patternType string) ApiDeleteKafkaAclsRequest {
 	r.patternType = &patternType
 	return r
 }
+
 // The ACL operation.
 func (r ApiDeleteKafkaAclsRequest) Operation(operation string) ApiDeleteKafkaAclsRequest {
 	r.operation = &operation
 	return r
 }
+
 // The ACL permission.
 func (r ApiDeleteKafkaAclsRequest) Permission(permission string) ApiDeleteKafkaAclsRequest {
 	r.permission = &permission
 	return r
 }
+
 // The ACL resource name.
 func (r ApiDeleteKafkaAclsRequest) ResourceName(resourceName string) ApiDeleteKafkaAclsRequest {
 	r.resourceName = &resourceName
 	return r
 }
+
 // The ACL principal. This is the Service Account name or user name.
 func (r ApiDeleteKafkaAclsRequest) Principal(principal string) ApiDeleteKafkaAclsRequest {
 	r.principal = &principal
 	return r
 }
+
 // The ACL host.
 func (r ApiDeleteKafkaAclsRequest) Host(host string) ApiDeleteKafkaAclsRequest {
 	r.host = &host
@@ -479,20 +485,21 @@ DeleteKafkaAcls Delete ACLs
 
 Delete the ACLs that match the search criteria.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiDeleteKafkaAclsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiDeleteKafkaAclsRequest
 */
 func (a *ACLV3ApiService) DeleteKafkaAcls(ctx _context.Context, clusterId string) ApiDeleteKafkaAclsRequest {
 	return ApiDeleteKafkaAclsRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ctx:        ctx,
+		clusterId:  clusterId,
 	}
 }
 
 // Execute executes the request
-//  @return InlineResponse200
+//
+//	@return InlineResponse200
 func (a *ACLV3ApiService) DeleteKafkaAclsExecute(r ApiDeleteKafkaAclsRequest) (InlineResponse200, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
@@ -644,16 +651,16 @@ func (a *ACLV3ApiService) DeleteKafkaAclsExecute(r ApiDeleteKafkaAclsRequest) (I
 }
 
 type ApiGetKafkaAclsRequest struct {
-	ctx _context.Context
-	ApiService ACLV3Api
-	clusterId string
+	ctx          _context.Context
+	ApiService   ACLV3Api
+	clusterId    string
 	resourceType *AclResourceType
 	resourceName *string
-	patternType *string
-	principal *string
-	host *string
-	operation *string
-	permission *string
+	patternType  *string
+	principal    *string
+	host         *string
+	operation    *string
+	permission   *string
 }
 
 // The ACL resource type.
@@ -661,31 +668,37 @@ func (r ApiGetKafkaAclsRequest) ResourceType(resourceType AclResourceType) ApiGe
 	r.resourceType = &resourceType
 	return r
 }
+
 // The ACL resource name.
 func (r ApiGetKafkaAclsRequest) ResourceName(resourceName string) ApiGetKafkaAclsRequest {
 	r.resourceName = &resourceName
 	return r
 }
+
 // The ACL pattern type.
 func (r ApiGetKafkaAclsRequest) PatternType(patternType string) ApiGetKafkaAclsRequest {
 	r.patternType = &patternType
 	return r
 }
+
 // The ACL principal. This is the Service Account name or user name.
 func (r ApiGetKafkaAclsRequest) Principal(principal string) ApiGetKafkaAclsRequest {
 	r.principal = &principal
 	return r
 }
+
 // The ACL host.
 func (r ApiGetKafkaAclsRequest) Host(host string) ApiGetKafkaAclsRequest {
 	r.host = &host
 	return r
 }
+
 // The ACL operation.
 func (r ApiGetKafkaAclsRequest) Operation(operation string) ApiGetKafkaAclsRequest {
 	r.operation = &operation
 	return r
 }
+
 // The ACL permission.
 func (r ApiGetKafkaAclsRequest) Permission(permission string) ApiGetKafkaAclsRequest {
 	r.permission = &permission
@@ -703,20 +716,21 @@ GetKafkaAcls List ACLs
 
 Return a list of ACLs that match the search criteria.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiGetKafkaAclsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiGetKafkaAclsRequest
 */
 func (a *ACLV3ApiService) GetKafkaAcls(ctx _context.Context, clusterId string) ApiGetKafkaAclsRequest {
 	return ApiGetKafkaAclsRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ctx:        ctx,
+		clusterId:  clusterId,
 	}
 }
 
 // Execute executes the request
-//  @return AclDataList
+//
+//	@return AclDataList
 func (a *ACLV3ApiService) GetKafkaAclsExecute(r ApiGetKafkaAclsRequest) (AclDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet

--- a/kafkarest/v3/api_cluster_linking_v3.go
+++ b/kafkarest/v3/api_cluster_linking_v3.go
@@ -42,16 +42,16 @@ var (
 type ClusterLinkingV3Api interface {
 
 	/*
-	CreateKafkaLink Create a cluster link
+			CreateKafkaLink Create a cluster link
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Cluster link creation requires source cluster security configurations in
-the configs JSON section of the data request payload.
+		Cluster link creation requires source cluster security configurations in
+		the configs JSON section of the data request payload.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @return ApiCreateKafkaLinkRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiCreateKafkaLinkRequest
 	*/
 	CreateKafkaLink(ctx _context.Context, clusterId string) ApiCreateKafkaLinkRequest
 
@@ -59,17 +59,17 @@ the configs JSON section of the data request payload.
 	CreateKafkaLinkExecute(r ApiCreateKafkaLinkRequest) (*_nethttp.Response, error)
 
 	/*
-	CreateKafkaMirrorTopic Create a mirror topic
+			CreateKafkaMirrorTopic Create a mirror topic
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Create a topic in the destination cluster mirroring a topic in
-the source cluster
+		Create a topic in the destination cluster mirroring a topic in
+		the source cluster
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param linkName The link name
-	 @return ApiCreateKafkaMirrorTopicRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param linkName The link name
+			 @return ApiCreateKafkaMirrorTopicRequest
 	*/
 	CreateKafkaMirrorTopic(ctx _context.Context, clusterId string, linkName string) ApiCreateKafkaMirrorTopicRequest
 
@@ -77,14 +77,14 @@ the source cluster
 	CreateKafkaMirrorTopicExecute(r ApiCreateKafkaMirrorTopicRequest) (*_nethttp.Response, error)
 
 	/*
-	DeleteKafkaLink Delete the cluster link
+		DeleteKafkaLink Delete the cluster link
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param linkName The link name
-	 @return ApiDeleteKafkaLinkRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param clusterId The Kafka cluster ID.
+		 @param linkName The link name
+		 @return ApiDeleteKafkaLinkRequest
 	*/
 	DeleteKafkaLink(ctx _context.Context, clusterId string, linkName string) ApiDeleteKafkaLinkRequest
 
@@ -92,15 +92,15 @@ the source cluster
 	DeleteKafkaLinkExecute(r ApiDeleteKafkaLinkRequest) (*_nethttp.Response, error)
 
 	/*
-	DeleteKafkaLinkConfig Reset the given config to default value
+		DeleteKafkaLinkConfig Reset the given config to default value
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param linkName The link name
-	 @param configName The link config name
-	 @return ApiDeleteKafkaLinkConfigRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param clusterId The Kafka cluster ID.
+		 @param linkName The link name
+		 @param configName The link config name
+		 @return ApiDeleteKafkaLinkConfigRequest
 	*/
 	DeleteKafkaLinkConfig(ctx _context.Context, clusterId string, linkName string, configName string) ApiDeleteKafkaLinkConfigRequest
 
@@ -108,16 +108,16 @@ the source cluster
 	DeleteKafkaLinkConfigExecute(r ApiDeleteKafkaLinkConfigRequest) (*_nethttp.Response, error)
 
 	/*
-	GetKafkaLink Describe the cluster link
+			GetKafkaLink Describe the cluster link
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-``link_id`` in ``ListLinksResponseData`` is deprecated and may be removed in a future release. Use the new ``cluster_link_id`` instead.
+		``link_id`` in ``ListLinksResponseData`` is deprecated and may be removed in a future release. Use the new ``cluster_link_id`` instead.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param linkName The link name
-	 @return ApiGetKafkaLinkRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param linkName The link name
+			 @return ApiGetKafkaLinkRequest
 	*/
 	GetKafkaLink(ctx _context.Context, clusterId string, linkName string) ApiGetKafkaLinkRequest
 
@@ -126,15 +126,15 @@ the source cluster
 	GetKafkaLinkExecute(r ApiGetKafkaLinkRequest) (ListLinksResponseData, *_nethttp.Response, error)
 
 	/*
-	GetKafkaLinkConfigs Describe the config under the cluster link
+		GetKafkaLinkConfigs Describe the config under the cluster link
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param linkName The link name
-	 @param configName The link config name
-	 @return ApiGetKafkaLinkConfigsRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param clusterId The Kafka cluster ID.
+		 @param linkName The link name
+		 @param configName The link config name
+		 @return ApiGetKafkaLinkConfigsRequest
 	*/
 	GetKafkaLinkConfigs(ctx _context.Context, clusterId string, linkName string, configName string) ApiGetKafkaLinkConfigsRequest
 
@@ -143,14 +143,14 @@ the source cluster
 	GetKafkaLinkConfigsExecute(r ApiGetKafkaLinkConfigsRequest) (ListLinkConfigsResponseData, *_nethttp.Response, error)
 
 	/*
-	ListKafkaLinkConfigs List all configs of the cluster link
+		ListKafkaLinkConfigs List all configs of the cluster link
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param linkName The link name
-	 @return ApiListKafkaLinkConfigsRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param clusterId The Kafka cluster ID.
+		 @param linkName The link name
+		 @return ApiListKafkaLinkConfigsRequest
 	*/
 	ListKafkaLinkConfigs(ctx _context.Context, clusterId string, linkName string) ApiListKafkaLinkConfigsRequest
 
@@ -159,15 +159,15 @@ the source cluster
 	ListKafkaLinkConfigsExecute(r ApiListKafkaLinkConfigsRequest) (ListLinkConfigsResponseDataList, *_nethttp.Response, error)
 
 	/*
-	ListKafkaLinks List all cluster links in the dest cluster
+			ListKafkaLinks List all cluster links in the dest cluster
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-``link_id`` in ``ListLinksResponseData`` is deprecated and may be removed in a future release. Use the new ``cluster_link_id`` instead.
+		``link_id`` in ``ListLinksResponseData`` is deprecated and may be removed in a future release. Use the new ``cluster_link_id`` instead.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @return ApiListKafkaLinksRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiListKafkaLinksRequest
 	*/
 	ListKafkaLinks(ctx _context.Context, clusterId string) ApiListKafkaLinksRequest
 
@@ -176,15 +176,15 @@ the source cluster
 	ListKafkaLinksExecute(r ApiListKafkaLinksRequest) (ListLinksResponseDataList, *_nethttp.Response, error)
 
 	/*
-	ListKafkaMirrorTopics List mirror topics
+			ListKafkaMirrorTopics List mirror topics
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-List all mirror topics in the cluster
+		List all mirror topics in the cluster
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @return ApiListKafkaMirrorTopicsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiListKafkaMirrorTopicsRequest
 	*/
 	ListKafkaMirrorTopics(ctx _context.Context, clusterId string) ApiListKafkaMirrorTopicsRequest
 
@@ -193,16 +193,16 @@ List all mirror topics in the cluster
 	ListKafkaMirrorTopicsExecute(r ApiListKafkaMirrorTopicsRequest) (ListMirrorTopicsResponseDataList, *_nethttp.Response, error)
 
 	/*
-	ListKafkaMirrorTopicsUnderLink List mirror topics
+			ListKafkaMirrorTopicsUnderLink List mirror topics
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-List all mirror topics under the link
+		List all mirror topics under the link
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param linkName The link name
-	 @return ApiListKafkaMirrorTopicsUnderLinkRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param linkName The link name
+			 @return ApiListKafkaMirrorTopicsUnderLinkRequest
 	*/
 	ListKafkaMirrorTopicsUnderLink(ctx _context.Context, clusterId string, linkName string) ApiListKafkaMirrorTopicsUnderLinkRequest
 
@@ -211,15 +211,15 @@ List all mirror topics under the link
 	ListKafkaMirrorTopicsUnderLinkExecute(r ApiListKafkaMirrorTopicsUnderLinkRequest) (ListMirrorTopicsResponseDataList, *_nethttp.Response, error)
 
 	/*
-	ReadKafkaMirrorTopic Describe the mirror topic
+		ReadKafkaMirrorTopic Describe the mirror topic
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param linkName The link name
-	 @param mirrorTopicName Cluster Linking mirror topic name
-	 @return ApiReadKafkaMirrorTopicRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param clusterId The Kafka cluster ID.
+		 @param linkName The link name
+		 @param mirrorTopicName Cluster Linking mirror topic name
+		 @return ApiReadKafkaMirrorTopicRequest
 	*/
 	ReadKafkaMirrorTopic(ctx _context.Context, clusterId string, linkName string, mirrorTopicName string) ApiReadKafkaMirrorTopicRequest
 
@@ -228,15 +228,15 @@ List all mirror topics under the link
 	ReadKafkaMirrorTopicExecute(r ApiReadKafkaMirrorTopicRequest) (ListMirrorTopicsResponseData, *_nethttp.Response, error)
 
 	/*
-	UpdateKafkaLinkConfig Alter the config under the cluster link
+		UpdateKafkaLinkConfig Alter the config under the cluster link
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param linkName The link name
-	 @param configName The link config name
-	 @return ApiUpdateKafkaLinkConfigRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param clusterId The Kafka cluster ID.
+		 @param linkName The link name
+		 @param configName The link config name
+		 @return ApiUpdateKafkaLinkConfigRequest
 	*/
 	UpdateKafkaLinkConfig(ctx _context.Context, clusterId string, linkName string, configName string) ApiUpdateKafkaLinkConfigRequest
 
@@ -244,16 +244,16 @@ List all mirror topics under the link
 	UpdateKafkaLinkConfigExecute(r ApiUpdateKafkaLinkConfigRequest) (*_nethttp.Response, error)
 
 	/*
-	UpdateKafkaLinkConfigBatch Batch Alter Cluster Link Configs
+			UpdateKafkaLinkConfigBatch Batch Alter Cluster Link Configs
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Batch Alter Cluster Link Configs
+		Batch Alter Cluster Link Configs
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param linkName The link name
-	 @return ApiUpdateKafkaLinkConfigBatchRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param linkName The link name
+			 @return ApiUpdateKafkaLinkConfigBatchRequest
 	*/
 	UpdateKafkaLinkConfigBatch(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaLinkConfigBatchRequest
 
@@ -261,14 +261,14 @@ Batch Alter Cluster Link Configs
 	UpdateKafkaLinkConfigBatchExecute(r ApiUpdateKafkaLinkConfigBatchRequest) (*_nethttp.Response, error)
 
 	/*
-	UpdateKafkaMirrorTopicsFailover Failover the mirror topics
+		UpdateKafkaMirrorTopicsFailover Failover the mirror topics
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param linkName The link name
-	 @return ApiUpdateKafkaMirrorTopicsFailoverRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param clusterId The Kafka cluster ID.
+		 @param linkName The link name
+		 @return ApiUpdateKafkaMirrorTopicsFailoverRequest
 	*/
 	UpdateKafkaMirrorTopicsFailover(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaMirrorTopicsFailoverRequest
 
@@ -277,14 +277,14 @@ Batch Alter Cluster Link Configs
 	UpdateKafkaMirrorTopicsFailoverExecute(r ApiUpdateKafkaMirrorTopicsFailoverRequest) (AlterMirrorStatusResponseDataList, *_nethttp.Response, error)
 
 	/*
-	UpdateKafkaMirrorTopicsPause Pause the mirror topics
+		UpdateKafkaMirrorTopicsPause Pause the mirror topics
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param linkName The link name
-	 @return ApiUpdateKafkaMirrorTopicsPauseRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param clusterId The Kafka cluster ID.
+		 @param linkName The link name
+		 @return ApiUpdateKafkaMirrorTopicsPauseRequest
 	*/
 	UpdateKafkaMirrorTopicsPause(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaMirrorTopicsPauseRequest
 
@@ -293,14 +293,14 @@ Batch Alter Cluster Link Configs
 	UpdateKafkaMirrorTopicsPauseExecute(r ApiUpdateKafkaMirrorTopicsPauseRequest) (AlterMirrorStatusResponseDataList, *_nethttp.Response, error)
 
 	/*
-	UpdateKafkaMirrorTopicsPromote Promote the mirror topics
+		UpdateKafkaMirrorTopicsPromote Promote the mirror topics
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param linkName The link name
-	 @return ApiUpdateKafkaMirrorTopicsPromoteRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param clusterId The Kafka cluster ID.
+		 @param linkName The link name
+		 @return ApiUpdateKafkaMirrorTopicsPromoteRequest
 	*/
 	UpdateKafkaMirrorTopicsPromote(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaMirrorTopicsPromoteRequest
 
@@ -309,14 +309,14 @@ Batch Alter Cluster Link Configs
 	UpdateKafkaMirrorTopicsPromoteExecute(r ApiUpdateKafkaMirrorTopicsPromoteRequest) (AlterMirrorStatusResponseDataList, *_nethttp.Response, error)
 
 	/*
-	UpdateKafkaMirrorTopicsResume Resume the mirror topics
+		UpdateKafkaMirrorTopicsResume Resume the mirror topics
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param linkName The link name
-	 @return ApiUpdateKafkaMirrorTopicsResumeRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param clusterId The Kafka cluster ID.
+		 @param linkName The link name
+		 @return ApiUpdateKafkaMirrorTopicsResumeRequest
 	*/
 	UpdateKafkaMirrorTopicsResume(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaMirrorTopicsResumeRequest
 
@@ -325,14 +325,14 @@ Batch Alter Cluster Link Configs
 	UpdateKafkaMirrorTopicsResumeExecute(r ApiUpdateKafkaMirrorTopicsResumeRequest) (AlterMirrorStatusResponseDataList, *_nethttp.Response, error)
 
 	/*
-	UpdateKafkaMirrorTopicsReverseAndPauseMirror Reverse the local mirror topic and Pause the remote mirror topic
+		UpdateKafkaMirrorTopicsReverseAndPauseMirror Reverse the local mirror topic and Pause the remote mirror topic
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param linkName The link name
-	 @return ApiUpdateKafkaMirrorTopicsReverseAndPauseMirrorRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param clusterId The Kafka cluster ID.
+		 @param linkName The link name
+		 @return ApiUpdateKafkaMirrorTopicsReverseAndPauseMirrorRequest
 	*/
 	UpdateKafkaMirrorTopicsReverseAndPauseMirror(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaMirrorTopicsReverseAndPauseMirrorRequest
 
@@ -341,14 +341,14 @@ Batch Alter Cluster Link Configs
 	UpdateKafkaMirrorTopicsReverseAndPauseMirrorExecute(r ApiUpdateKafkaMirrorTopicsReverseAndPauseMirrorRequest) (AlterMirrorStatusResponseDataList, *_nethttp.Response, error)
 
 	/*
-	UpdateKafkaMirrorTopicsReverseAndStartMirror Reverse the local mirror topic and start the remote mirror topic
+		UpdateKafkaMirrorTopicsReverseAndStartMirror Reverse the local mirror topic and start the remote mirror topic
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param linkName The link name
-	 @return ApiUpdateKafkaMirrorTopicsReverseAndStartMirrorRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param clusterId The Kafka cluster ID.
+		 @param linkName The link name
+		 @return ApiUpdateKafkaMirrorTopicsReverseAndStartMirrorRequest
 	*/
 	UpdateKafkaMirrorTopicsReverseAndStartMirror(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaMirrorTopicsReverseAndStartMirrorRequest
 
@@ -357,14 +357,14 @@ Batch Alter Cluster Link Configs
 	UpdateKafkaMirrorTopicsReverseAndStartMirrorExecute(r ApiUpdateKafkaMirrorTopicsReverseAndStartMirrorRequest) (AlterMirrorStatusResponseDataList, *_nethttp.Response, error)
 
 	/*
-	UpdateKafkaMirrorTopicsTruncateAndRestoreMirror Truncates the local topic to the remote stopped mirror log end offsets and restores mirroring to the local topic to mirror from the remote topic
+		UpdateKafkaMirrorTopicsTruncateAndRestoreMirror Truncates the local topic to the remote stopped mirror log end offsets and restores mirroring to the local topic to mirror from the remote topic
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param linkName The link name
-	 @return ApiUpdateKafkaMirrorTopicsTruncateAndRestoreMirrorRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param clusterId The Kafka cluster ID.
+		 @param linkName The link name
+		 @return ApiUpdateKafkaMirrorTopicsTruncateAndRestoreMirrorRequest
 	*/
 	UpdateKafkaMirrorTopicsTruncateAndRestoreMirror(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaMirrorTopicsTruncateAndRestoreMirrorRequest
 
@@ -377,12 +377,12 @@ Batch Alter Cluster Link Configs
 type ClusterLinkingV3ApiService service
 
 type ApiCreateKafkaLinkRequest struct {
-	ctx _context.Context
-	ApiService ClusterLinkingV3Api
-	clusterId string
-	linkName *string
-	validateOnly *bool
-	validateLink *bool
+	ctx                   _context.Context
+	ApiService            ClusterLinkingV3Api
+	clusterId             string
+	linkName              *string
+	validateOnly          *bool
+	validateLink          *bool
 	createLinkRequestData *CreateLinkRequestData
 }
 
@@ -391,16 +391,19 @@ func (r ApiCreateKafkaLinkRequest) LinkName(linkName string) ApiCreateKafkaLinkR
 	r.linkName = &linkName
 	return r
 }
+
 // To validate the action can be performed successfully or not. Default: false
 func (r ApiCreateKafkaLinkRequest) ValidateOnly(validateOnly bool) ApiCreateKafkaLinkRequest {
 	r.validateOnly = &validateOnly
 	return r
 }
+
 // To synchronously validate that the source cluster ID is expected and the dest cluster has the permission to read topics in the source cluster. Default: true
 func (r ApiCreateKafkaLinkRequest) ValidateLink(validateLink bool) ApiCreateKafkaLinkRequest {
 	r.validateLink = &validateLink
 	return r
 }
+
 // Create a cluster link
 func (r ApiCreateKafkaLinkRequest) CreateLinkRequestData(createLinkRequestData CreateLinkRequestData) ApiCreateKafkaLinkRequest {
 	r.createLinkRequestData = &createLinkRequestData
@@ -419,15 +422,15 @@ CreateKafkaLink Create a cluster link
 Cluster link creation requires source cluster security configurations in
 the configs JSON section of the data request payload.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiCreateKafkaLinkRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiCreateKafkaLinkRequest
 */
 func (a *ClusterLinkingV3ApiService) CreateKafkaLink(ctx _context.Context, clusterId string) ApiCreateKafkaLinkRequest {
 	return ApiCreateKafkaLinkRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ctx:        ctx,
+		clusterId:  clusterId,
 	}
 }
 
@@ -550,10 +553,10 @@ func (a *ClusterLinkingV3ApiService) CreateKafkaLinkExecute(r ApiCreateKafkaLink
 }
 
 type ApiCreateKafkaMirrorTopicRequest struct {
-	ctx _context.Context
-	ApiService ClusterLinkingV3Api
-	clusterId string
-	linkName string
+	ctx                          _context.Context
+	ApiService                   ClusterLinkingV3Api
+	clusterId                    string
+	linkName                     string
 	createMirrorTopicRequestData *CreateMirrorTopicRequestData
 }
 
@@ -575,17 +578,17 @@ CreateKafkaMirrorTopic Create a mirror topic
 Create a topic in the destination cluster mirroring a topic in
 the source cluster
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiCreateKafkaMirrorTopicRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiCreateKafkaMirrorTopicRequest
 */
 func (a *ClusterLinkingV3ApiService) CreateKafkaMirrorTopic(ctx _context.Context, clusterId string, linkName string) ApiCreateKafkaMirrorTopicRequest {
 	return ApiCreateKafkaMirrorTopicRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		linkName: linkName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		linkName:   linkName,
 	}
 }
 
@@ -699,11 +702,11 @@ func (a *ClusterLinkingV3ApiService) CreateKafkaMirrorTopicExecute(r ApiCreateKa
 }
 
 type ApiDeleteKafkaLinkRequest struct {
-	ctx _context.Context
-	ApiService ClusterLinkingV3Api
-	clusterId string
-	linkName string
-	force *bool
+	ctx          _context.Context
+	ApiService   ClusterLinkingV3Api
+	clusterId    string
+	linkName     string
+	force        *bool
 	validateOnly *bool
 }
 
@@ -712,6 +715,7 @@ func (r ApiDeleteKafkaLinkRequest) Force(force bool) ApiDeleteKafkaLinkRequest {
 	r.force = &force
 	return r
 }
+
 // To validate the action can be performed successfully or not. Default: false
 func (r ApiDeleteKafkaLinkRequest) ValidateOnly(validateOnly bool) ApiDeleteKafkaLinkRequest {
 	r.validateOnly = &validateOnly
@@ -727,17 +731,17 @@ DeleteKafkaLink Delete the cluster link
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiDeleteKafkaLinkRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiDeleteKafkaLinkRequest
 */
 func (a *ClusterLinkingV3ApiService) DeleteKafkaLink(ctx _context.Context, clusterId string, linkName string) ApiDeleteKafkaLinkRequest {
 	return ApiDeleteKafkaLinkRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		linkName: linkName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		linkName:   linkName,
 	}
 }
 
@@ -855,13 +859,12 @@ func (a *ClusterLinkingV3ApiService) DeleteKafkaLinkExecute(r ApiDeleteKafkaLink
 }
 
 type ApiDeleteKafkaLinkConfigRequest struct {
-	ctx _context.Context
+	ctx        _context.Context
 	ApiService ClusterLinkingV3Api
-	clusterId string
-	linkName string
+	clusterId  string
+	linkName   string
 	configName string
 }
-
 
 func (r ApiDeleteKafkaLinkConfigRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.DeleteKafkaLinkConfigExecute(r)
@@ -872,18 +875,18 @@ DeleteKafkaLinkConfig Reset the given config to default value
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @param configName The link config name
- @return ApiDeleteKafkaLinkConfigRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@param configName The link config name
+	@return ApiDeleteKafkaLinkConfigRequest
 */
 func (a *ClusterLinkingV3ApiService) DeleteKafkaLinkConfig(ctx _context.Context, clusterId string, linkName string, configName string) ApiDeleteKafkaLinkConfigRequest {
 	return ApiDeleteKafkaLinkConfigRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		linkName: linkName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		linkName:   linkName,
 		configName: configName,
 	}
 }
@@ -997,10 +1000,10 @@ func (a *ClusterLinkingV3ApiService) DeleteKafkaLinkConfigExecute(r ApiDeleteKaf
 }
 
 type ApiGetKafkaLinkRequest struct {
-	ctx _context.Context
-	ApiService ClusterLinkingV3Api
-	clusterId string
-	linkName string
+	ctx          _context.Context
+	ApiService   ClusterLinkingV3Api
+	clusterId    string
+	linkName     string
 	includeTasks *bool
 }
 
@@ -1019,24 +1022,25 @@ GetKafkaLink Describe the cluster link
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-``link_id`` in ``ListLinksResponseData`` is deprecated and may be removed in a future release. Use the new ``cluster_link_id`` instead.
+“link_id“ in “ListLinksResponseData“ is deprecated and may be removed in a future release. Use the new “cluster_link_id“ instead.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiGetKafkaLinkRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiGetKafkaLinkRequest
 */
 func (a *ClusterLinkingV3ApiService) GetKafkaLink(ctx _context.Context, clusterId string, linkName string) ApiGetKafkaLinkRequest {
 	return ApiGetKafkaLinkRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		linkName: linkName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		linkName:   linkName,
 	}
 }
 
 // Execute executes the request
-//  @return ListLinksResponseData
+//
+//	@return ListLinksResponseData
 func (a *ClusterLinkingV3ApiService) GetKafkaLinkExecute(r ApiGetKafkaLinkRequest) (ListLinksResponseData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1157,13 +1161,12 @@ func (a *ClusterLinkingV3ApiService) GetKafkaLinkExecute(r ApiGetKafkaLinkReques
 }
 
 type ApiGetKafkaLinkConfigsRequest struct {
-	ctx _context.Context
+	ctx        _context.Context
 	ApiService ClusterLinkingV3Api
-	clusterId string
-	linkName string
+	clusterId  string
+	linkName   string
 	configName string
 }
-
 
 func (r ApiGetKafkaLinkConfigsRequest) Execute() (ListLinkConfigsResponseData, *_nethttp.Response, error) {
 	return r.ApiService.GetKafkaLinkConfigsExecute(r)
@@ -1174,24 +1177,25 @@ GetKafkaLinkConfigs Describe the config under the cluster link
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @param configName The link config name
- @return ApiGetKafkaLinkConfigsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@param configName The link config name
+	@return ApiGetKafkaLinkConfigsRequest
 */
 func (a *ClusterLinkingV3ApiService) GetKafkaLinkConfigs(ctx _context.Context, clusterId string, linkName string, configName string) ApiGetKafkaLinkConfigsRequest {
 	return ApiGetKafkaLinkConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		linkName: linkName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		linkName:   linkName,
 		configName: configName,
 	}
 }
 
 // Execute executes the request
-//  @return ListLinkConfigsResponseData
+//
+//	@return ListLinkConfigsResponseData
 func (a *ClusterLinkingV3ApiService) GetKafkaLinkConfigsExecute(r ApiGetKafkaLinkConfigsRequest) (ListLinkConfigsResponseData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1310,12 +1314,11 @@ func (a *ClusterLinkingV3ApiService) GetKafkaLinkConfigsExecute(r ApiGetKafkaLin
 }
 
 type ApiListKafkaLinkConfigsRequest struct {
-	ctx _context.Context
+	ctx        _context.Context
 	ApiService ClusterLinkingV3Api
-	clusterId string
-	linkName string
+	clusterId  string
+	linkName   string
 }
-
 
 func (r ApiListKafkaLinkConfigsRequest) Execute() (ListLinkConfigsResponseDataList, *_nethttp.Response, error) {
 	return r.ApiService.ListKafkaLinkConfigsExecute(r)
@@ -1326,22 +1329,23 @@ ListKafkaLinkConfigs List all configs of the cluster link
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiListKafkaLinkConfigsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiListKafkaLinkConfigsRequest
 */
 func (a *ClusterLinkingV3ApiService) ListKafkaLinkConfigs(ctx _context.Context, clusterId string, linkName string) ApiListKafkaLinkConfigsRequest {
 	return ApiListKafkaLinkConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		linkName: linkName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		linkName:   linkName,
 	}
 }
 
 // Execute executes the request
-//  @return ListLinkConfigsResponseDataList
+//
+//	@return ListLinkConfigsResponseDataList
 func (a *ClusterLinkingV3ApiService) ListKafkaLinkConfigsExecute(r ApiListKafkaLinkConfigsRequest) (ListLinkConfigsResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1459,11 +1463,10 @@ func (a *ClusterLinkingV3ApiService) ListKafkaLinkConfigsExecute(r ApiListKafkaL
 }
 
 type ApiListKafkaLinksRequest struct {
-	ctx _context.Context
+	ctx        _context.Context
 	ApiService ClusterLinkingV3Api
-	clusterId string
+	clusterId  string
 }
-
 
 func (r ApiListKafkaLinksRequest) Execute() (ListLinksResponseDataList, *_nethttp.Response, error) {
 	return r.ApiService.ListKafkaLinksExecute(r)
@@ -1474,22 +1477,23 @@ ListKafkaLinks List all cluster links in the dest cluster
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-``link_id`` in ``ListLinksResponseData`` is deprecated and may be removed in a future release. Use the new ``cluster_link_id`` instead.
+“link_id“ in “ListLinksResponseData“ is deprecated and may be removed in a future release. Use the new “cluster_link_id“ instead.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiListKafkaLinksRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiListKafkaLinksRequest
 */
 func (a *ClusterLinkingV3ApiService) ListKafkaLinks(ctx _context.Context, clusterId string) ApiListKafkaLinksRequest {
 	return ApiListKafkaLinksRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ctx:        ctx,
+		clusterId:  clusterId,
 	}
 }
 
 // Execute executes the request
-//  @return ListLinksResponseDataList
+//
+//	@return ListLinksResponseDataList
 func (a *ClusterLinkingV3ApiService) ListKafkaLinksExecute(r ApiListKafkaLinksRequest) (ListLinksResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1606,9 +1610,9 @@ func (a *ClusterLinkingV3ApiService) ListKafkaLinksExecute(r ApiListKafkaLinksRe
 }
 
 type ApiListKafkaMirrorTopicsRequest struct {
-	ctx _context.Context
-	ApiService ClusterLinkingV3Api
-	clusterId string
+	ctx          _context.Context
+	ApiService   ClusterLinkingV3Api
+	clusterId    string
 	mirrorStatus *MirrorTopicStatus
 }
 
@@ -1629,20 +1633,21 @@ ListKafkaMirrorTopics List mirror topics
 
 List all mirror topics in the cluster
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiListKafkaMirrorTopicsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiListKafkaMirrorTopicsRequest
 */
 func (a *ClusterLinkingV3ApiService) ListKafkaMirrorTopics(ctx _context.Context, clusterId string) ApiListKafkaMirrorTopicsRequest {
 	return ApiListKafkaMirrorTopicsRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ctx:        ctx,
+		clusterId:  clusterId,
 	}
 }
 
 // Execute executes the request
-//  @return ListMirrorTopicsResponseDataList
+//
+//	@return ListMirrorTopicsResponseDataList
 func (a *ClusterLinkingV3ApiService) ListKafkaMirrorTopicsExecute(r ApiListKafkaMirrorTopicsRequest) (ListMirrorTopicsResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1762,10 +1767,10 @@ func (a *ClusterLinkingV3ApiService) ListKafkaMirrorTopicsExecute(r ApiListKafka
 }
 
 type ApiListKafkaMirrorTopicsUnderLinkRequest struct {
-	ctx _context.Context
-	ApiService ClusterLinkingV3Api
-	clusterId string
-	linkName string
+	ctx          _context.Context
+	ApiService   ClusterLinkingV3Api
+	clusterId    string
+	linkName     string
 	mirrorStatus *MirrorTopicStatus
 }
 
@@ -1786,22 +1791,23 @@ ListKafkaMirrorTopicsUnderLink List mirror topics
 
 List all mirror topics under the link
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiListKafkaMirrorTopicsUnderLinkRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiListKafkaMirrorTopicsUnderLinkRequest
 */
 func (a *ClusterLinkingV3ApiService) ListKafkaMirrorTopicsUnderLink(ctx _context.Context, clusterId string, linkName string) ApiListKafkaMirrorTopicsUnderLinkRequest {
 	return ApiListKafkaMirrorTopicsUnderLinkRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		linkName: linkName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		linkName:   linkName,
 	}
 }
 
 // Execute executes the request
-//  @return ListMirrorTopicsResponseDataList
+//
+//	@return ListMirrorTopicsResponseDataList
 func (a *ClusterLinkingV3ApiService) ListKafkaMirrorTopicsUnderLinkExecute(r ApiListKafkaMirrorTopicsUnderLinkRequest) (ListMirrorTopicsResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1922,11 +1928,11 @@ func (a *ClusterLinkingV3ApiService) ListKafkaMirrorTopicsUnderLinkExecute(r Api
 }
 
 type ApiReadKafkaMirrorTopicRequest struct {
-	ctx _context.Context
-	ApiService ClusterLinkingV3Api
-	clusterId string
-	linkName string
-	mirrorTopicName string
+	ctx                          _context.Context
+	ApiService                   ClusterLinkingV3Api
+	clusterId                    string
+	linkName                     string
+	mirrorTopicName              string
 	includeStateTransitionErrors *bool
 }
 
@@ -1945,24 +1951,25 @@ ReadKafkaMirrorTopic Describe the mirror topic
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @param mirrorTopicName Cluster Linking mirror topic name
- @return ApiReadKafkaMirrorTopicRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@param mirrorTopicName Cluster Linking mirror topic name
+	@return ApiReadKafkaMirrorTopicRequest
 */
 func (a *ClusterLinkingV3ApiService) ReadKafkaMirrorTopic(ctx _context.Context, clusterId string, linkName string, mirrorTopicName string) ApiReadKafkaMirrorTopicRequest {
 	return ApiReadKafkaMirrorTopicRequest{
-		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		linkName: linkName,
+		ApiService:      a,
+		ctx:             ctx,
+		clusterId:       clusterId,
+		linkName:        linkName,
 		mirrorTopicName: mirrorTopicName,
 	}
 }
 
 // Execute executes the request
-//  @return ListMirrorTopicsResponseData
+//
+//	@return ListMirrorTopicsResponseData
 func (a *ClusterLinkingV3ApiService) ReadKafkaMirrorTopicExecute(r ApiReadKafkaMirrorTopicRequest) (ListMirrorTopicsResponseData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -2084,11 +2091,11 @@ func (a *ClusterLinkingV3ApiService) ReadKafkaMirrorTopicExecute(r ApiReadKafkaM
 }
 
 type ApiUpdateKafkaLinkConfigRequest struct {
-	ctx _context.Context
-	ApiService ClusterLinkingV3Api
-	clusterId string
-	linkName string
-	configName string
+	ctx                         _context.Context
+	ApiService                  ClusterLinkingV3Api
+	clusterId                   string
+	linkName                    string
+	configName                  string
 	updateLinkConfigRequestData *UpdateLinkConfigRequestData
 }
 
@@ -2107,18 +2114,18 @@ UpdateKafkaLinkConfig Alter the config under the cluster link
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @param configName The link config name
- @return ApiUpdateKafkaLinkConfigRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@param configName The link config name
+	@return ApiUpdateKafkaLinkConfigRequest
 */
 func (a *ClusterLinkingV3ApiService) UpdateKafkaLinkConfig(ctx _context.Context, clusterId string, linkName string, configName string) ApiUpdateKafkaLinkConfigRequest {
 	return ApiUpdateKafkaLinkConfigRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		linkName: linkName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		linkName:   linkName,
 		configName: configName,
 	}
 }
@@ -2234,11 +2241,11 @@ func (a *ClusterLinkingV3ApiService) UpdateKafkaLinkConfigExecute(r ApiUpdateKaf
 }
 
 type ApiUpdateKafkaLinkConfigBatchRequest struct {
-	ctx _context.Context
-	ApiService ClusterLinkingV3Api
-	clusterId string
-	linkName string
-	validateOnly *bool
+	ctx                         _context.Context
+	ApiService                  ClusterLinkingV3Api
+	clusterId                   string
+	linkName                    string
+	validateOnly                *bool
 	alterConfigBatchRequestData *AlterConfigBatchRequestData
 }
 
@@ -2263,17 +2270,17 @@ UpdateKafkaLinkConfigBatch Batch Alter Cluster Link Configs
 
 Batch Alter Cluster Link Configs
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiUpdateKafkaLinkConfigBatchRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiUpdateKafkaLinkConfigBatchRequest
 */
 func (a *ClusterLinkingV3ApiService) UpdateKafkaLinkConfigBatch(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaLinkConfigBatchRequest {
 	return ApiUpdateKafkaLinkConfigBatchRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		linkName: linkName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		linkName:   linkName,
 	}
 }
 
@@ -2390,11 +2397,11 @@ func (a *ClusterLinkingV3ApiService) UpdateKafkaLinkConfigBatchExecute(r ApiUpda
 }
 
 type ApiUpdateKafkaMirrorTopicsFailoverRequest struct {
-	ctx _context.Context
-	ApiService ClusterLinkingV3Api
-	clusterId string
-	linkName string
-	validateOnly *bool
+	ctx                     _context.Context
+	ApiService              ClusterLinkingV3Api
+	clusterId               string
+	linkName                string
+	validateOnly            *bool
 	alterMirrorsRequestData *AlterMirrorsRequestData
 }
 
@@ -2403,6 +2410,7 @@ func (r ApiUpdateKafkaMirrorTopicsFailoverRequest) ValidateOnly(validateOnly boo
 	r.validateOnly = &validateOnly
 	return r
 }
+
 // Mirror topics to be altered.
 func (r ApiUpdateKafkaMirrorTopicsFailoverRequest) AlterMirrorsRequestData(alterMirrorsRequestData AlterMirrorsRequestData) ApiUpdateKafkaMirrorTopicsFailoverRequest {
 	r.alterMirrorsRequestData = &alterMirrorsRequestData
@@ -2418,22 +2426,23 @@ UpdateKafkaMirrorTopicsFailover Failover the mirror topics
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiUpdateKafkaMirrorTopicsFailoverRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiUpdateKafkaMirrorTopicsFailoverRequest
 */
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsFailover(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaMirrorTopicsFailoverRequest {
 	return ApiUpdateKafkaMirrorTopicsFailoverRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		linkName: linkName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		linkName:   linkName,
 	}
 }
 
 // Execute executes the request
-//  @return AlterMirrorStatusResponseDataList
+//
+//	@return AlterMirrorStatusResponseDataList
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsFailoverExecute(r ApiUpdateKafkaMirrorTopicsFailoverRequest) (AlterMirrorStatusResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
@@ -2556,11 +2565,11 @@ func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsFailoverExecute(r Ap
 }
 
 type ApiUpdateKafkaMirrorTopicsPauseRequest struct {
-	ctx _context.Context
-	ApiService ClusterLinkingV3Api
-	clusterId string
-	linkName string
-	validateOnly *bool
+	ctx                     _context.Context
+	ApiService              ClusterLinkingV3Api
+	clusterId               string
+	linkName                string
+	validateOnly            *bool
 	alterMirrorsRequestData *AlterMirrorsRequestData
 }
 
@@ -2569,6 +2578,7 @@ func (r ApiUpdateKafkaMirrorTopicsPauseRequest) ValidateOnly(validateOnly bool) 
 	r.validateOnly = &validateOnly
 	return r
 }
+
 // Mirror topics to be altered.
 func (r ApiUpdateKafkaMirrorTopicsPauseRequest) AlterMirrorsRequestData(alterMirrorsRequestData AlterMirrorsRequestData) ApiUpdateKafkaMirrorTopicsPauseRequest {
 	r.alterMirrorsRequestData = &alterMirrorsRequestData
@@ -2584,22 +2594,23 @@ UpdateKafkaMirrorTopicsPause Pause the mirror topics
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiUpdateKafkaMirrorTopicsPauseRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiUpdateKafkaMirrorTopicsPauseRequest
 */
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsPause(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaMirrorTopicsPauseRequest {
 	return ApiUpdateKafkaMirrorTopicsPauseRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		linkName: linkName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		linkName:   linkName,
 	}
 }
 
 // Execute executes the request
-//  @return AlterMirrorStatusResponseDataList
+//
+//	@return AlterMirrorStatusResponseDataList
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsPauseExecute(r ApiUpdateKafkaMirrorTopicsPauseRequest) (AlterMirrorStatusResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
@@ -2722,11 +2733,11 @@ func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsPauseExecute(r ApiUp
 }
 
 type ApiUpdateKafkaMirrorTopicsPromoteRequest struct {
-	ctx _context.Context
-	ApiService ClusterLinkingV3Api
-	clusterId string
-	linkName string
-	validateOnly *bool
+	ctx                     _context.Context
+	ApiService              ClusterLinkingV3Api
+	clusterId               string
+	linkName                string
+	validateOnly            *bool
 	alterMirrorsRequestData *AlterMirrorsRequestData
 }
 
@@ -2735,6 +2746,7 @@ func (r ApiUpdateKafkaMirrorTopicsPromoteRequest) ValidateOnly(validateOnly bool
 	r.validateOnly = &validateOnly
 	return r
 }
+
 // Mirror topics to be altered.
 func (r ApiUpdateKafkaMirrorTopicsPromoteRequest) AlterMirrorsRequestData(alterMirrorsRequestData AlterMirrorsRequestData) ApiUpdateKafkaMirrorTopicsPromoteRequest {
 	r.alterMirrorsRequestData = &alterMirrorsRequestData
@@ -2750,22 +2762,23 @@ UpdateKafkaMirrorTopicsPromote Promote the mirror topics
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiUpdateKafkaMirrorTopicsPromoteRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiUpdateKafkaMirrorTopicsPromoteRequest
 */
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsPromote(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaMirrorTopicsPromoteRequest {
 	return ApiUpdateKafkaMirrorTopicsPromoteRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		linkName: linkName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		linkName:   linkName,
 	}
 }
 
 // Execute executes the request
-//  @return AlterMirrorStatusResponseDataList
+//
+//	@return AlterMirrorStatusResponseDataList
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsPromoteExecute(r ApiUpdateKafkaMirrorTopicsPromoteRequest) (AlterMirrorStatusResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
@@ -2888,11 +2901,11 @@ func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsPromoteExecute(r Api
 }
 
 type ApiUpdateKafkaMirrorTopicsResumeRequest struct {
-	ctx _context.Context
-	ApiService ClusterLinkingV3Api
-	clusterId string
-	linkName string
-	validateOnly *bool
+	ctx                     _context.Context
+	ApiService              ClusterLinkingV3Api
+	clusterId               string
+	linkName                string
+	validateOnly            *bool
 	alterMirrorsRequestData *AlterMirrorsRequestData
 }
 
@@ -2901,6 +2914,7 @@ func (r ApiUpdateKafkaMirrorTopicsResumeRequest) ValidateOnly(validateOnly bool)
 	r.validateOnly = &validateOnly
 	return r
 }
+
 // Mirror topics to be altered.
 func (r ApiUpdateKafkaMirrorTopicsResumeRequest) AlterMirrorsRequestData(alterMirrorsRequestData AlterMirrorsRequestData) ApiUpdateKafkaMirrorTopicsResumeRequest {
 	r.alterMirrorsRequestData = &alterMirrorsRequestData
@@ -2916,22 +2930,23 @@ UpdateKafkaMirrorTopicsResume Resume the mirror topics
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiUpdateKafkaMirrorTopicsResumeRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiUpdateKafkaMirrorTopicsResumeRequest
 */
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsResume(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaMirrorTopicsResumeRequest {
 	return ApiUpdateKafkaMirrorTopicsResumeRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		linkName: linkName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		linkName:   linkName,
 	}
 }
 
 // Execute executes the request
-//  @return AlterMirrorStatusResponseDataList
+//
+//	@return AlterMirrorStatusResponseDataList
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsResumeExecute(r ApiUpdateKafkaMirrorTopicsResumeRequest) (AlterMirrorStatusResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
@@ -3054,11 +3069,11 @@ func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsResumeExecute(r ApiU
 }
 
 type ApiUpdateKafkaMirrorTopicsReverseAndPauseMirrorRequest struct {
-	ctx _context.Context
-	ApiService ClusterLinkingV3Api
-	clusterId string
-	linkName string
-	validateOnly *bool
+	ctx                     _context.Context
+	ApiService              ClusterLinkingV3Api
+	clusterId               string
+	linkName                string
+	validateOnly            *bool
 	alterMirrorsRequestData *AlterMirrorsRequestData
 }
 
@@ -3067,6 +3082,7 @@ func (r ApiUpdateKafkaMirrorTopicsReverseAndPauseMirrorRequest) ValidateOnly(val
 	r.validateOnly = &validateOnly
 	return r
 }
+
 // Mirror topics to be altered.
 func (r ApiUpdateKafkaMirrorTopicsReverseAndPauseMirrorRequest) AlterMirrorsRequestData(alterMirrorsRequestData AlterMirrorsRequestData) ApiUpdateKafkaMirrorTopicsReverseAndPauseMirrorRequest {
 	r.alterMirrorsRequestData = &alterMirrorsRequestData
@@ -3082,22 +3098,23 @@ UpdateKafkaMirrorTopicsReverseAndPauseMirror Reverse the local mirror topic and 
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiUpdateKafkaMirrorTopicsReverseAndPauseMirrorRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiUpdateKafkaMirrorTopicsReverseAndPauseMirrorRequest
 */
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsReverseAndPauseMirror(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaMirrorTopicsReverseAndPauseMirrorRequest {
 	return ApiUpdateKafkaMirrorTopicsReverseAndPauseMirrorRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		linkName: linkName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		linkName:   linkName,
 	}
 }
 
 // Execute executes the request
-//  @return AlterMirrorStatusResponseDataList
+//
+//	@return AlterMirrorStatusResponseDataList
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsReverseAndPauseMirrorExecute(r ApiUpdateKafkaMirrorTopicsReverseAndPauseMirrorRequest) (AlterMirrorStatusResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
@@ -3220,11 +3237,11 @@ func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsReverseAndPauseMirro
 }
 
 type ApiUpdateKafkaMirrorTopicsReverseAndStartMirrorRequest struct {
-	ctx _context.Context
-	ApiService ClusterLinkingV3Api
-	clusterId string
-	linkName string
-	validateOnly *bool
+	ctx                     _context.Context
+	ApiService              ClusterLinkingV3Api
+	clusterId               string
+	linkName                string
+	validateOnly            *bool
 	alterMirrorsRequestData *AlterMirrorsRequestData
 }
 
@@ -3233,6 +3250,7 @@ func (r ApiUpdateKafkaMirrorTopicsReverseAndStartMirrorRequest) ValidateOnly(val
 	r.validateOnly = &validateOnly
 	return r
 }
+
 // Mirror topics to be altered.
 func (r ApiUpdateKafkaMirrorTopicsReverseAndStartMirrorRequest) AlterMirrorsRequestData(alterMirrorsRequestData AlterMirrorsRequestData) ApiUpdateKafkaMirrorTopicsReverseAndStartMirrorRequest {
 	r.alterMirrorsRequestData = &alterMirrorsRequestData
@@ -3248,22 +3266,23 @@ UpdateKafkaMirrorTopicsReverseAndStartMirror Reverse the local mirror topic and 
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiUpdateKafkaMirrorTopicsReverseAndStartMirrorRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiUpdateKafkaMirrorTopicsReverseAndStartMirrorRequest
 */
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsReverseAndStartMirror(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaMirrorTopicsReverseAndStartMirrorRequest {
 	return ApiUpdateKafkaMirrorTopicsReverseAndStartMirrorRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		linkName: linkName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		linkName:   linkName,
 	}
 }
 
 // Execute executes the request
-//  @return AlterMirrorStatusResponseDataList
+//
+//	@return AlterMirrorStatusResponseDataList
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsReverseAndStartMirrorExecute(r ApiUpdateKafkaMirrorTopicsReverseAndStartMirrorRequest) (AlterMirrorStatusResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
@@ -3386,13 +3405,13 @@ func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsReverseAndStartMirro
 }
 
 type ApiUpdateKafkaMirrorTopicsTruncateAndRestoreMirrorRequest struct {
-	ctx _context.Context
-	ApiService ClusterLinkingV3Api
-	clusterId string
-	linkName string
+	ctx                                 _context.Context
+	ApiService                          ClusterLinkingV3Api
+	clusterId                           string
+	linkName                            string
 	includePartitionLevelTruncationData *bool
-	validateOnly *bool
-	alterMirrorsRequestData *AlterMirrorsRequestData
+	validateOnly                        *bool
+	alterMirrorsRequestData             *AlterMirrorsRequestData
 }
 
 // Whether to include partition level truncation information when truncating and restoring a topic in the response. Default: false
@@ -3400,11 +3419,13 @@ func (r ApiUpdateKafkaMirrorTopicsTruncateAndRestoreMirrorRequest) IncludePartit
 	r.includePartitionLevelTruncationData = &includePartitionLevelTruncationData
 	return r
 }
+
 // To validate the action can be performed successfully or not. Default: false
 func (r ApiUpdateKafkaMirrorTopicsTruncateAndRestoreMirrorRequest) ValidateOnly(validateOnly bool) ApiUpdateKafkaMirrorTopicsTruncateAndRestoreMirrorRequest {
 	r.validateOnly = &validateOnly
 	return r
 }
+
 // Mirror topics to be altered.
 func (r ApiUpdateKafkaMirrorTopicsTruncateAndRestoreMirrorRequest) AlterMirrorsRequestData(alterMirrorsRequestData AlterMirrorsRequestData) ApiUpdateKafkaMirrorTopicsTruncateAndRestoreMirrorRequest {
 	r.alterMirrorsRequestData = &alterMirrorsRequestData
@@ -3420,22 +3441,23 @@ UpdateKafkaMirrorTopicsTruncateAndRestoreMirror Truncates the local topic to the
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param linkName The link name
- @return ApiUpdateKafkaMirrorTopicsTruncateAndRestoreMirrorRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param linkName The link name
+	@return ApiUpdateKafkaMirrorTopicsTruncateAndRestoreMirrorRequest
 */
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsTruncateAndRestoreMirror(ctx _context.Context, clusterId string, linkName string) ApiUpdateKafkaMirrorTopicsTruncateAndRestoreMirrorRequest {
 	return ApiUpdateKafkaMirrorTopicsTruncateAndRestoreMirrorRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		linkName: linkName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		linkName:   linkName,
 	}
 }
 
 // Execute executes the request
-//  @return AlterMirrorStatusResponseDataList
+//
+//	@return AlterMirrorStatusResponseDataList
 func (a *ClusterLinkingV3ApiService) UpdateKafkaMirrorTopicsTruncateAndRestoreMirrorExecute(r ApiUpdateKafkaMirrorTopicsTruncateAndRestoreMirrorRequest) (AlterMirrorStatusResponseDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost

--- a/kafkarest/v3/api_cluster_v3.go
+++ b/kafkarest/v3/api_cluster_v3.go
@@ -42,15 +42,15 @@ var (
 type ClusterV3Api interface {
 
 	/*
-	GetKafkaCluster Get Cluster
+			GetKafkaCluster Get Cluster
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the Kafka cluster with the specified ``cluster_id``.
+		Return the Kafka cluster with the specified ``cluster_id``.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @return ApiGetKafkaClusterRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiGetKafkaClusterRequest
 	*/
 	GetKafkaCluster(ctx _context.Context, clusterId string) ApiGetKafkaClusterRequest
 
@@ -63,11 +63,10 @@ Return the Kafka cluster with the specified ``cluster_id``.
 type ClusterV3ApiService service
 
 type ApiGetKafkaClusterRequest struct {
-	ctx _context.Context
+	ctx        _context.Context
 	ApiService ClusterV3Api
-	clusterId string
+	clusterId  string
 }
-
 
 func (r ApiGetKafkaClusterRequest) Execute() (ClusterData, *_nethttp.Response, error) {
 	return r.ApiService.GetKafkaClusterExecute(r)
@@ -78,22 +77,23 @@ GetKafkaCluster Get Cluster
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the Kafka cluster with the specified ``cluster_id``.
+Return the Kafka cluster with the specified “cluster_id“.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiGetKafkaClusterRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiGetKafkaClusterRequest
 */
 func (a *ClusterV3ApiService) GetKafkaCluster(ctx _context.Context, clusterId string) ApiGetKafkaClusterRequest {
 	return ApiGetKafkaClusterRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ctx:        ctx,
+		clusterId:  clusterId,
 	}
 }
 
 // Execute executes the request
-//  @return ClusterData
+//
+//	@return ClusterData
 func (a *ClusterV3ApiService) GetKafkaClusterExecute(r ApiGetKafkaClusterRequest) (ClusterData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet

--- a/kafkarest/v3/api_configs_v3.go
+++ b/kafkarest/v3/api_configs_v3.go
@@ -42,17 +42,17 @@ var (
 type ConfigsV3Api interface {
 
 	/*
-	DeleteKafkaClusterConfig Reset Dynamic Broker Config
+			DeleteKafkaClusterConfig Reset Dynamic Broker Config
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Reset the configuration parameter specified by ``name`` to its
-default value by deleting a dynamic cluster-wide configuration.
+		Reset the configuration parameter specified by ``name`` to its
+		default value by deleting a dynamic cluster-wide configuration.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param name The configuration parameter name.
-	 @return ApiDeleteKafkaClusterConfigRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param name The configuration parameter name.
+			 @return ApiDeleteKafkaClusterConfigRequest
 	*/
 	DeleteKafkaClusterConfig(ctx _context.Context, clusterId string, name string) ApiDeleteKafkaClusterConfigRequest
 
@@ -60,17 +60,17 @@ default value by deleting a dynamic cluster-wide configuration.
 	DeleteKafkaClusterConfigExecute(r ApiDeleteKafkaClusterConfigRequest) (*_nethttp.Response, error)
 
 	/*
-	DeleteKafkaTopicConfig Reset Topic Config
+			DeleteKafkaTopicConfig Reset Topic Config
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Reset the configuration parameter with given `name` to its default value.
+		Reset the configuration parameter with given `name` to its default value.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param topicName The topic name.
-	 @param name The configuration parameter name.
-	 @return ApiDeleteKafkaTopicConfigRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @param name The configuration parameter name.
+			 @return ApiDeleteKafkaTopicConfigRequest
 	*/
 	DeleteKafkaTopicConfig(ctx _context.Context, clusterId string, topicName string, name string) ApiDeleteKafkaTopicConfigRequest
 
@@ -78,16 +78,16 @@ Reset the configuration parameter with given `name` to its default value.
 	DeleteKafkaTopicConfigExecute(r ApiDeleteKafkaTopicConfigRequest) (*_nethttp.Response, error)
 
 	/*
-	GetKafkaClusterConfig Get Dynamic Broker Config
+			GetKafkaClusterConfig Get Dynamic Broker Config
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the dynamic cluster-wide broker configuration parameter specified by ``name``.
+		Return the dynamic cluster-wide broker configuration parameter specified by ``name``.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param name The configuration parameter name.
-	 @return ApiGetKafkaClusterConfigRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param name The configuration parameter name.
+			 @return ApiGetKafkaClusterConfigRequest
 	*/
 	GetKafkaClusterConfig(ctx _context.Context, clusterId string, name string) ApiGetKafkaClusterConfigRequest
 
@@ -96,17 +96,17 @@ Return the dynamic cluster-wide broker configuration parameter specified by ``na
 	GetKafkaClusterConfigExecute(r ApiGetKafkaClusterConfigRequest) (ClusterConfigData, *_nethttp.Response, error)
 
 	/*
-	GetKafkaTopicConfig Get Topic Config
+			GetKafkaTopicConfig Get Topic Config
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the configuration parameter with the given `name`.
+		Return the configuration parameter with the given `name`.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param topicName The topic name.
-	 @param name The configuration parameter name.
-	 @return ApiGetKafkaTopicConfigRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @param name The configuration parameter name.
+			 @return ApiGetKafkaTopicConfigRequest
 	*/
 	GetKafkaTopicConfig(ctx _context.Context, clusterId string, topicName string, name string) ApiGetKafkaTopicConfigRequest
 
@@ -115,16 +115,16 @@ Return the configuration parameter with the given `name`.
 	GetKafkaTopicConfigExecute(r ApiGetKafkaTopicConfigRequest) (TopicConfigData, *_nethttp.Response, error)
 
 	/*
-	ListKafkaAllTopicConfigs List All Topic Configs
+			ListKafkaAllTopicConfigs List All Topic Configs
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the list of configuration parameters for all topics hosted by the specified
-cluster.
+		Return the list of configuration parameters for all topics hosted by the specified
+		cluster.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @return ApiListKafkaAllTopicConfigsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiListKafkaAllTopicConfigsRequest
 	*/
 	ListKafkaAllTopicConfigs(ctx _context.Context, clusterId string) ApiListKafkaAllTopicConfigsRequest
 
@@ -133,16 +133,16 @@ cluster.
 	ListKafkaAllTopicConfigsExecute(r ApiListKafkaAllTopicConfigsRequest) (TopicConfigDataList, *_nethttp.Response, error)
 
 	/*
-	ListKafkaClusterConfigs List Dynamic Broker Configs
+			ListKafkaClusterConfigs List Dynamic Broker Configs
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return a list of dynamic cluster-wide broker configuration parameters for the specified Kafka
-cluster. Returns an empty list if there are no dynamic cluster-wide broker configuration parameters.
+		Return a list of dynamic cluster-wide broker configuration parameters for the specified Kafka
+		cluster. Returns an empty list if there are no dynamic cluster-wide broker configuration parameters.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @return ApiListKafkaClusterConfigsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiListKafkaClusterConfigsRequest
 	*/
 	ListKafkaClusterConfigs(ctx _context.Context, clusterId string) ApiListKafkaClusterConfigsRequest
 
@@ -151,16 +151,16 @@ cluster. Returns an empty list if there are no dynamic cluster-wide broker confi
 	ListKafkaClusterConfigsExecute(r ApiListKafkaClusterConfigsRequest) (ClusterConfigDataList, *_nethttp.Response, error)
 
 	/*
-	ListKafkaDefaultTopicConfigs List New Topic Default Configs
+			ListKafkaDefaultTopicConfigs List New Topic Default Configs
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-List the default configuration parameters used if the topic were to be newly created.
+		List the default configuration parameters used if the topic were to be newly created.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param topicName The topic name.
-	 @return ApiListKafkaDefaultTopicConfigsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @return ApiListKafkaDefaultTopicConfigsRequest
 	*/
 	ListKafkaDefaultTopicConfigs(ctx _context.Context, clusterId string, topicName string) ApiListKafkaDefaultTopicConfigsRequest
 
@@ -169,16 +169,16 @@ List the default configuration parameters used if the topic were to be newly cre
 	ListKafkaDefaultTopicConfigsExecute(r ApiListKafkaDefaultTopicConfigsRequest) (TopicConfigDataList, *_nethttp.Response, error)
 
 	/*
-	ListKafkaTopicConfigs List Topic Configs
+			ListKafkaTopicConfigs List Topic Configs
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the list of configuration parameters that belong to the specified topic.
+		Return the list of configuration parameters that belong to the specified topic.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param topicName The topic name.
-	 @return ApiListKafkaTopicConfigsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @return ApiListKafkaTopicConfigsRequest
 	*/
 	ListKafkaTopicConfigs(ctx _context.Context, clusterId string, topicName string) ApiListKafkaTopicConfigsRequest
 
@@ -187,16 +187,16 @@ Return the list of configuration parameters that belong to the specified topic.
 	ListKafkaTopicConfigsExecute(r ApiListKafkaTopicConfigsRequest) (TopicConfigDataList, *_nethttp.Response, error)
 
 	/*
-	UpdateKafkaClusterConfig Update Dynamic Broker Config
+			UpdateKafkaClusterConfig Update Dynamic Broker Config
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Update the dynamic cluster-wide broker configuration parameter specified by ``name``.
+		Update the dynamic cluster-wide broker configuration parameter specified by ``name``.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param name The configuration parameter name.
-	 @return ApiUpdateKafkaClusterConfigRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param name The configuration parameter name.
+			 @return ApiUpdateKafkaClusterConfigRequest
 	*/
 	UpdateKafkaClusterConfig(ctx _context.Context, clusterId string, name string) ApiUpdateKafkaClusterConfigRequest
 
@@ -204,15 +204,15 @@ Update the dynamic cluster-wide broker configuration parameter specified by ``na
 	UpdateKafkaClusterConfigExecute(r ApiUpdateKafkaClusterConfigRequest) (*_nethttp.Response, error)
 
 	/*
-	UpdateKafkaClusterConfigs Batch Alter Dynamic Broker Configs
+			UpdateKafkaClusterConfigs Batch Alter Dynamic Broker Configs
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Update or delete a set of dynamic cluster-wide broker configuration parameters.
+		Update or delete a set of dynamic cluster-wide broker configuration parameters.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @return ApiUpdateKafkaClusterConfigsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiUpdateKafkaClusterConfigsRequest
 	*/
 	UpdateKafkaClusterConfigs(ctx _context.Context, clusterId string) ApiUpdateKafkaClusterConfigsRequest
 
@@ -220,17 +220,19 @@ Update or delete a set of dynamic cluster-wide broker configuration parameters.
 	UpdateKafkaClusterConfigsExecute(r ApiUpdateKafkaClusterConfigsRequest) (*_nethttp.Response, error)
 
 	/*
-	UpdateKafkaTopicConfig Update Topic Config
+			UpdateKafkaTopicConfig Update Topic Config
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Update the configuration parameter with given `name`.
+		Update the configuration parameter with given `name`. To update the
+		number of partitions, see
+		https://docs.confluent.io/cloud/current/api.html#tag/Topic-(v3)/operation/updatePartitionCountKafkaTopic.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param topicName The topic name.
-	 @param name The configuration parameter name.
-	 @return ApiUpdateKafkaTopicConfigRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @param name The configuration parameter name.
+			 @return ApiUpdateKafkaTopicConfigRequest
 	*/
 	UpdateKafkaTopicConfig(ctx _context.Context, clusterId string, topicName string, name string) ApiUpdateKafkaTopicConfigRequest
 
@@ -238,18 +240,18 @@ Update the configuration parameter with given `name`.
 	UpdateKafkaTopicConfigExecute(r ApiUpdateKafkaTopicConfigRequest) (*_nethttp.Response, error)
 
 	/*
-	UpdateKafkaTopicConfigBatch Batch Alter Topic Configs
+			UpdateKafkaTopicConfigBatch Batch Alter Topic Configs
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Update or delete a set of topic configuration parameters.
-Also supports a dry-run mode that only validates whether the operation would succeed if the
-``validate_only`` request property is explicitly specified and set to true.
+		Update or delete a set of topic configuration parameters.
+		Also supports a dry-run mode that only validates whether the operation would succeed if the
+		``validate_only`` request property is explicitly specified and set to true.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param topicName The topic name.
-	 @return ApiUpdateKafkaTopicConfigBatchRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @return ApiUpdateKafkaTopicConfigBatchRequest
 	*/
 	UpdateKafkaTopicConfigBatch(ctx _context.Context, clusterId string, topicName string) ApiUpdateKafkaTopicConfigBatchRequest
 
@@ -261,12 +263,11 @@ Also supports a dry-run mode that only validates whether the operation would suc
 type ConfigsV3ApiService service
 
 type ApiDeleteKafkaClusterConfigRequest struct {
-	ctx _context.Context
+	ctx        _context.Context
 	ApiService ConfigsV3Api
-	clusterId string
-	name string
+	clusterId  string
+	name       string
 }
-
 
 func (r ApiDeleteKafkaClusterConfigRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.DeleteKafkaClusterConfigExecute(r)
@@ -277,20 +278,20 @@ DeleteKafkaClusterConfig Reset Dynamic Broker Config
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Reset the configuration parameter specified by ``name`` to its
+Reset the configuration parameter specified by “name“ to its
 default value by deleting a dynamic cluster-wide configuration.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param name The configuration parameter name.
- @return ApiDeleteKafkaClusterConfigRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param name The configuration parameter name.
+	@return ApiDeleteKafkaClusterConfigRequest
 */
 func (a *ConfigsV3ApiService) DeleteKafkaClusterConfig(ctx _context.Context, clusterId string, name string) ApiDeleteKafkaClusterConfigRequest {
 	return ApiDeleteKafkaClusterConfigRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		name: name,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		name:       name,
 	}
 }
 
@@ -412,13 +413,12 @@ func (a *ConfigsV3ApiService) DeleteKafkaClusterConfigExecute(r ApiDeleteKafkaCl
 }
 
 type ApiDeleteKafkaTopicConfigRequest struct {
-	ctx _context.Context
+	ctx        _context.Context
 	ApiService ConfigsV3Api
-	clusterId string
-	topicName string
-	name string
+	clusterId  string
+	topicName  string
+	name       string
 }
-
 
 func (r ApiDeleteKafkaTopicConfigRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.DeleteKafkaTopicConfigExecute(r)
@@ -431,19 +431,19 @@ DeleteKafkaTopicConfig Reset Topic Config
 
 Reset the configuration parameter with given `name` to its default value.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @param name The configuration parameter name.
- @return ApiDeleteKafkaTopicConfigRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@param name The configuration parameter name.
+	@return ApiDeleteKafkaTopicConfigRequest
 */
 func (a *ConfigsV3ApiService) DeleteKafkaTopicConfig(ctx _context.Context, clusterId string, topicName string, name string) ApiDeleteKafkaTopicConfigRequest {
 	return ApiDeleteKafkaTopicConfigRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		topicName: topicName,
-		name: name,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		topicName:  topicName,
+		name:       name,
 	}
 }
 
@@ -576,12 +576,11 @@ func (a *ConfigsV3ApiService) DeleteKafkaTopicConfigExecute(r ApiDeleteKafkaTopi
 }
 
 type ApiGetKafkaClusterConfigRequest struct {
-	ctx _context.Context
+	ctx        _context.Context
 	ApiService ConfigsV3Api
-	clusterId string
-	name string
+	clusterId  string
+	name       string
 }
-
 
 func (r ApiGetKafkaClusterConfigRequest) Execute() (ClusterConfigData, *_nethttp.Response, error) {
 	return r.ApiService.GetKafkaClusterConfigExecute(r)
@@ -592,24 +591,25 @@ GetKafkaClusterConfig Get Dynamic Broker Config
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the dynamic cluster-wide broker configuration parameter specified by ``name``.
+Return the dynamic cluster-wide broker configuration parameter specified by “name“.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param name The configuration parameter name.
- @return ApiGetKafkaClusterConfigRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param name The configuration parameter name.
+	@return ApiGetKafkaClusterConfigRequest
 */
 func (a *ConfigsV3ApiService) GetKafkaClusterConfig(ctx _context.Context, clusterId string, name string) ApiGetKafkaClusterConfigRequest {
 	return ApiGetKafkaClusterConfigRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		name: name,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		name:       name,
 	}
 }
 
 // Execute executes the request
-//  @return ClusterConfigData
+//
+//	@return ClusterConfigData
 func (a *ConfigsV3ApiService) GetKafkaClusterConfigExecute(r ApiGetKafkaClusterConfigRequest) (ClusterConfigData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -737,13 +737,12 @@ func (a *ConfigsV3ApiService) GetKafkaClusterConfigExecute(r ApiGetKafkaClusterC
 }
 
 type ApiGetKafkaTopicConfigRequest struct {
-	ctx _context.Context
+	ctx        _context.Context
 	ApiService ConfigsV3Api
-	clusterId string
-	topicName string
-	name string
+	clusterId  string
+	topicName  string
+	name       string
 }
-
 
 func (r ApiGetKafkaTopicConfigRequest) Execute() (TopicConfigData, *_nethttp.Response, error) {
 	return r.ApiService.GetKafkaTopicConfigExecute(r)
@@ -756,24 +755,25 @@ GetKafkaTopicConfig Get Topic Config
 
 Return the configuration parameter with the given `name`.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @param name The configuration parameter name.
- @return ApiGetKafkaTopicConfigRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@param name The configuration parameter name.
+	@return ApiGetKafkaTopicConfigRequest
 */
 func (a *ConfigsV3ApiService) GetKafkaTopicConfig(ctx _context.Context, clusterId string, topicName string, name string) ApiGetKafkaTopicConfigRequest {
 	return ApiGetKafkaTopicConfigRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		topicName: topicName,
-		name: name,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		topicName:  topicName,
+		name:       name,
 	}
 }
 
 // Execute executes the request
-//  @return TopicConfigData
+//
+//	@return TopicConfigData
 func (a *ConfigsV3ApiService) GetKafkaTopicConfigExecute(r ApiGetKafkaTopicConfigRequest) (TopicConfigData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -912,11 +912,10 @@ func (a *ConfigsV3ApiService) GetKafkaTopicConfigExecute(r ApiGetKafkaTopicConfi
 }
 
 type ApiListKafkaAllTopicConfigsRequest struct {
-	ctx _context.Context
+	ctx        _context.Context
 	ApiService ConfigsV3Api
-	clusterId string
+	clusterId  string
 }
-
 
 func (r ApiListKafkaAllTopicConfigsRequest) Execute() (TopicConfigDataList, *_nethttp.Response, error) {
 	return r.ApiService.ListKafkaAllTopicConfigsExecute(r)
@@ -930,20 +929,21 @@ ListKafkaAllTopicConfigs List All Topic Configs
 Return the list of configuration parameters for all topics hosted by the specified
 cluster.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiListKafkaAllTopicConfigsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiListKafkaAllTopicConfigsRequest
 */
 func (a *ConfigsV3ApiService) ListKafkaAllTopicConfigs(ctx _context.Context, clusterId string) ApiListKafkaAllTopicConfigsRequest {
 	return ApiListKafkaAllTopicConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ctx:        ctx,
+		clusterId:  clusterId,
 	}
 }
 
 // Execute executes the request
-//  @return TopicConfigDataList
+//
+//	@return TopicConfigDataList
 func (a *ConfigsV3ApiService) ListKafkaAllTopicConfigsExecute(r ApiListKafkaAllTopicConfigsRequest) (TopicConfigDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1070,11 +1070,10 @@ func (a *ConfigsV3ApiService) ListKafkaAllTopicConfigsExecute(r ApiListKafkaAllT
 }
 
 type ApiListKafkaClusterConfigsRequest struct {
-	ctx _context.Context
+	ctx        _context.Context
 	ApiService ConfigsV3Api
-	clusterId string
+	clusterId  string
 }
-
 
 func (r ApiListKafkaClusterConfigsRequest) Execute() (ClusterConfigDataList, *_nethttp.Response, error) {
 	return r.ApiService.ListKafkaClusterConfigsExecute(r)
@@ -1088,20 +1087,21 @@ ListKafkaClusterConfigs List Dynamic Broker Configs
 Return a list of dynamic cluster-wide broker configuration parameters for the specified Kafka
 cluster. Returns an empty list if there are no dynamic cluster-wide broker configuration parameters.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiListKafkaClusterConfigsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiListKafkaClusterConfigsRequest
 */
 func (a *ConfigsV3ApiService) ListKafkaClusterConfigs(ctx _context.Context, clusterId string) ApiListKafkaClusterConfigsRequest {
 	return ApiListKafkaClusterConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ctx:        ctx,
+		clusterId:  clusterId,
 	}
 }
 
 // Execute executes the request
-//  @return ClusterConfigDataList
+//
+//	@return ClusterConfigDataList
 func (a *ConfigsV3ApiService) ListKafkaClusterConfigsExecute(r ApiListKafkaClusterConfigsRequest) (ClusterConfigDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1228,12 +1228,11 @@ func (a *ConfigsV3ApiService) ListKafkaClusterConfigsExecute(r ApiListKafkaClust
 }
 
 type ApiListKafkaDefaultTopicConfigsRequest struct {
-	ctx _context.Context
+	ctx        _context.Context
 	ApiService ConfigsV3Api
-	clusterId string
-	topicName string
+	clusterId  string
+	topicName  string
 }
-
 
 func (r ApiListKafkaDefaultTopicConfigsRequest) Execute() (TopicConfigDataList, *_nethttp.Response, error) {
 	return r.ApiService.ListKafkaDefaultTopicConfigsExecute(r)
@@ -1246,22 +1245,23 @@ ListKafkaDefaultTopicConfigs List New Topic Default Configs
 
 List the default configuration parameters used if the topic were to be newly created.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @return ApiListKafkaDefaultTopicConfigsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@return ApiListKafkaDefaultTopicConfigsRequest
 */
 func (a *ConfigsV3ApiService) ListKafkaDefaultTopicConfigs(ctx _context.Context, clusterId string, topicName string) ApiListKafkaDefaultTopicConfigsRequest {
 	return ApiListKafkaDefaultTopicConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		topicName: topicName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		topicName:  topicName,
 	}
 }
 
 // Execute executes the request
-//  @return TopicConfigDataList
+//
+//	@return TopicConfigDataList
 func (a *ConfigsV3ApiService) ListKafkaDefaultTopicConfigsExecute(r ApiListKafkaDefaultTopicConfigsRequest) (TopicConfigDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1389,12 +1389,11 @@ func (a *ConfigsV3ApiService) ListKafkaDefaultTopicConfigsExecute(r ApiListKafka
 }
 
 type ApiListKafkaTopicConfigsRequest struct {
-	ctx _context.Context
+	ctx        _context.Context
 	ApiService ConfigsV3Api
-	clusterId string
-	topicName string
+	clusterId  string
+	topicName  string
 }
-
 
 func (r ApiListKafkaTopicConfigsRequest) Execute() (TopicConfigDataList, *_nethttp.Response, error) {
 	return r.ApiService.ListKafkaTopicConfigsExecute(r)
@@ -1407,22 +1406,23 @@ ListKafkaTopicConfigs List Topic Configs
 
 Return the list of configuration parameters that belong to the specified topic.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @return ApiListKafkaTopicConfigsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@return ApiListKafkaTopicConfigsRequest
 */
 func (a *ConfigsV3ApiService) ListKafkaTopicConfigs(ctx _context.Context, clusterId string, topicName string) ApiListKafkaTopicConfigsRequest {
 	return ApiListKafkaTopicConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		topicName: topicName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		topicName:  topicName,
 	}
 }
 
 // Execute executes the request
-//  @return TopicConfigDataList
+//
+//	@return TopicConfigDataList
 func (a *ConfigsV3ApiService) ListKafkaTopicConfigsExecute(r ApiListKafkaTopicConfigsRequest) (TopicConfigDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1560,10 +1560,10 @@ func (a *ConfigsV3ApiService) ListKafkaTopicConfigsExecute(r ApiListKafkaTopicCo
 }
 
 type ApiUpdateKafkaClusterConfigRequest struct {
-	ctx _context.Context
-	ApiService ConfigsV3Api
-	clusterId string
-	name string
+	ctx                     _context.Context
+	ApiService              ConfigsV3Api
+	clusterId               string
+	name                    string
 	updateConfigRequestData *UpdateConfigRequestData
 }
 
@@ -1582,19 +1582,19 @@ UpdateKafkaClusterConfig Update Dynamic Broker Config
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Update the dynamic cluster-wide broker configuration parameter specified by ``name``.
+Update the dynamic cluster-wide broker configuration parameter specified by “name“.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param name The configuration parameter name.
- @return ApiUpdateKafkaClusterConfigRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param name The configuration parameter name.
+	@return ApiUpdateKafkaClusterConfigRequest
 */
 func (a *ConfigsV3ApiService) UpdateKafkaClusterConfig(ctx _context.Context, clusterId string, name string) ApiUpdateKafkaClusterConfigRequest {
 	return ApiUpdateKafkaClusterConfigRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		name: name,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		name:       name,
 	}
 }
 
@@ -1718,9 +1718,9 @@ func (a *ConfigsV3ApiService) UpdateKafkaClusterConfigExecute(r ApiUpdateKafkaCl
 }
 
 type ApiUpdateKafkaClusterConfigsRequest struct {
-	ctx _context.Context
-	ApiService ConfigsV3Api
-	clusterId string
+	ctx                         _context.Context
+	ApiService                  ConfigsV3Api
+	clusterId                   string
 	alterConfigBatchRequestData *AlterConfigBatchRequestData
 }
 
@@ -1741,15 +1741,15 @@ UpdateKafkaClusterConfigs Batch Alter Dynamic Broker Configs
 
 Update or delete a set of dynamic cluster-wide broker configuration parameters.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiUpdateKafkaClusterConfigsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiUpdateKafkaClusterConfigsRequest
 */
 func (a *ConfigsV3ApiService) UpdateKafkaClusterConfigs(ctx _context.Context, clusterId string) ApiUpdateKafkaClusterConfigsRequest {
 	return ApiUpdateKafkaClusterConfigsRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ctx:        ctx,
+		clusterId:  clusterId,
 	}
 }
 
@@ -1872,11 +1872,11 @@ func (a *ConfigsV3ApiService) UpdateKafkaClusterConfigsExecute(r ApiUpdateKafkaC
 }
 
 type ApiUpdateKafkaTopicConfigRequest struct {
-	ctx _context.Context
-	ApiService ConfigsV3Api
-	clusterId string
-	topicName string
-	name string
+	ctx                     _context.Context
+	ApiService              ConfigsV3Api
+	clusterId               string
+	topicName               string
+	name                    string
 	updateConfigRequestData *UpdateConfigRequestData
 }
 
@@ -1895,21 +1895,23 @@ UpdateKafkaTopicConfig Update Topic Config
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Update the configuration parameter with given `name`.
+Update the configuration parameter with given `name`. To update the
+number of partitions, see
+https://docs.confluent.io/cloud/current/api.html#tag/Topic-(v3)/operation/updatePartitionCountKafkaTopic.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @param name The configuration parameter name.
- @return ApiUpdateKafkaTopicConfigRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@param name The configuration parameter name.
+	@return ApiUpdateKafkaTopicConfigRequest
 */
 func (a *ConfigsV3ApiService) UpdateKafkaTopicConfig(ctx _context.Context, clusterId string, topicName string, name string) ApiUpdateKafkaTopicConfigRequest {
 	return ApiUpdateKafkaTopicConfigRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		topicName: topicName,
-		name: name,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		topicName:  topicName,
+		name:       name,
 	}
 }
 
@@ -2044,10 +2046,10 @@ func (a *ConfigsV3ApiService) UpdateKafkaTopicConfigExecute(r ApiUpdateKafkaTopi
 }
 
 type ApiUpdateKafkaTopicConfigBatchRequest struct {
-	ctx _context.Context
-	ApiService ConfigsV3Api
-	clusterId string
-	topicName string
+	ctx                         _context.Context
+	ApiService                  ConfigsV3Api
+	clusterId                   string
+	topicName                   string
 	alterConfigBatchRequestData *AlterConfigBatchRequestData
 }
 
@@ -2068,19 +2070,19 @@ UpdateKafkaTopicConfigBatch Batch Alter Topic Configs
 
 Update or delete a set of topic configuration parameters.
 Also supports a dry-run mode that only validates whether the operation would succeed if the
-``validate_only`` request property is explicitly specified and set to true.
+“validate_only“ request property is explicitly specified and set to true.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @return ApiUpdateKafkaTopicConfigBatchRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@return ApiUpdateKafkaTopicConfigBatchRequest
 */
 func (a *ConfigsV3ApiService) UpdateKafkaTopicConfigBatch(ctx _context.Context, clusterId string, topicName string) ApiUpdateKafkaTopicConfigBatchRequest {
 	return ApiUpdateKafkaTopicConfigBatchRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		topicName: topicName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		topicName:  topicName,
 	}
 }
 

--- a/kafkarest/v3/api_consumer_group_v3.go
+++ b/kafkarest/v3/api_consumer_group_v3.go
@@ -42,17 +42,17 @@ var (
 type ConsumerGroupV3Api interface {
 
 	/*
-	GetKafkaConsumer Get Consumer
+			GetKafkaConsumer Get Consumer
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the consumer specified by the ``consumer_id``.
+		Return the consumer specified by the ``consumer_id``.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param consumerGroupId The consumer group ID.
-	 @param consumerId The consumer ID.
-	 @return ApiGetKafkaConsumerRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param consumerGroupId The consumer group ID.
+			 @param consumerId The consumer ID.
+			 @return ApiGetKafkaConsumerRequest
 	*/
 	GetKafkaConsumer(ctx _context.Context, clusterId string, consumerGroupId string, consumerId string) ApiGetKafkaConsumerRequest
 
@@ -61,16 +61,16 @@ Return the consumer specified by the ``consumer_id``.
 	GetKafkaConsumerExecute(r ApiGetKafkaConsumerRequest) (ConsumerData, *_nethttp.Response, error)
 
 	/*
-	GetKafkaConsumerGroup Get Consumer Group
+			GetKafkaConsumerGroup Get Consumer Group
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the consumer group specified by the ``consumer_group_id``.
+		Return the consumer group specified by the ``consumer_group_id``.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param consumerGroupId The consumer group ID.
-	 @return ApiGetKafkaConsumerGroupRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param consumerGroupId The consumer group ID.
+			 @return ApiGetKafkaConsumerGroupRequest
 	*/
 	GetKafkaConsumerGroup(ctx _context.Context, clusterId string, consumerGroupId string) ApiGetKafkaConsumerGroupRequest
 
@@ -79,17 +79,17 @@ Return the consumer group specified by the ``consumer_group_id``.
 	GetKafkaConsumerGroupExecute(r ApiGetKafkaConsumerGroupRequest) (ConsumerGroupData, *_nethttp.Response, error)
 
 	/*
-	GetKafkaConsumerGroupLagSummary Get Consumer Group Lag Summary
+			GetKafkaConsumerGroupLagSummary Get Consumer Group Lag Summary
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Available in dedicated clusters only](https://img.shields.io/badge/-Available%20in%20dedicated%20clusters%20only-%23bc8540)](https://docs.confluent.io/cloud/current/clusters/cluster-types.html#dedicated-cluster)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Available in dedicated clusters only](https://img.shields.io/badge/-Available%20in%20dedicated%20clusters%20only-%23bc8540)](https://docs.confluent.io/cloud/current/clusters/cluster-types.html#dedicated-cluster)
 
-Return the maximum and total lag of the consumers belonging to the
-specified consumer group.
+		Return the maximum and total lag of the consumers belonging to the
+		specified consumer group.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param consumerGroupId The consumer group ID.
-	 @return ApiGetKafkaConsumerGroupLagSummaryRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param consumerGroupId The consumer group ID.
+			 @return ApiGetKafkaConsumerGroupLagSummaryRequest
 	*/
 	GetKafkaConsumerGroupLagSummary(ctx _context.Context, clusterId string, consumerGroupId string) ApiGetKafkaConsumerGroupLagSummaryRequest
 
@@ -98,18 +98,18 @@ specified consumer group.
 	GetKafkaConsumerGroupLagSummaryExecute(r ApiGetKafkaConsumerGroupLagSummaryRequest) (ConsumerGroupLagSummaryData, *_nethttp.Response, error)
 
 	/*
-	GetKafkaConsumerLag Get Consumer Lag
+			GetKafkaConsumerLag Get Consumer Lag
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Available in dedicated clusters only](https://img.shields.io/badge/-Available%20in%20dedicated%20clusters%20only-%23bc8540)](https://docs.confluent.io/cloud/current/clusters/cluster-types.html#dedicated-cluster)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Available in dedicated clusters only](https://img.shields.io/badge/-Available%20in%20dedicated%20clusters%20only-%23bc8540)](https://docs.confluent.io/cloud/current/clusters/cluster-types.html#dedicated-cluster)
 
-Return the consumer lag on a partition with the given `partition_id`.
+		Return the consumer lag on a partition with the given `partition_id`.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param consumerGroupId The consumer group ID.
-	 @param topicName The topic name.
-	 @param partitionId The partition ID.
-	 @return ApiGetKafkaConsumerLagRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param consumerGroupId The consumer group ID.
+			 @param topicName The topic name.
+			 @param partitionId The partition ID.
+			 @return ApiGetKafkaConsumerLagRequest
 	*/
 	GetKafkaConsumerLag(ctx _context.Context, clusterId string, consumerGroupId string, topicName string, partitionId int32) ApiGetKafkaConsumerLagRequest
 
@@ -118,16 +118,16 @@ Return the consumer lag on a partition with the given `partition_id`.
 	GetKafkaConsumerLagExecute(r ApiGetKafkaConsumerLagRequest) (ConsumerLagData, *_nethttp.Response, error)
 
 	/*
-	ListKafkaConsumerGroups List Consumer Groups
+			ListKafkaConsumerGroups List Consumer Groups
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the list of consumer groups that belong to the specified
-Kafka cluster.
+		Return the list of consumer groups that belong to the specified
+		Kafka cluster.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @return ApiListKafkaConsumerGroupsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiListKafkaConsumerGroupsRequest
 	*/
 	ListKafkaConsumerGroups(ctx _context.Context, clusterId string) ApiListKafkaConsumerGroupsRequest
 
@@ -136,17 +136,17 @@ Kafka cluster.
 	ListKafkaConsumerGroupsExecute(r ApiListKafkaConsumerGroupsRequest) (ConsumerGroupDataList, *_nethttp.Response, error)
 
 	/*
-	ListKafkaConsumerLags List Consumer Lags
+			ListKafkaConsumerLags List Consumer Lags
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Available in dedicated clusters only](https://img.shields.io/badge/-Available%20in%20dedicated%20clusters%20only-%23bc8540)](https://docs.confluent.io/cloud/current/clusters/cluster-types.html#dedicated-cluster)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy) [![Available in dedicated clusters only](https://img.shields.io/badge/-Available%20in%20dedicated%20clusters%20only-%23bc8540)](https://docs.confluent.io/cloud/current/clusters/cluster-types.html#dedicated-cluster)
 
-Return a list of consumer lags of the consumers belonging to the
-specified consumer group.
+		Return a list of consumer lags of the consumers belonging to the
+		specified consumer group.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param consumerGroupId The consumer group ID.
-	 @return ApiListKafkaConsumerLagsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param consumerGroupId The consumer group ID.
+			 @return ApiListKafkaConsumerLagsRequest
 	*/
 	ListKafkaConsumerLags(ctx _context.Context, clusterId string, consumerGroupId string) ApiListKafkaConsumerLagsRequest
 
@@ -155,17 +155,17 @@ specified consumer group.
 	ListKafkaConsumerLagsExecute(r ApiListKafkaConsumerLagsRequest) (ConsumerLagDataList, *_nethttp.Response, error)
 
 	/*
-	ListKafkaConsumers List Consumers
+			ListKafkaConsumers List Consumers
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return a list of consumers that belong to the specified consumer
-group.
+		Return a list of consumers that belong to the specified consumer
+		group.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param consumerGroupId The consumer group ID.
-	 @return ApiListKafkaConsumersRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param consumerGroupId The consumer group ID.
+			 @return ApiListKafkaConsumersRequest
 	*/
 	ListKafkaConsumers(ctx _context.Context, clusterId string, consumerGroupId string) ApiListKafkaConsumersRequest
 
@@ -178,13 +178,12 @@ group.
 type ConsumerGroupV3ApiService service
 
 type ApiGetKafkaConsumerRequest struct {
-	ctx _context.Context
-	ApiService ConsumerGroupV3Api
-	clusterId string
+	ctx             _context.Context
+	ApiService      ConsumerGroupV3Api
+	clusterId       string
 	consumerGroupId string
-	consumerId string
+	consumerId      string
 }
-
 
 func (r ApiGetKafkaConsumerRequest) Execute() (ConsumerData, *_nethttp.Response, error) {
 	return r.ApiService.GetKafkaConsumerExecute(r)
@@ -195,26 +194,27 @@ GetKafkaConsumer Get Consumer
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the consumer specified by the ``consumer_id``.
+Return the consumer specified by the “consumer_id“.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param consumerGroupId The consumer group ID.
- @param consumerId The consumer ID.
- @return ApiGetKafkaConsumerRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param consumerGroupId The consumer group ID.
+	@param consumerId The consumer ID.
+	@return ApiGetKafkaConsumerRequest
 */
 func (a *ConsumerGroupV3ApiService) GetKafkaConsumer(ctx _context.Context, clusterId string, consumerGroupId string, consumerId string) ApiGetKafkaConsumerRequest {
 	return ApiGetKafkaConsumerRequest{
-		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ApiService:      a,
+		ctx:             ctx,
+		clusterId:       clusterId,
 		consumerGroupId: consumerGroupId,
-		consumerId: consumerId,
+		consumerId:      consumerId,
 	}
 }
 
 // Execute executes the request
-//  @return ConsumerData
+//
+//	@return ConsumerData
 func (a *ConsumerGroupV3ApiService) GetKafkaConsumerExecute(r ApiGetKafkaConsumerRequest) (ConsumerData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -343,12 +343,11 @@ func (a *ConsumerGroupV3ApiService) GetKafkaConsumerExecute(r ApiGetKafkaConsume
 }
 
 type ApiGetKafkaConsumerGroupRequest struct {
-	ctx _context.Context
-	ApiService ConsumerGroupV3Api
-	clusterId string
+	ctx             _context.Context
+	ApiService      ConsumerGroupV3Api
+	clusterId       string
 	consumerGroupId string
 }
-
 
 func (r ApiGetKafkaConsumerGroupRequest) Execute() (ConsumerGroupData, *_nethttp.Response, error) {
 	return r.ApiService.GetKafkaConsumerGroupExecute(r)
@@ -359,24 +358,25 @@ GetKafkaConsumerGroup Get Consumer Group
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the consumer group specified by the ``consumer_group_id``.
+Return the consumer group specified by the “consumer_group_id“.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param consumerGroupId The consumer group ID.
- @return ApiGetKafkaConsumerGroupRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param consumerGroupId The consumer group ID.
+	@return ApiGetKafkaConsumerGroupRequest
 */
 func (a *ConsumerGroupV3ApiService) GetKafkaConsumerGroup(ctx _context.Context, clusterId string, consumerGroupId string) ApiGetKafkaConsumerGroupRequest {
 	return ApiGetKafkaConsumerGroupRequest{
-		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ApiService:      a,
+		ctx:             ctx,
+		clusterId:       clusterId,
 		consumerGroupId: consumerGroupId,
 	}
 }
 
 // Execute executes the request
-//  @return ConsumerGroupData
+//
+//	@return ConsumerGroupData
 func (a *ConsumerGroupV3ApiService) GetKafkaConsumerGroupExecute(r ApiGetKafkaConsumerGroupRequest) (ConsumerGroupData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -504,12 +504,11 @@ func (a *ConsumerGroupV3ApiService) GetKafkaConsumerGroupExecute(r ApiGetKafkaCo
 }
 
 type ApiGetKafkaConsumerGroupLagSummaryRequest struct {
-	ctx _context.Context
-	ApiService ConsumerGroupV3Api
-	clusterId string
+	ctx             _context.Context
+	ApiService      ConsumerGroupV3Api
+	clusterId       string
 	consumerGroupId string
 }
-
 
 func (r ApiGetKafkaConsumerGroupLagSummaryRequest) Execute() (ConsumerGroupLagSummaryData, *_nethttp.Response, error) {
 	return r.ApiService.GetKafkaConsumerGroupLagSummaryExecute(r)
@@ -523,22 +522,23 @@ GetKafkaConsumerGroupLagSummary Get Consumer Group Lag Summary
 Return the maximum and total lag of the consumers belonging to the
 specified consumer group.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param consumerGroupId The consumer group ID.
- @return ApiGetKafkaConsumerGroupLagSummaryRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param consumerGroupId The consumer group ID.
+	@return ApiGetKafkaConsumerGroupLagSummaryRequest
 */
 func (a *ConsumerGroupV3ApiService) GetKafkaConsumerGroupLagSummary(ctx _context.Context, clusterId string, consumerGroupId string) ApiGetKafkaConsumerGroupLagSummaryRequest {
 	return ApiGetKafkaConsumerGroupLagSummaryRequest{
-		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ApiService:      a,
+		ctx:             ctx,
+		clusterId:       clusterId,
 		consumerGroupId: consumerGroupId,
 	}
 }
 
 // Execute executes the request
-//  @return ConsumerGroupLagSummaryData
+//
+//	@return ConsumerGroupLagSummaryData
 func (a *ConsumerGroupV3ApiService) GetKafkaConsumerGroupLagSummaryExecute(r ApiGetKafkaConsumerGroupLagSummaryRequest) (ConsumerGroupLagSummaryData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -666,14 +666,13 @@ func (a *ConsumerGroupV3ApiService) GetKafkaConsumerGroupLagSummaryExecute(r Api
 }
 
 type ApiGetKafkaConsumerLagRequest struct {
-	ctx _context.Context
-	ApiService ConsumerGroupV3Api
-	clusterId string
+	ctx             _context.Context
+	ApiService      ConsumerGroupV3Api
+	clusterId       string
 	consumerGroupId string
-	topicName string
-	partitionId int32
+	topicName       string
+	partitionId     int32
 }
-
 
 func (r ApiGetKafkaConsumerLagRequest) Execute() (ConsumerLagData, *_nethttp.Response, error) {
 	return r.ApiService.GetKafkaConsumerLagExecute(r)
@@ -686,26 +685,27 @@ GetKafkaConsumerLag Get Consumer Lag
 
 Return the consumer lag on a partition with the given `partition_id`.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param consumerGroupId The consumer group ID.
- @param topicName The topic name.
- @param partitionId The partition ID.
- @return ApiGetKafkaConsumerLagRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param consumerGroupId The consumer group ID.
+	@param topicName The topic name.
+	@param partitionId The partition ID.
+	@return ApiGetKafkaConsumerLagRequest
 */
 func (a *ConsumerGroupV3ApiService) GetKafkaConsumerLag(ctx _context.Context, clusterId string, consumerGroupId string, topicName string, partitionId int32) ApiGetKafkaConsumerLagRequest {
 	return ApiGetKafkaConsumerLagRequest{
-		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ApiService:      a,
+		ctx:             ctx,
+		clusterId:       clusterId,
 		consumerGroupId: consumerGroupId,
-		topicName: topicName,
-		partitionId: partitionId,
+		topicName:       topicName,
+		partitionId:     partitionId,
 	}
 }
 
 // Execute executes the request
-//  @return ConsumerLagData
+//
+//	@return ConsumerLagData
 func (a *ConsumerGroupV3ApiService) GetKafkaConsumerLagExecute(r ApiGetKafkaConsumerLagRequest) (ConsumerLagData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -835,11 +835,10 @@ func (a *ConsumerGroupV3ApiService) GetKafkaConsumerLagExecute(r ApiGetKafkaCons
 }
 
 type ApiListKafkaConsumerGroupsRequest struct {
-	ctx _context.Context
+	ctx        _context.Context
 	ApiService ConsumerGroupV3Api
-	clusterId string
+	clusterId  string
 }
-
 
 func (r ApiListKafkaConsumerGroupsRequest) Execute() (ConsumerGroupDataList, *_nethttp.Response, error) {
 	return r.ApiService.ListKafkaConsumerGroupsExecute(r)
@@ -853,20 +852,21 @@ ListKafkaConsumerGroups List Consumer Groups
 Return the list of consumer groups that belong to the specified
 Kafka cluster.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiListKafkaConsumerGroupsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiListKafkaConsumerGroupsRequest
 */
 func (a *ConsumerGroupV3ApiService) ListKafkaConsumerGroups(ctx _context.Context, clusterId string) ApiListKafkaConsumerGroupsRequest {
 	return ApiListKafkaConsumerGroupsRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ctx:        ctx,
+		clusterId:  clusterId,
 	}
 }
 
 // Execute executes the request
-//  @return ConsumerGroupDataList
+//
+//	@return ConsumerGroupDataList
 func (a *ConsumerGroupV3ApiService) ListKafkaConsumerGroupsExecute(r ApiListKafkaConsumerGroupsRequest) (ConsumerGroupDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -993,12 +993,11 @@ func (a *ConsumerGroupV3ApiService) ListKafkaConsumerGroupsExecute(r ApiListKafk
 }
 
 type ApiListKafkaConsumerLagsRequest struct {
-	ctx _context.Context
-	ApiService ConsumerGroupV3Api
-	clusterId string
+	ctx             _context.Context
+	ApiService      ConsumerGroupV3Api
+	clusterId       string
 	consumerGroupId string
 }
-
 
 func (r ApiListKafkaConsumerLagsRequest) Execute() (ConsumerLagDataList, *_nethttp.Response, error) {
 	return r.ApiService.ListKafkaConsumerLagsExecute(r)
@@ -1012,22 +1011,23 @@ ListKafkaConsumerLags List Consumer Lags
 Return a list of consumer lags of the consumers belonging to the
 specified consumer group.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param consumerGroupId The consumer group ID.
- @return ApiListKafkaConsumerLagsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param consumerGroupId The consumer group ID.
+	@return ApiListKafkaConsumerLagsRequest
 */
 func (a *ConsumerGroupV3ApiService) ListKafkaConsumerLags(ctx _context.Context, clusterId string, consumerGroupId string) ApiListKafkaConsumerLagsRequest {
 	return ApiListKafkaConsumerLagsRequest{
-		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ApiService:      a,
+		ctx:             ctx,
+		clusterId:       clusterId,
 		consumerGroupId: consumerGroupId,
 	}
 }
 
 // Execute executes the request
-//  @return ConsumerLagDataList
+//
+//	@return ConsumerLagDataList
 func (a *ConsumerGroupV3ApiService) ListKafkaConsumerLagsExecute(r ApiListKafkaConsumerLagsRequest) (ConsumerLagDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -1155,12 +1155,11 @@ func (a *ConsumerGroupV3ApiService) ListKafkaConsumerLagsExecute(r ApiListKafkaC
 }
 
 type ApiListKafkaConsumersRequest struct {
-	ctx _context.Context
-	ApiService ConsumerGroupV3Api
-	clusterId string
+	ctx             _context.Context
+	ApiService      ConsumerGroupV3Api
+	clusterId       string
 	consumerGroupId string
 }
-
 
 func (r ApiListKafkaConsumersRequest) Execute() (ConsumerDataList, *_nethttp.Response, error) {
 	return r.ApiService.ListKafkaConsumersExecute(r)
@@ -1174,22 +1173,23 @@ ListKafkaConsumers List Consumers
 Return a list of consumers that belong to the specified consumer
 group.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param consumerGroupId The consumer group ID.
- @return ApiListKafkaConsumersRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param consumerGroupId The consumer group ID.
+	@return ApiListKafkaConsumersRequest
 */
 func (a *ConsumerGroupV3ApiService) ListKafkaConsumers(ctx _context.Context, clusterId string, consumerGroupId string) ApiListKafkaConsumersRequest {
 	return ApiListKafkaConsumersRequest{
-		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ApiService:      a,
+		ctx:             ctx,
+		clusterId:       clusterId,
 		consumerGroupId: consumerGroupId,
 	}
 }
 
 // Execute executes the request
-//  @return ConsumerDataList
+//
+//	@return ConsumerDataList
 func (a *ConsumerGroupV3ApiService) ListKafkaConsumersExecute(r ApiListKafkaConsumersRequest) (ConsumerDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet

--- a/kafkarest/v3/api_partition_v3.go
+++ b/kafkarest/v3/api_partition_v3.go
@@ -42,17 +42,17 @@ var (
 type PartitionV3Api interface {
 
 	/*
-	GetKafkaPartition Get Partition
+			GetKafkaPartition Get Partition
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the partition with the given `partition_id`.
+		Return the partition with the given `partition_id`.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param topicName The topic name.
-	 @param partitionId The partition ID.
-	 @return ApiGetKafkaPartitionRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @param partitionId The partition ID.
+			 @return ApiGetKafkaPartitionRequest
 	*/
 	GetKafkaPartition(ctx _context.Context, clusterId string, topicName string, partitionId int32) ApiGetKafkaPartitionRequest
 
@@ -61,16 +61,16 @@ Return the partition with the given `partition_id`.
 	GetKafkaPartitionExecute(r ApiGetKafkaPartitionRequest) (PartitionData, *_nethttp.Response, error)
 
 	/*
-	ListKafkaPartitions List Partitions
+			ListKafkaPartitions List Partitions
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the list of partitions that belong to the specified topic.
+		Return the list of partitions that belong to the specified topic.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param topicName The topic name.
-	 @return ApiListKafkaPartitionsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @return ApiListKafkaPartitionsRequest
 	*/
 	ListKafkaPartitions(ctx _context.Context, clusterId string, topicName string) ApiListKafkaPartitionsRequest
 
@@ -83,13 +83,12 @@ Return the list of partitions that belong to the specified topic.
 type PartitionV3ApiService service
 
 type ApiGetKafkaPartitionRequest struct {
-	ctx _context.Context
-	ApiService PartitionV3Api
-	clusterId string
-	topicName string
+	ctx         _context.Context
+	ApiService  PartitionV3Api
+	clusterId   string
+	topicName   string
 	partitionId int32
 }
-
 
 func (r ApiGetKafkaPartitionRequest) Execute() (PartitionData, *_nethttp.Response, error) {
 	return r.ApiService.GetKafkaPartitionExecute(r)
@@ -102,24 +101,25 @@ GetKafkaPartition Get Partition
 
 Return the partition with the given `partition_id`.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @param partitionId The partition ID.
- @return ApiGetKafkaPartitionRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@param partitionId The partition ID.
+	@return ApiGetKafkaPartitionRequest
 */
 func (a *PartitionV3ApiService) GetKafkaPartition(ctx _context.Context, clusterId string, topicName string, partitionId int32) ApiGetKafkaPartitionRequest {
 	return ApiGetKafkaPartitionRequest{
-		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		topicName: topicName,
+		ApiService:  a,
+		ctx:         ctx,
+		clusterId:   clusterId,
+		topicName:   topicName,
 		partitionId: partitionId,
 	}
 }
 
 // Execute executes the request
-//  @return PartitionData
+//
+//	@return PartitionData
 func (a *PartitionV3ApiService) GetKafkaPartitionExecute(r ApiGetKafkaPartitionRequest) (PartitionData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -258,12 +258,11 @@ func (a *PartitionV3ApiService) GetKafkaPartitionExecute(r ApiGetKafkaPartitionR
 }
 
 type ApiListKafkaPartitionsRequest struct {
-	ctx _context.Context
+	ctx        _context.Context
 	ApiService PartitionV3Api
-	clusterId string
-	topicName string
+	clusterId  string
+	topicName  string
 }
-
 
 func (r ApiListKafkaPartitionsRequest) Execute() (PartitionDataList, *_nethttp.Response, error) {
 	return r.ApiService.ListKafkaPartitionsExecute(r)
@@ -276,22 +275,23 @@ ListKafkaPartitions List Partitions
 
 Return the list of partitions that belong to the specified topic.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @return ApiListKafkaPartitionsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@return ApiListKafkaPartitionsRequest
 */
 func (a *PartitionV3ApiService) ListKafkaPartitions(ctx _context.Context, clusterId string, topicName string) ApiListKafkaPartitionsRequest {
 	return ApiListKafkaPartitionsRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		topicName: topicName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		topicName:  topicName,
 	}
 }
 
 // Execute executes the request
-//  @return PartitionDataList
+//
+//	@return PartitionDataList
 func (a *PartitionV3ApiService) ListKafkaPartitionsExecute(r ApiListKafkaPartitionsRequest) (PartitionDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet

--- a/kafkarest/v3/api_records_v3.go
+++ b/kafkarest/v3/api_records_v3.go
@@ -42,31 +42,31 @@ var (
 type RecordsV3Api interface {
 
 	/*
-	ProduceRecord Produce Records
+			ProduceRecord Produce Records
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Produce records to the given topic, returning delivery reports for each
-record produced. This API can be used in streaming mode by setting
-"Transfer-Encoding: chunked" header. For as long as the connection is
-kept open, the server will keep accepting records. Records are streamed
-to and from the server as Concatenated JSON. For each record sent to the
-server, the server will asynchronously send back a delivery report, in
-the same order, each with its own error_code. An error_code of 200
-indicates success. The HTTP status code will be HTTP 200 OK as long as
-the connection is successfully established. To identify records that
-have encountered an error, check the error_code of each delivery report.
+		Produce records to the given topic, returning delivery reports for each
+		record produced. This API can be used in streaming mode by setting
+		"Transfer-Encoding: chunked" header. For as long as the connection is
+		kept open, the server will keep accepting records. Records are streamed
+		to and from the server as Concatenated JSON. For each record sent to the
+		server, the server will asynchronously send back a delivery report, in
+		the same order, each with its own error_code. An error_code of 200
+		indicates success. The HTTP status code will be HTTP 200 OK as long as
+		the connection is successfully established. To identify records that
+		have encountered an error, check the error_code of each delivery report.
 
-Note that the cluster_id is validated only when running in Confluent Cloud.
+		Note that the cluster_id is validated only when running in Confluent Cloud.
 
-This API currently does not support Schema Registry integration. Sending
-schemas is not supported. Only BINARY, JSON, and STRING formats are
-supported.
+		This API currently does not support Schema Registry integration. Sending
+		schemas is not supported. Only BINARY, JSON, and STRING formats are
+		supported.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param topicName The topic name.
-	 @return ApiProduceRecordRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @return ApiProduceRecordRequest
 	*/
 	ProduceRecord(ctx _context.Context, clusterId string, topicName string) ApiProduceRecordRequest
 
@@ -79,10 +79,10 @@ supported.
 type RecordsV3ApiService service
 
 type ApiProduceRecordRequest struct {
-	ctx _context.Context
-	ApiService RecordsV3Api
-	clusterId string
-	topicName string
+	ctx            _context.Context
+	ApiService     RecordsV3Api
+	clusterId      string
+	topicName      string
 	produceRequest *ProduceRequest
 }
 
@@ -118,22 +118,23 @@ This API currently does not support Schema Registry integration. Sending
 schemas is not supported. Only BINARY, JSON, and STRING formats are
 supported.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @return ApiProduceRecordRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@return ApiProduceRecordRequest
 */
 func (a *RecordsV3ApiService) ProduceRecord(ctx _context.Context, clusterId string, topicName string) ApiProduceRecordRequest {
 	return ApiProduceRecordRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		topicName: topicName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		topicName:  topicName,
 	}
 }
 
 // Execute executes the request
-//  @return ProduceResponse
+//
+//	@return ProduceResponse
 func (a *RecordsV3ApiService) ProduceRecordExecute(r ApiProduceRecordRequest) (ProduceResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost

--- a/kafkarest/v3/api_topic_v3.go
+++ b/kafkarest/v3/api_topic_v3.go
@@ -42,18 +42,18 @@ var (
 type TopicV3Api interface {
 
 	/*
-	CreateKafkaTopic Create Topic
+			CreateKafkaTopic Create Topic
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Create a topic.
-Also supports a dry-run mode that only validates whether the topic creation would succeed
-if the ``validate_only`` request property is explicitly specified and set to true. Note that
-when dry-run mode is being used the response status would be 200 OK instead of 201 Created.
+		Create a topic.
+		Also supports a dry-run mode that only validates whether the topic creation would succeed
+		if the ``validate_only`` request property is explicitly specified and set to true. Note that
+		when dry-run mode is being used the response status would be 200 OK instead of 201 Created.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @return ApiCreateKafkaTopicRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiCreateKafkaTopicRequest
 	*/
 	CreateKafkaTopic(ctx _context.Context, clusterId string) ApiCreateKafkaTopicRequest
 
@@ -62,16 +62,16 @@ when dry-run mode is being used the response status would be 200 OK instead of 2
 	CreateKafkaTopicExecute(r ApiCreateKafkaTopicRequest) (TopicData, *_nethttp.Response, error)
 
 	/*
-	DeleteKafkaTopic Delete Topic
+			DeleteKafkaTopic Delete Topic
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Delete the topic with the given `topic_name`.
+		Delete the topic with the given `topic_name`.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param topicName The topic name.
-	 @return ApiDeleteKafkaTopicRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @return ApiDeleteKafkaTopicRequest
 	*/
 	DeleteKafkaTopic(ctx _context.Context, clusterId string, topicName string) ApiDeleteKafkaTopicRequest
 
@@ -79,16 +79,16 @@ Delete the topic with the given `topic_name`.
 	DeleteKafkaTopicExecute(r ApiDeleteKafkaTopicRequest) (*_nethttp.Response, error)
 
 	/*
-	GetKafkaTopic Get Topic
+			GetKafkaTopic Get Topic
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the topic with the given `topic_name`.
+		Return the topic with the given `topic_name`.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param topicName The topic name.
-	 @return ApiGetKafkaTopicRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @return ApiGetKafkaTopicRequest
 	*/
 	GetKafkaTopic(ctx _context.Context, clusterId string, topicName string) ApiGetKafkaTopicRequest
 
@@ -97,15 +97,15 @@ Return the topic with the given `topic_name`.
 	GetKafkaTopicExecute(r ApiGetKafkaTopicRequest) (TopicData, *_nethttp.Response, error)
 
 	/*
-	ListKafkaTopics List Topics
+			ListKafkaTopics List Topics
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Return the list of topics that belong to the specified Kafka cluster.
+		Return the list of topics that belong to the specified Kafka cluster.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @return ApiListKafkaTopicsRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @return ApiListKafkaTopicsRequest
 	*/
 	ListKafkaTopics(ctx _context.Context, clusterId string) ApiListKafkaTopicsRequest
 
@@ -114,16 +114,17 @@ Return the list of topics that belong to the specified Kafka cluster.
 	ListKafkaTopicsExecute(r ApiListKafkaTopicsRequest) (TopicDataList, *_nethttp.Response, error)
 
 	/*
-	UpdatePartitionCountKafkaTopic Update Partition Count
+			UpdatePartitionCountKafkaTopic Update Partition Count
 
-	[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Increase the number of partitions for a topic.
+		Increase the number of partitions for a topic. To update other topic
+		configurations, see https://docs.confluent.io/cloud/current/api.html#tag/Configs-(v3)/operation/updateKafkaTopicConfig.
 
-	 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 @param clusterId The Kafka cluster ID.
-	 @param topicName The topic name.
-	 @return ApiUpdatePartitionCountKafkaTopicRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param clusterId The Kafka cluster ID.
+			 @param topicName The topic name.
+			 @return ApiUpdatePartitionCountKafkaTopicRequest
 	*/
 	UpdatePartitionCountKafkaTopic(ctx _context.Context, clusterId string, topicName string) ApiUpdatePartitionCountKafkaTopicRequest
 
@@ -136,9 +137,9 @@ Increase the number of partitions for a topic.
 type TopicV3ApiService service
 
 type ApiCreateKafkaTopicRequest struct {
-	ctx _context.Context
-	ApiService TopicV3Api
-	clusterId string
+	ctx                    _context.Context
+	ApiService             TopicV3Api
+	clusterId              string
 	createTopicRequestData *CreateTopicRequestData
 }
 
@@ -159,23 +160,24 @@ CreateKafkaTopic Create Topic
 
 Create a topic.
 Also supports a dry-run mode that only validates whether the topic creation would succeed
-if the ``validate_only`` request property is explicitly specified and set to true. Note that
+if the “validate_only“ request property is explicitly specified and set to true. Note that
 when dry-run mode is being used the response status would be 200 OK instead of 201 Created.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiCreateKafkaTopicRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiCreateKafkaTopicRequest
 */
 func (a *TopicV3ApiService) CreateKafkaTopic(ctx _context.Context, clusterId string) ApiCreateKafkaTopicRequest {
 	return ApiCreateKafkaTopicRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ctx:        ctx,
+		clusterId:  clusterId,
 	}
 }
 
 // Execute executes the request
-//  @return TopicData
+//
+//	@return TopicData
 func (a *TopicV3ApiService) CreateKafkaTopicExecute(r ApiCreateKafkaTopicRequest) (TopicData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
@@ -304,12 +306,11 @@ func (a *TopicV3ApiService) CreateKafkaTopicExecute(r ApiCreateKafkaTopicRequest
 }
 
 type ApiDeleteKafkaTopicRequest struct {
-	ctx _context.Context
+	ctx        _context.Context
 	ApiService TopicV3Api
-	clusterId string
-	topicName string
+	clusterId  string
+	topicName  string
 }
-
 
 func (r ApiDeleteKafkaTopicRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.DeleteKafkaTopicExecute(r)
@@ -322,17 +323,17 @@ DeleteKafkaTopic Delete Topic
 
 Delete the topic with the given `topic_name`.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @return ApiDeleteKafkaTopicRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@return ApiDeleteKafkaTopicRequest
 */
 func (a *TopicV3ApiService) DeleteKafkaTopic(ctx _context.Context, clusterId string, topicName string) ApiDeleteKafkaTopicRequest {
 	return ApiDeleteKafkaTopicRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		topicName: topicName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		topicName:  topicName,
 	}
 }
 
@@ -464,10 +465,10 @@ func (a *TopicV3ApiService) DeleteKafkaTopicExecute(r ApiDeleteKafkaTopicRequest
 }
 
 type ApiGetKafkaTopicRequest struct {
-	ctx _context.Context
-	ApiService TopicV3Api
-	clusterId string
-	topicName string
+	ctx                         _context.Context
+	ApiService                  TopicV3Api
+	clusterId                   string
+	topicName                   string
 	includeAuthorizedOperations *bool
 }
 
@@ -488,22 +489,23 @@ GetKafkaTopic Get Topic
 
 Return the topic with the given `topic_name`.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @return ApiGetKafkaTopicRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@return ApiGetKafkaTopicRequest
 */
 func (a *TopicV3ApiService) GetKafkaTopic(ctx _context.Context, clusterId string, topicName string) ApiGetKafkaTopicRequest {
 	return ApiGetKafkaTopicRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		topicName: topicName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		topicName:  topicName,
 	}
 }
 
 // Execute executes the request
-//  @return TopicData
+//
+//	@return TopicData
 func (a *TopicV3ApiService) GetKafkaTopicExecute(r ApiGetKafkaTopicRequest) (TopicData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -644,11 +646,10 @@ func (a *TopicV3ApiService) GetKafkaTopicExecute(r ApiGetKafkaTopicRequest) (Top
 }
 
 type ApiListKafkaTopicsRequest struct {
-	ctx _context.Context
+	ctx        _context.Context
 	ApiService TopicV3Api
-	clusterId string
+	clusterId  string
 }
-
 
 func (r ApiListKafkaTopicsRequest) Execute() (TopicDataList, *_nethttp.Response, error) {
 	return r.ApiService.ListKafkaTopicsExecute(r)
@@ -661,20 +662,21 @@ ListKafkaTopics List Topics
 
 Return the list of topics that belong to the specified Kafka cluster.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @return ApiListKafkaTopicsRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@return ApiListKafkaTopicsRequest
 */
 func (a *TopicV3ApiService) ListKafkaTopics(ctx _context.Context, clusterId string) ApiListKafkaTopicsRequest {
 	return ApiListKafkaTopicsRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
+		ctx:        ctx,
+		clusterId:  clusterId,
 	}
 }
 
 // Execute executes the request
-//  @return TopicDataList
+//
+//	@return TopicDataList
 func (a *TopicV3ApiService) ListKafkaTopicsExecute(r ApiListKafkaTopicsRequest) (TopicDataList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
@@ -801,10 +803,10 @@ func (a *TopicV3ApiService) ListKafkaTopicsExecute(r ApiListKafkaTopicsRequest) 
 }
 
 type ApiUpdatePartitionCountKafkaTopicRequest struct {
-	ctx _context.Context
-	ApiService TopicV3Api
-	clusterId string
-	topicName string
+	ctx                             _context.Context
+	ApiService                      TopicV3Api
+	clusterId                       string
+	topicName                       string
 	updatePartitionCountRequestData *UpdatePartitionCountRequestData
 }
 
@@ -822,24 +824,26 @@ UpdatePartitionCountKafkaTopic Update Partition Count
 
 [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-Increase the number of partitions for a topic.
+Increase the number of partitions for a topic. To update other topic
+configurations, see https://docs.confluent.io/cloud/current/api.html#tag/Configs-(v3)/operation/updateKafkaTopicConfig.
 
- @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param clusterId The Kafka cluster ID.
- @param topicName The topic name.
- @return ApiUpdatePartitionCountKafkaTopicRequest
+	@param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param clusterId The Kafka cluster ID.
+	@param topicName The topic name.
+	@return ApiUpdatePartitionCountKafkaTopicRequest
 */
 func (a *TopicV3ApiService) UpdatePartitionCountKafkaTopic(ctx _context.Context, clusterId string, topicName string) ApiUpdatePartitionCountKafkaTopicRequest {
 	return ApiUpdatePartitionCountKafkaTopicRequest{
 		ApiService: a,
-		ctx: ctx,
-		clusterId: clusterId,
-		topicName: topicName,
+		ctx:        ctx,
+		clusterId:  clusterId,
+		topicName:  topicName,
 	}
 }
 
 // Execute executes the request
-//  @return TopicData
+//
+//	@return TopicData
 func (a *TopicV3ApiService) UpdatePartitionCountKafkaTopicExecute(r ApiUpdatePartitionCountKafkaTopicRequest) (TopicData, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch

--- a/kafkarest/v3/docs/ConsumerGroupData.md
+++ b/kafkarest/v3/docs/ConsumerGroupData.md
@@ -11,15 +11,17 @@ Name | Type | Description | Notes
 **IsSimple** | **bool** |  | 
 **PartitionAssignor** | **string** |  | 
 **State** | **string** |  | 
+**Type** | **string** |  | 
+**IsMixedConsumerGroup** | **bool** |  | 
 **Coordinator** | [**Relationship**](Relationship.md) |  | 
-**Consumer** | Pointer to [**Relationship**](Relationship.md) |  | [optional] 
+**Consumers** | [**Relationship**](Relationship.md) |  | 
 **LagSummary** | [**Relationship**](Relationship.md) |  | 
 
 ## Methods
 
 ### NewConsumerGroupData
 
-`func NewConsumerGroupData(kind string, metadata ResourceMetadata, clusterId string, consumerGroupId string, isSimple bool, partitionAssignor string, state string, coordinator Relationship, lagSummary Relationship, ) *ConsumerGroupData`
+`func NewConsumerGroupData(kind string, metadata ResourceMetadata, clusterId string, consumerGroupId string, isSimple bool, partitionAssignor string, state string, type_ string, isMixedConsumerGroup bool, coordinator Relationship, consumers Relationship, lagSummary Relationship, ) *ConsumerGroupData`
 
 NewConsumerGroupData instantiates a new ConsumerGroupData object
 This constructor will assign default values to properties that have it defined,
@@ -174,6 +176,46 @@ and a boolean to check if the value has been set.
 SetState sets State field to given value.
 
 
+### GetType
+
+`func (o *ConsumerGroupData) GetType() string`
+
+GetType returns the Type field if non-nil, zero value otherwise.
+
+### GetTypeOk
+
+`func (o *ConsumerGroupData) GetTypeOk() (*string, bool)`
+
+GetTypeOk returns a tuple with the Type field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetType
+
+`func (o *ConsumerGroupData) SetType(v string)`
+
+SetType sets Type field to given value.
+
+
+### GetIsMixedConsumerGroup
+
+`func (o *ConsumerGroupData) GetIsMixedConsumerGroup() bool`
+
+GetIsMixedConsumerGroup returns the IsMixedConsumerGroup field if non-nil, zero value otherwise.
+
+### GetIsMixedConsumerGroupOk
+
+`func (o *ConsumerGroupData) GetIsMixedConsumerGroupOk() (*bool, bool)`
+
+GetIsMixedConsumerGroupOk returns a tuple with the IsMixedConsumerGroup field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetIsMixedConsumerGroup
+
+`func (o *ConsumerGroupData) SetIsMixedConsumerGroup(v bool)`
+
+SetIsMixedConsumerGroup sets IsMixedConsumerGroup field to given value.
+
+
 ### GetCoordinator
 
 `func (o *ConsumerGroupData) GetCoordinator() Relationship`
@@ -194,30 +236,25 @@ and a boolean to check if the value has been set.
 SetCoordinator sets Coordinator field to given value.
 
 
-### GetConsumer
+### GetConsumers
 
-`func (o *ConsumerGroupData) GetConsumer() Relationship`
+`func (o *ConsumerGroupData) GetConsumers() Relationship`
 
-GetConsumer returns the Consumer field if non-nil, zero value otherwise.
+GetConsumers returns the Consumers field if non-nil, zero value otherwise.
 
-### GetConsumerOk
+### GetConsumersOk
 
-`func (o *ConsumerGroupData) GetConsumerOk() (*Relationship, bool)`
+`func (o *ConsumerGroupData) GetConsumersOk() (*Relationship, bool)`
 
-GetConsumerOk returns a tuple with the Consumer field if it's non-nil, zero value otherwise
+GetConsumersOk returns a tuple with the Consumers field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
-### SetConsumer
+### SetConsumers
 
-`func (o *ConsumerGroupData) SetConsumer(v Relationship)`
+`func (o *ConsumerGroupData) SetConsumers(v Relationship)`
 
-SetConsumer sets Consumer field to given value.
+SetConsumers sets Consumers field to given value.
 
-### HasConsumer
-
-`func (o *ConsumerGroupData) HasConsumer() bool`
-
-HasConsumer returns a boolean if a field has been set.
 
 ### GetLagSummary
 

--- a/kafkarest/v3/docs/ConsumerGroupDataAllOf.md
+++ b/kafkarest/v3/docs/ConsumerGroupDataAllOf.md
@@ -9,15 +9,17 @@ Name | Type | Description | Notes
 **IsSimple** | **bool** |  | 
 **PartitionAssignor** | **string** |  | 
 **State** | **string** |  | 
+**Type** | **string** |  | 
+**IsMixedConsumerGroup** | **bool** |  | 
 **Coordinator** | [**Relationship**](Relationship.md) |  | 
-**Consumer** | Pointer to [**Relationship**](Relationship.md) |  | [optional] 
+**Consumers** | [**Relationship**](Relationship.md) |  | 
 **LagSummary** | [**Relationship**](Relationship.md) |  | 
 
 ## Methods
 
 ### NewConsumerGroupDataAllOf
 
-`func NewConsumerGroupDataAllOf(clusterId string, consumerGroupId string, isSimple bool, partitionAssignor string, state string, coordinator Relationship, lagSummary Relationship, ) *ConsumerGroupDataAllOf`
+`func NewConsumerGroupDataAllOf(clusterId string, consumerGroupId string, isSimple bool, partitionAssignor string, state string, type_ string, isMixedConsumerGroup bool, coordinator Relationship, consumers Relationship, lagSummary Relationship, ) *ConsumerGroupDataAllOf`
 
 NewConsumerGroupDataAllOf instantiates a new ConsumerGroupDataAllOf object
 This constructor will assign default values to properties that have it defined,
@@ -132,6 +134,46 @@ and a boolean to check if the value has been set.
 SetState sets State field to given value.
 
 
+### GetType
+
+`func (o *ConsumerGroupDataAllOf) GetType() string`
+
+GetType returns the Type field if non-nil, zero value otherwise.
+
+### GetTypeOk
+
+`func (o *ConsumerGroupDataAllOf) GetTypeOk() (*string, bool)`
+
+GetTypeOk returns a tuple with the Type field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetType
+
+`func (o *ConsumerGroupDataAllOf) SetType(v string)`
+
+SetType sets Type field to given value.
+
+
+### GetIsMixedConsumerGroup
+
+`func (o *ConsumerGroupDataAllOf) GetIsMixedConsumerGroup() bool`
+
+GetIsMixedConsumerGroup returns the IsMixedConsumerGroup field if non-nil, zero value otherwise.
+
+### GetIsMixedConsumerGroupOk
+
+`func (o *ConsumerGroupDataAllOf) GetIsMixedConsumerGroupOk() (*bool, bool)`
+
+GetIsMixedConsumerGroupOk returns a tuple with the IsMixedConsumerGroup field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetIsMixedConsumerGroup
+
+`func (o *ConsumerGroupDataAllOf) SetIsMixedConsumerGroup(v bool)`
+
+SetIsMixedConsumerGroup sets IsMixedConsumerGroup field to given value.
+
+
 ### GetCoordinator
 
 `func (o *ConsumerGroupDataAllOf) GetCoordinator() Relationship`
@@ -152,30 +194,25 @@ and a boolean to check if the value has been set.
 SetCoordinator sets Coordinator field to given value.
 
 
-### GetConsumer
+### GetConsumers
 
-`func (o *ConsumerGroupDataAllOf) GetConsumer() Relationship`
+`func (o *ConsumerGroupDataAllOf) GetConsumers() Relationship`
 
-GetConsumer returns the Consumer field if non-nil, zero value otherwise.
+GetConsumers returns the Consumers field if non-nil, zero value otherwise.
 
-### GetConsumerOk
+### GetConsumersOk
 
-`func (o *ConsumerGroupDataAllOf) GetConsumerOk() (*Relationship, bool)`
+`func (o *ConsumerGroupDataAllOf) GetConsumersOk() (*Relationship, bool)`
 
-GetConsumerOk returns a tuple with the Consumer field if it's non-nil, zero value otherwise
+GetConsumersOk returns a tuple with the Consumers field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
-### SetConsumer
+### SetConsumers
 
-`func (o *ConsumerGroupDataAllOf) SetConsumer(v Relationship)`
+`func (o *ConsumerGroupDataAllOf) SetConsumers(v Relationship)`
 
-SetConsumer sets Consumer field to given value.
+SetConsumers sets Consumers field to given value.
 
-### HasConsumer
-
-`func (o *ConsumerGroupDataAllOf) HasConsumer() bool`
-
-HasConsumer returns a boolean if a field has been set.
 
 ### GetLagSummary
 

--- a/kafkarest/v3/docs/ListLinkConfigsResponseData.md
+++ b/kafkarest/v3/docs/ListLinkConfigsResponseData.md
@@ -9,8 +9,9 @@ Name | Type | Description | Notes
 **ClusterId** | **string** |  | 
 **Name** | **string** |  | 
 **Value** | **string** |  | 
-**ReadOnly** | **bool** |  | 
-**Sensitive** | **bool** |  | 
+**IsDefault** | **bool** |  | 
+**IsReadOnly** | **bool** |  | 
+**IsSensitive** | **bool** |  | 
 **Source** | **string** |  | 
 **Synonyms** | **[]string** |  | 
 **LinkName** | **string** |  | 
@@ -19,7 +20,7 @@ Name | Type | Description | Notes
 
 ### NewListLinkConfigsResponseData
 
-`func NewListLinkConfigsResponseData(kind string, metadata ResourceMetadata, clusterId string, name string, value string, readOnly bool, sensitive bool, source string, synonyms []string, linkName string, ) *ListLinkConfigsResponseData`
+`func NewListLinkConfigsResponseData(kind string, metadata ResourceMetadata, clusterId string, name string, value string, isDefault bool, isReadOnly bool, isSensitive bool, source string, synonyms []string, linkName string, ) *ListLinkConfigsResponseData`
 
 NewListLinkConfigsResponseData instantiates a new ListLinkConfigsResponseData object
 This constructor will assign default values to properties that have it defined,
@@ -134,44 +135,64 @@ and a boolean to check if the value has been set.
 SetValue sets Value field to given value.
 
 
-### GetReadOnly
+### GetIsDefault
 
-`func (o *ListLinkConfigsResponseData) GetReadOnly() bool`
+`func (o *ListLinkConfigsResponseData) GetIsDefault() bool`
 
-GetReadOnly returns the ReadOnly field if non-nil, zero value otherwise.
+GetIsDefault returns the IsDefault field if non-nil, zero value otherwise.
 
-### GetReadOnlyOk
+### GetIsDefaultOk
 
-`func (o *ListLinkConfigsResponseData) GetReadOnlyOk() (*bool, bool)`
+`func (o *ListLinkConfigsResponseData) GetIsDefaultOk() (*bool, bool)`
 
-GetReadOnlyOk returns a tuple with the ReadOnly field if it's non-nil, zero value otherwise
+GetIsDefaultOk returns a tuple with the IsDefault field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
-### SetReadOnly
+### SetIsDefault
 
-`func (o *ListLinkConfigsResponseData) SetReadOnly(v bool)`
+`func (o *ListLinkConfigsResponseData) SetIsDefault(v bool)`
 
-SetReadOnly sets ReadOnly field to given value.
+SetIsDefault sets IsDefault field to given value.
 
 
-### GetSensitive
+### GetIsReadOnly
 
-`func (o *ListLinkConfigsResponseData) GetSensitive() bool`
+`func (o *ListLinkConfigsResponseData) GetIsReadOnly() bool`
 
-GetSensitive returns the Sensitive field if non-nil, zero value otherwise.
+GetIsReadOnly returns the IsReadOnly field if non-nil, zero value otherwise.
 
-### GetSensitiveOk
+### GetIsReadOnlyOk
 
-`func (o *ListLinkConfigsResponseData) GetSensitiveOk() (*bool, bool)`
+`func (o *ListLinkConfigsResponseData) GetIsReadOnlyOk() (*bool, bool)`
 
-GetSensitiveOk returns a tuple with the Sensitive field if it's non-nil, zero value otherwise
+GetIsReadOnlyOk returns a tuple with the IsReadOnly field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
-### SetSensitive
+### SetIsReadOnly
 
-`func (o *ListLinkConfigsResponseData) SetSensitive(v bool)`
+`func (o *ListLinkConfigsResponseData) SetIsReadOnly(v bool)`
 
-SetSensitive sets Sensitive field to given value.
+SetIsReadOnly sets IsReadOnly field to given value.
+
+
+### GetIsSensitive
+
+`func (o *ListLinkConfigsResponseData) GetIsSensitive() bool`
+
+GetIsSensitive returns the IsSensitive field if non-nil, zero value otherwise.
+
+### GetIsSensitiveOk
+
+`func (o *ListLinkConfigsResponseData) GetIsSensitiveOk() (*bool, bool)`
+
+GetIsSensitiveOk returns a tuple with the IsSensitive field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetIsSensitive
+
+`func (o *ListLinkConfigsResponseData) SetIsSensitive(v bool)`
+
+SetIsSensitive sets IsSensitive field to given value.
 
 
 ### GetSource

--- a/kafkarest/v3/docs/ListLinkConfigsResponseDataAllOf.md
+++ b/kafkarest/v3/docs/ListLinkConfigsResponseDataAllOf.md
@@ -7,8 +7,9 @@ Name | Type | Description | Notes
 **ClusterId** | **string** |  | 
 **Name** | **string** |  | 
 **Value** | **string** |  | 
-**ReadOnly** | **bool** |  | 
-**Sensitive** | **bool** |  | 
+**IsDefault** | **bool** |  | 
+**IsReadOnly** | **bool** |  | 
+**IsSensitive** | **bool** |  | 
 **Source** | **string** |  | 
 **Synonyms** | **[]string** |  | 
 **LinkName** | **string** |  | 
@@ -17,7 +18,7 @@ Name | Type | Description | Notes
 
 ### NewListLinkConfigsResponseDataAllOf
 
-`func NewListLinkConfigsResponseDataAllOf(clusterId string, name string, value string, readOnly bool, sensitive bool, source string, synonyms []string, linkName string, ) *ListLinkConfigsResponseDataAllOf`
+`func NewListLinkConfigsResponseDataAllOf(clusterId string, name string, value string, isDefault bool, isReadOnly bool, isSensitive bool, source string, synonyms []string, linkName string, ) *ListLinkConfigsResponseDataAllOf`
 
 NewListLinkConfigsResponseDataAllOf instantiates a new ListLinkConfigsResponseDataAllOf object
 This constructor will assign default values to properties that have it defined,
@@ -92,44 +93,64 @@ and a boolean to check if the value has been set.
 SetValue sets Value field to given value.
 
 
-### GetReadOnly
+### GetIsDefault
 
-`func (o *ListLinkConfigsResponseDataAllOf) GetReadOnly() bool`
+`func (o *ListLinkConfigsResponseDataAllOf) GetIsDefault() bool`
 
-GetReadOnly returns the ReadOnly field if non-nil, zero value otherwise.
+GetIsDefault returns the IsDefault field if non-nil, zero value otherwise.
 
-### GetReadOnlyOk
+### GetIsDefaultOk
 
-`func (o *ListLinkConfigsResponseDataAllOf) GetReadOnlyOk() (*bool, bool)`
+`func (o *ListLinkConfigsResponseDataAllOf) GetIsDefaultOk() (*bool, bool)`
 
-GetReadOnlyOk returns a tuple with the ReadOnly field if it's non-nil, zero value otherwise
+GetIsDefaultOk returns a tuple with the IsDefault field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
-### SetReadOnly
+### SetIsDefault
 
-`func (o *ListLinkConfigsResponseDataAllOf) SetReadOnly(v bool)`
+`func (o *ListLinkConfigsResponseDataAllOf) SetIsDefault(v bool)`
 
-SetReadOnly sets ReadOnly field to given value.
+SetIsDefault sets IsDefault field to given value.
 
 
-### GetSensitive
+### GetIsReadOnly
 
-`func (o *ListLinkConfigsResponseDataAllOf) GetSensitive() bool`
+`func (o *ListLinkConfigsResponseDataAllOf) GetIsReadOnly() bool`
 
-GetSensitive returns the Sensitive field if non-nil, zero value otherwise.
+GetIsReadOnly returns the IsReadOnly field if non-nil, zero value otherwise.
 
-### GetSensitiveOk
+### GetIsReadOnlyOk
 
-`func (o *ListLinkConfigsResponseDataAllOf) GetSensitiveOk() (*bool, bool)`
+`func (o *ListLinkConfigsResponseDataAllOf) GetIsReadOnlyOk() (*bool, bool)`
 
-GetSensitiveOk returns a tuple with the Sensitive field if it's non-nil, zero value otherwise
+GetIsReadOnlyOk returns a tuple with the IsReadOnly field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
-### SetSensitive
+### SetIsReadOnly
 
-`func (o *ListLinkConfigsResponseDataAllOf) SetSensitive(v bool)`
+`func (o *ListLinkConfigsResponseDataAllOf) SetIsReadOnly(v bool)`
 
-SetSensitive sets Sensitive field to given value.
+SetIsReadOnly sets IsReadOnly field to given value.
+
+
+### GetIsSensitive
+
+`func (o *ListLinkConfigsResponseDataAllOf) GetIsSensitive() bool`
+
+GetIsSensitive returns the IsSensitive field if non-nil, zero value otherwise.
+
+### GetIsSensitiveOk
+
+`func (o *ListLinkConfigsResponseDataAllOf) GetIsSensitiveOk() (*bool, bool)`
+
+GetIsSensitiveOk returns a tuple with the IsSensitive field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetIsSensitive
+
+`func (o *ListLinkConfigsResponseDataAllOf) SetIsSensitive(v bool)`
+
+SetIsSensitive sets IsSensitive field to given value.
 
 
 ### GetSource

--- a/kafkarest/v3/model_consumer_group_data.go
+++ b/kafkarest/v3/model_consumer_group_data.go
@@ -36,23 +36,25 @@ import (
 
 // ConsumerGroupData struct for ConsumerGroupData
 type ConsumerGroupData struct {
-	Kind              string           `json:"kind,omitempty"`
-	Metadata          ResourceMetadata `json:"metadata,omitempty"`
-	ClusterId         string           `json:"cluster_id,omitempty"`
-	ConsumerGroupId   string           `json:"consumer_group_id,omitempty"`
-	IsSimple          bool             `json:"is_simple,omitempty"`
-	PartitionAssignor string           `json:"partition_assignor,omitempty"`
-	State             string           `json:"state,omitempty"`
-	Coordinator       Relationship     `json:"coordinator,omitempty"`
-	Consumer          *Relationship    `json:"consumer,omitempty"`
-	LagSummary        Relationship     `json:"lag_summary,omitempty"`
+	Kind                 string           `json:"kind,omitempty"`
+	Metadata             ResourceMetadata `json:"metadata,omitempty"`
+	ClusterId            string           `json:"cluster_id,omitempty"`
+	ConsumerGroupId      string           `json:"consumer_group_id,omitempty"`
+	IsSimple             bool             `json:"is_simple,omitempty"`
+	PartitionAssignor    string           `json:"partition_assignor,omitempty"`
+	State                string           `json:"state,omitempty"`
+	Type                 string           `json:"type,omitempty"`
+	IsMixedConsumerGroup bool             `json:"is_mixed_consumer_group,omitempty"`
+	Coordinator          Relationship     `json:"coordinator,omitempty"`
+	Consumers            Relationship     `json:"consumers,omitempty"`
+	LagSummary           Relationship     `json:"lag_summary,omitempty"`
 }
 
 // NewConsumerGroupData instantiates a new ConsumerGroupData object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewConsumerGroupData(kind string, metadata ResourceMetadata, clusterId string, consumerGroupId string, isSimple bool, partitionAssignor string, state string, coordinator Relationship, lagSummary Relationship) *ConsumerGroupData {
+func NewConsumerGroupData(kind string, metadata ResourceMetadata, clusterId string, consumerGroupId string, isSimple bool, partitionAssignor string, state string, type_ string, isMixedConsumerGroup bool, coordinator Relationship, consumers Relationship, lagSummary Relationship) *ConsumerGroupData {
 	this := ConsumerGroupData{}
 	this.Kind = kind
 	this.Metadata = metadata
@@ -61,7 +63,10 @@ func NewConsumerGroupData(kind string, metadata ResourceMetadata, clusterId stri
 	this.IsSimple = isSimple
 	this.PartitionAssignor = partitionAssignor
 	this.State = state
+	this.Type = type_
+	this.IsMixedConsumerGroup = isMixedConsumerGroup
 	this.Coordinator = coordinator
+	this.Consumers = consumers
 	this.LagSummary = lagSummary
 	return &this
 }
@@ -242,6 +247,54 @@ func (o *ConsumerGroupData) SetState(v string) {
 	o.State = v
 }
 
+// GetType returns the Type field value
+func (o *ConsumerGroupData) GetType() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.Type
+}
+
+// GetTypeOk returns a tuple with the Type field value
+// and a boolean to check if the value has been set.
+func (o *ConsumerGroupData) GetTypeOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.Type, true
+}
+
+// SetType sets field value
+func (o *ConsumerGroupData) SetType(v string) {
+	o.Type = v
+}
+
+// GetIsMixedConsumerGroup returns the IsMixedConsumerGroup field value
+func (o *ConsumerGroupData) GetIsMixedConsumerGroup() bool {
+	if o == nil {
+		var ret bool
+		return ret
+	}
+
+	return o.IsMixedConsumerGroup
+}
+
+// GetIsMixedConsumerGroupOk returns a tuple with the IsMixedConsumerGroup field value
+// and a boolean to check if the value has been set.
+func (o *ConsumerGroupData) GetIsMixedConsumerGroupOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.IsMixedConsumerGroup, true
+}
+
+// SetIsMixedConsumerGroup sets field value
+func (o *ConsumerGroupData) SetIsMixedConsumerGroup(v bool) {
+	o.IsMixedConsumerGroup = v
+}
+
 // GetCoordinator returns the Coordinator field value
 func (o *ConsumerGroupData) GetCoordinator() Relationship {
 	if o == nil {
@@ -266,36 +319,28 @@ func (o *ConsumerGroupData) SetCoordinator(v Relationship) {
 	o.Coordinator = v
 }
 
-// GetConsumer returns the Consumer field value if set, zero value otherwise.
-func (o *ConsumerGroupData) GetConsumer() Relationship {
-	if o == nil || o.Consumer == nil {
+// GetConsumers returns the Consumers field value
+func (o *ConsumerGroupData) GetConsumers() Relationship {
+	if o == nil {
 		var ret Relationship
 		return ret
 	}
-	return *o.Consumer
+
+	return o.Consumers
 }
 
-// GetConsumerOk returns a tuple with the Consumer field value if set, nil otherwise
+// GetConsumersOk returns a tuple with the Consumers field value
 // and a boolean to check if the value has been set.
-func (o *ConsumerGroupData) GetConsumerOk() (*Relationship, bool) {
-	if o == nil || o.Consumer == nil {
+func (o *ConsumerGroupData) GetConsumersOk() (*Relationship, bool) {
+	if o == nil {
 		return nil, false
 	}
-	return o.Consumer, true
+	return &o.Consumers, true
 }
 
-// HasConsumer returns a boolean if a field has been set.
-func (o *ConsumerGroupData) HasConsumer() bool {
-	if o != nil && o.Consumer != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetConsumer gets a reference to the given Relationship and assigns it to the Consumer field.
-func (o *ConsumerGroupData) SetConsumer(v Relationship) {
-	o.Consumer = &v
+// SetConsumers sets field value
+func (o *ConsumerGroupData) SetConsumers(v Relationship) {
+	o.Consumers = v
 }
 
 // GetLagSummary returns the LagSummary field value
@@ -331,8 +376,10 @@ func (o *ConsumerGroupData) Redact() {
 	o.recurseRedact(&o.IsSimple)
 	o.recurseRedact(&o.PartitionAssignor)
 	o.recurseRedact(&o.State)
+	o.recurseRedact(&o.Type)
+	o.recurseRedact(&o.IsMixedConsumerGroup)
 	o.recurseRedact(&o.Coordinator)
-	o.recurseRedact(o.Consumer)
+	o.recurseRedact(&o.Consumers)
 	o.recurseRedact(&o.LagSummary)
 }
 
@@ -390,10 +437,16 @@ func (o ConsumerGroupData) MarshalJSON() ([]byte, error) {
 		toSerialize["state"] = o.State
 	}
 	if true {
+		toSerialize["type"] = o.Type
+	}
+	if true {
+		toSerialize["is_mixed_consumer_group"] = o.IsMixedConsumerGroup
+	}
+	if true {
 		toSerialize["coordinator"] = o.Coordinator
 	}
-	if o.Consumer != nil {
-		toSerialize["consumer"] = o.Consumer
+	if true {
+		toSerialize["consumers"] = o.Consumers
 	}
 	if true {
 		toSerialize["lag_summary"] = o.LagSummary

--- a/kafkarest/v3/model_consumer_group_data_all_of.go
+++ b/kafkarest/v3/model_consumer_group_data_all_of.go
@@ -36,28 +36,33 @@ import (
 
 // ConsumerGroupDataAllOf struct for ConsumerGroupDataAllOf
 type ConsumerGroupDataAllOf struct {
-	ClusterId         string        `json:"cluster_id,omitempty"`
-	ConsumerGroupId   string        `json:"consumer_group_id,omitempty"`
-	IsSimple          bool          `json:"is_simple,omitempty"`
-	PartitionAssignor string        `json:"partition_assignor,omitempty"`
-	State             string        `json:"state,omitempty"`
-	Coordinator       Relationship  `json:"coordinator,omitempty"`
-	Consumer          *Relationship `json:"consumer,omitempty"`
-	LagSummary        Relationship  `json:"lag_summary,omitempty"`
+	ClusterId            string       `json:"cluster_id,omitempty"`
+	ConsumerGroupId      string       `json:"consumer_group_id,omitempty"`
+	IsSimple             bool         `json:"is_simple,omitempty"`
+	PartitionAssignor    string       `json:"partition_assignor,omitempty"`
+	State                string       `json:"state,omitempty"`
+	Type                 string       `json:"type,omitempty"`
+	IsMixedConsumerGroup bool         `json:"is_mixed_consumer_group,omitempty"`
+	Coordinator          Relationship `json:"coordinator,omitempty"`
+	Consumers            Relationship `json:"consumers,omitempty"`
+	LagSummary           Relationship `json:"lag_summary,omitempty"`
 }
 
 // NewConsumerGroupDataAllOf instantiates a new ConsumerGroupDataAllOf object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewConsumerGroupDataAllOf(clusterId string, consumerGroupId string, isSimple bool, partitionAssignor string, state string, coordinator Relationship, lagSummary Relationship) *ConsumerGroupDataAllOf {
+func NewConsumerGroupDataAllOf(clusterId string, consumerGroupId string, isSimple bool, partitionAssignor string, state string, type_ string, isMixedConsumerGroup bool, coordinator Relationship, consumers Relationship, lagSummary Relationship) *ConsumerGroupDataAllOf {
 	this := ConsumerGroupDataAllOf{}
 	this.ClusterId = clusterId
 	this.ConsumerGroupId = consumerGroupId
 	this.IsSimple = isSimple
 	this.PartitionAssignor = partitionAssignor
 	this.State = state
+	this.Type = type_
+	this.IsMixedConsumerGroup = isMixedConsumerGroup
 	this.Coordinator = coordinator
+	this.Consumers = consumers
 	this.LagSummary = lagSummary
 	return &this
 }
@@ -190,6 +195,54 @@ func (o *ConsumerGroupDataAllOf) SetState(v string) {
 	o.State = v
 }
 
+// GetType returns the Type field value
+func (o *ConsumerGroupDataAllOf) GetType() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.Type
+}
+
+// GetTypeOk returns a tuple with the Type field value
+// and a boolean to check if the value has been set.
+func (o *ConsumerGroupDataAllOf) GetTypeOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.Type, true
+}
+
+// SetType sets field value
+func (o *ConsumerGroupDataAllOf) SetType(v string) {
+	o.Type = v
+}
+
+// GetIsMixedConsumerGroup returns the IsMixedConsumerGroup field value
+func (o *ConsumerGroupDataAllOf) GetIsMixedConsumerGroup() bool {
+	if o == nil {
+		var ret bool
+		return ret
+	}
+
+	return o.IsMixedConsumerGroup
+}
+
+// GetIsMixedConsumerGroupOk returns a tuple with the IsMixedConsumerGroup field value
+// and a boolean to check if the value has been set.
+func (o *ConsumerGroupDataAllOf) GetIsMixedConsumerGroupOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.IsMixedConsumerGroup, true
+}
+
+// SetIsMixedConsumerGroup sets field value
+func (o *ConsumerGroupDataAllOf) SetIsMixedConsumerGroup(v bool) {
+	o.IsMixedConsumerGroup = v
+}
+
 // GetCoordinator returns the Coordinator field value
 func (o *ConsumerGroupDataAllOf) GetCoordinator() Relationship {
 	if o == nil {
@@ -214,36 +267,28 @@ func (o *ConsumerGroupDataAllOf) SetCoordinator(v Relationship) {
 	o.Coordinator = v
 }
 
-// GetConsumer returns the Consumer field value if set, zero value otherwise.
-func (o *ConsumerGroupDataAllOf) GetConsumer() Relationship {
-	if o == nil || o.Consumer == nil {
+// GetConsumers returns the Consumers field value
+func (o *ConsumerGroupDataAllOf) GetConsumers() Relationship {
+	if o == nil {
 		var ret Relationship
 		return ret
 	}
-	return *o.Consumer
+
+	return o.Consumers
 }
 
-// GetConsumerOk returns a tuple with the Consumer field value if set, nil otherwise
+// GetConsumersOk returns a tuple with the Consumers field value
 // and a boolean to check if the value has been set.
-func (o *ConsumerGroupDataAllOf) GetConsumerOk() (*Relationship, bool) {
-	if o == nil || o.Consumer == nil {
+func (o *ConsumerGroupDataAllOf) GetConsumersOk() (*Relationship, bool) {
+	if o == nil {
 		return nil, false
 	}
-	return o.Consumer, true
+	return &o.Consumers, true
 }
 
-// HasConsumer returns a boolean if a field has been set.
-func (o *ConsumerGroupDataAllOf) HasConsumer() bool {
-	if o != nil && o.Consumer != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetConsumer gets a reference to the given Relationship and assigns it to the Consumer field.
-func (o *ConsumerGroupDataAllOf) SetConsumer(v Relationship) {
-	o.Consumer = &v
+// SetConsumers sets field value
+func (o *ConsumerGroupDataAllOf) SetConsumers(v Relationship) {
+	o.Consumers = v
 }
 
 // GetLagSummary returns the LagSummary field value
@@ -277,8 +322,10 @@ func (o *ConsumerGroupDataAllOf) Redact() {
 	o.recurseRedact(&o.IsSimple)
 	o.recurseRedact(&o.PartitionAssignor)
 	o.recurseRedact(&o.State)
+	o.recurseRedact(&o.Type)
+	o.recurseRedact(&o.IsMixedConsumerGroup)
 	o.recurseRedact(&o.Coordinator)
-	o.recurseRedact(o.Consumer)
+	o.recurseRedact(&o.Consumers)
 	o.recurseRedact(&o.LagSummary)
 }
 
@@ -330,10 +377,16 @@ func (o ConsumerGroupDataAllOf) MarshalJSON() ([]byte, error) {
 		toSerialize["state"] = o.State
 	}
 	if true {
+		toSerialize["type"] = o.Type
+	}
+	if true {
+		toSerialize["is_mixed_consumer_group"] = o.IsMixedConsumerGroup
+	}
+	if true {
 		toSerialize["coordinator"] = o.Coordinator
 	}
-	if o.Consumer != nil {
-		toSerialize["consumer"] = o.Consumer
+	if true {
+		toSerialize["consumers"] = o.Consumers
 	}
 	if true {
 		toSerialize["lag_summary"] = o.LagSummary

--- a/kafkarest/v3/model_list_link_configs_response_data.go
+++ b/kafkarest/v3/model_list_link_configs_response_data.go
@@ -36,31 +36,33 @@ import (
 
 // ListLinkConfigsResponseData struct for ListLinkConfigsResponseData
 type ListLinkConfigsResponseData struct {
-	Kind      string           `json:"kind,omitempty"`
-	Metadata  ResourceMetadata `json:"metadata,omitempty"`
-	ClusterId string           `json:"cluster_id,omitempty"`
-	Name      string           `json:"name,omitempty"`
-	Value     string           `json:"value,omitempty"`
-	ReadOnly  bool             `json:"read_only,omitempty"`
-	Sensitive bool             `json:"sensitive,omitempty"`
-	Source    string           `json:"source,omitempty"`
-	Synonyms  []string         `json:"synonyms,omitempty"`
-	LinkName  string           `json:"link_name,omitempty"`
+	Kind        string           `json:"kind,omitempty"`
+	Metadata    ResourceMetadata `json:"metadata,omitempty"`
+	ClusterId   string           `json:"cluster_id,omitempty"`
+	Name        string           `json:"name,omitempty"`
+	Value       string           `json:"value,omitempty"`
+	IsDefault   bool             `json:"is_default,omitempty"`
+	IsReadOnly  bool             `json:"is_read_only,omitempty"`
+	IsSensitive bool             `json:"is_sensitive,omitempty"`
+	Source      string           `json:"source,omitempty"`
+	Synonyms    []string         `json:"synonyms,omitempty"`
+	LinkName    string           `json:"link_name,omitempty"`
 }
 
 // NewListLinkConfigsResponseData instantiates a new ListLinkConfigsResponseData object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewListLinkConfigsResponseData(kind string, metadata ResourceMetadata, clusterId string, name string, value string, readOnly bool, sensitive bool, source string, synonyms []string, linkName string) *ListLinkConfigsResponseData {
+func NewListLinkConfigsResponseData(kind string, metadata ResourceMetadata, clusterId string, name string, value string, isDefault bool, isReadOnly bool, isSensitive bool, source string, synonyms []string, linkName string) *ListLinkConfigsResponseData {
 	this := ListLinkConfigsResponseData{}
 	this.Kind = kind
 	this.Metadata = metadata
 	this.ClusterId = clusterId
 	this.Name = name
 	this.Value = value
-	this.ReadOnly = readOnly
-	this.Sensitive = sensitive
+	this.IsDefault = isDefault
+	this.IsReadOnly = isReadOnly
+	this.IsSensitive = isSensitive
 	this.Source = source
 	this.Synonyms = synonyms
 	this.LinkName = linkName
@@ -195,52 +197,76 @@ func (o *ListLinkConfigsResponseData) SetValue(v string) {
 	o.Value = v
 }
 
-// GetReadOnly returns the ReadOnly field value
-func (o *ListLinkConfigsResponseData) GetReadOnly() bool {
+// GetIsDefault returns the IsDefault field value
+func (o *ListLinkConfigsResponseData) GetIsDefault() bool {
 	if o == nil {
 		var ret bool
 		return ret
 	}
 
-	return o.ReadOnly
+	return o.IsDefault
 }
 
-// GetReadOnlyOk returns a tuple with the ReadOnly field value
+// GetIsDefaultOk returns a tuple with the IsDefault field value
 // and a boolean to check if the value has been set.
-func (o *ListLinkConfigsResponseData) GetReadOnlyOk() (*bool, bool) {
+func (o *ListLinkConfigsResponseData) GetIsDefaultOk() (*bool, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.ReadOnly, true
+	return &o.IsDefault, true
 }
 
-// SetReadOnly sets field value
-func (o *ListLinkConfigsResponseData) SetReadOnly(v bool) {
-	o.ReadOnly = v
+// SetIsDefault sets field value
+func (o *ListLinkConfigsResponseData) SetIsDefault(v bool) {
+	o.IsDefault = v
 }
 
-// GetSensitive returns the Sensitive field value
-func (o *ListLinkConfigsResponseData) GetSensitive() bool {
+// GetIsReadOnly returns the IsReadOnly field value
+func (o *ListLinkConfigsResponseData) GetIsReadOnly() bool {
 	if o == nil {
 		var ret bool
 		return ret
 	}
 
-	return o.Sensitive
+	return o.IsReadOnly
 }
 
-// GetSensitiveOk returns a tuple with the Sensitive field value
+// GetIsReadOnlyOk returns a tuple with the IsReadOnly field value
 // and a boolean to check if the value has been set.
-func (o *ListLinkConfigsResponseData) GetSensitiveOk() (*bool, bool) {
+func (o *ListLinkConfigsResponseData) GetIsReadOnlyOk() (*bool, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.Sensitive, true
+	return &o.IsReadOnly, true
 }
 
-// SetSensitive sets field value
-func (o *ListLinkConfigsResponseData) SetSensitive(v bool) {
-	o.Sensitive = v
+// SetIsReadOnly sets field value
+func (o *ListLinkConfigsResponseData) SetIsReadOnly(v bool) {
+	o.IsReadOnly = v
+}
+
+// GetIsSensitive returns the IsSensitive field value
+func (o *ListLinkConfigsResponseData) GetIsSensitive() bool {
+	if o == nil {
+		var ret bool
+		return ret
+	}
+
+	return o.IsSensitive
+}
+
+// GetIsSensitiveOk returns a tuple with the IsSensitive field value
+// and a boolean to check if the value has been set.
+func (o *ListLinkConfigsResponseData) GetIsSensitiveOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.IsSensitive, true
+}
+
+// SetIsSensitive sets field value
+func (o *ListLinkConfigsResponseData) SetIsSensitive(v bool) {
+	o.IsSensitive = v
 }
 
 // GetSource returns the Source field value
@@ -322,8 +348,9 @@ func (o *ListLinkConfigsResponseData) Redact() {
 	o.recurseRedact(&o.ClusterId)
 	o.recurseRedact(&o.Name)
 	o.recurseRedact(&o.Value)
-	o.recurseRedact(&o.ReadOnly)
-	o.recurseRedact(&o.Sensitive)
+	o.recurseRedact(&o.IsDefault)
+	o.recurseRedact(&o.IsReadOnly)
+	o.recurseRedact(&o.IsSensitive)
 	o.recurseRedact(&o.Source)
 	o.recurseRedact(&o.Synonyms)
 	o.recurseRedact(&o.LinkName)
@@ -377,10 +404,13 @@ func (o ListLinkConfigsResponseData) MarshalJSON() ([]byte, error) {
 		toSerialize["value"] = o.Value
 	}
 	if true {
-		toSerialize["read_only"] = o.ReadOnly
+		toSerialize["is_default"] = o.IsDefault
 	}
 	if true {
-		toSerialize["sensitive"] = o.Sensitive
+		toSerialize["is_read_only"] = o.IsReadOnly
+	}
+	if true {
+		toSerialize["is_sensitive"] = o.IsSensitive
 	}
 	if true {
 		toSerialize["source"] = o.Source

--- a/kafkarest/v3/model_list_link_configs_response_data_all_of.go
+++ b/kafkarest/v3/model_list_link_configs_response_data_all_of.go
@@ -36,27 +36,29 @@ import (
 
 // ListLinkConfigsResponseDataAllOf struct for ListLinkConfigsResponseDataAllOf
 type ListLinkConfigsResponseDataAllOf struct {
-	ClusterId string   `json:"cluster_id,omitempty"`
-	Name      string   `json:"name,omitempty"`
-	Value     string   `json:"value,omitempty"`
-	ReadOnly  bool     `json:"read_only,omitempty"`
-	Sensitive bool     `json:"sensitive,omitempty"`
-	Source    string   `json:"source,omitempty"`
-	Synonyms  []string `json:"synonyms,omitempty"`
-	LinkName  string   `json:"link_name,omitempty"`
+	ClusterId   string   `json:"cluster_id,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Value       string   `json:"value,omitempty"`
+	IsDefault   bool     `json:"is_default,omitempty"`
+	IsReadOnly  bool     `json:"is_read_only,omitempty"`
+	IsSensitive bool     `json:"is_sensitive,omitempty"`
+	Source      string   `json:"source,omitempty"`
+	Synonyms    []string `json:"synonyms,omitempty"`
+	LinkName    string   `json:"link_name,omitempty"`
 }
 
 // NewListLinkConfigsResponseDataAllOf instantiates a new ListLinkConfigsResponseDataAllOf object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewListLinkConfigsResponseDataAllOf(clusterId string, name string, value string, readOnly bool, sensitive bool, source string, synonyms []string, linkName string) *ListLinkConfigsResponseDataAllOf {
+func NewListLinkConfigsResponseDataAllOf(clusterId string, name string, value string, isDefault bool, isReadOnly bool, isSensitive bool, source string, synonyms []string, linkName string) *ListLinkConfigsResponseDataAllOf {
 	this := ListLinkConfigsResponseDataAllOf{}
 	this.ClusterId = clusterId
 	this.Name = name
 	this.Value = value
-	this.ReadOnly = readOnly
-	this.Sensitive = sensitive
+	this.IsDefault = isDefault
+	this.IsReadOnly = isReadOnly
+	this.IsSensitive = isSensitive
 	this.Source = source
 	this.Synonyms = synonyms
 	this.LinkName = linkName
@@ -143,52 +145,76 @@ func (o *ListLinkConfigsResponseDataAllOf) SetValue(v string) {
 	o.Value = v
 }
 
-// GetReadOnly returns the ReadOnly field value
-func (o *ListLinkConfigsResponseDataAllOf) GetReadOnly() bool {
+// GetIsDefault returns the IsDefault field value
+func (o *ListLinkConfigsResponseDataAllOf) GetIsDefault() bool {
 	if o == nil {
 		var ret bool
 		return ret
 	}
 
-	return o.ReadOnly
+	return o.IsDefault
 }
 
-// GetReadOnlyOk returns a tuple with the ReadOnly field value
+// GetIsDefaultOk returns a tuple with the IsDefault field value
 // and a boolean to check if the value has been set.
-func (o *ListLinkConfigsResponseDataAllOf) GetReadOnlyOk() (*bool, bool) {
+func (o *ListLinkConfigsResponseDataAllOf) GetIsDefaultOk() (*bool, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.ReadOnly, true
+	return &o.IsDefault, true
 }
 
-// SetReadOnly sets field value
-func (o *ListLinkConfigsResponseDataAllOf) SetReadOnly(v bool) {
-	o.ReadOnly = v
+// SetIsDefault sets field value
+func (o *ListLinkConfigsResponseDataAllOf) SetIsDefault(v bool) {
+	o.IsDefault = v
 }
 
-// GetSensitive returns the Sensitive field value
-func (o *ListLinkConfigsResponseDataAllOf) GetSensitive() bool {
+// GetIsReadOnly returns the IsReadOnly field value
+func (o *ListLinkConfigsResponseDataAllOf) GetIsReadOnly() bool {
 	if o == nil {
 		var ret bool
 		return ret
 	}
 
-	return o.Sensitive
+	return o.IsReadOnly
 }
 
-// GetSensitiveOk returns a tuple with the Sensitive field value
+// GetIsReadOnlyOk returns a tuple with the IsReadOnly field value
 // and a boolean to check if the value has been set.
-func (o *ListLinkConfigsResponseDataAllOf) GetSensitiveOk() (*bool, bool) {
+func (o *ListLinkConfigsResponseDataAllOf) GetIsReadOnlyOk() (*bool, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.Sensitive, true
+	return &o.IsReadOnly, true
 }
 
-// SetSensitive sets field value
-func (o *ListLinkConfigsResponseDataAllOf) SetSensitive(v bool) {
-	o.Sensitive = v
+// SetIsReadOnly sets field value
+func (o *ListLinkConfigsResponseDataAllOf) SetIsReadOnly(v bool) {
+	o.IsReadOnly = v
+}
+
+// GetIsSensitive returns the IsSensitive field value
+func (o *ListLinkConfigsResponseDataAllOf) GetIsSensitive() bool {
+	if o == nil {
+		var ret bool
+		return ret
+	}
+
+	return o.IsSensitive
+}
+
+// GetIsSensitiveOk returns a tuple with the IsSensitive field value
+// and a boolean to check if the value has been set.
+func (o *ListLinkConfigsResponseDataAllOf) GetIsSensitiveOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.IsSensitive, true
+}
+
+// SetIsSensitive sets field value
+func (o *ListLinkConfigsResponseDataAllOf) SetIsSensitive(v bool) {
+	o.IsSensitive = v
 }
 
 // GetSource returns the Source field value
@@ -268,8 +294,9 @@ func (o *ListLinkConfigsResponseDataAllOf) Redact() {
 	o.recurseRedact(&o.ClusterId)
 	o.recurseRedact(&o.Name)
 	o.recurseRedact(&o.Value)
-	o.recurseRedact(&o.ReadOnly)
-	o.recurseRedact(&o.Sensitive)
+	o.recurseRedact(&o.IsDefault)
+	o.recurseRedact(&o.IsReadOnly)
+	o.recurseRedact(&o.IsSensitive)
 	o.recurseRedact(&o.Source)
 	o.recurseRedact(&o.Synonyms)
 	o.recurseRedact(&o.LinkName)
@@ -317,10 +344,13 @@ func (o ListLinkConfigsResponseDataAllOf) MarshalJSON() ([]byte, error) {
 		toSerialize["value"] = o.Value
 	}
 	if true {
-		toSerialize["read_only"] = o.ReadOnly
+		toSerialize["is_default"] = o.IsDefault
 	}
 	if true {
-		toSerialize["sensitive"] = o.Sensitive
+		toSerialize["is_read_only"] = o.IsReadOnly
+	}
+	if true {
+		toSerialize["is_sensitive"] = o.IsSensitive
 	}
 	if true {
 		toSerialize["source"] = o.Source


### PR DESCRIPTION
**What**:
Update kafka rest SDK

**Test**:
```
>go vet -v
internal/profilerecord
internal/godebugs
internal/asan
internal/coverage/rtcov
internal/race
internal/byteorder
unicode/utf8
unicode
internal/goos
internal/unsafeheader
internal/goexperiment
runtime/internal/math
internal/itoa
internal/msan
runtime/internal/sys
cmp
encoding
math/bits
unicode/utf16
crypto/internal/alias
vendor/golang.org/x/crypto/cryptobyte/asn1
internal/nettrace
container/list
vendor/golang.org/x/crypto/internal/alias
log/internal
crypto/internal/boring/sig
internal/chacha8rand
internal/cpu
sync/atomic
crypto/subtle
internal/abi
math
internal/runtime/atomic
internal/bytealg
internal/runtime/exithook
internal/stringslite
runtime
iter
internal/weak
internal/reflectlite
sync
maps
slices
internal/bisect
internal/singleflight
internal/testlog
errors
sort
internal/godebug
internal/oserror
path
vendor/golang.org/x/net/dns/dnsmessage
io
crypto/internal/edwards25519/field
math/rand/v2
strconv
crypto/internal/nistec/fiat
math/rand
syscall
internal/concurrent
hash
crypto/internal/randutil
bytes
strings
unique
crypto/rc4
reflect
crypto/internal/edwards25519
crypto
hash/crc32
crypto/md5
net/netip
vendor/golang.org/x/text/transform
crypto/cipher
bufio
net/http/internal/ascii
regexp/syntax
crypto/internal/boring
crypto/des
crypto/hmac
crypto/sha1
crypto/sha256
crypto/aes
crypto/sha512
vendor/golang.org/x/crypto/hkdf
internal/syscall/execenv
regexp
time
internal/syscall/unix
context
crypto/x509/internal/macos
io/fs
internal/poll
internal/fmtsort
encoding/binary
embed
internal/filepathlite
crypto/internal/nistec
encoding/base64
vendor/golang.org/x/crypto/chacha20
vendor/golang.org/x/crypto/internal/poly1305
os
encoding/pem
vendor/golang.org/x/crypto/chacha20poly1305
crypto/ecdh
io/ioutil
path/filepath
fmt
vendor/golang.org/x/sys/cpu
vendor/golang.org/x/net/route
vendor/golang.org/x/crypto/sha3
net
log
encoding/hex
net/http/internal
net/url
mime/quotedprintable
encoding/xml
vendor/golang.org/x/net/http2/hpack
compress/flate
mime
encoding/json
vendor/golang.org/x/text/unicode/norm
math/big
vendor/golang.org/x/text/unicode/bidi
compress/gzip
vendor/golang.org/x/text/secure/bidirule
vendor/golang.org/x/net/idna
crypto/dsa
crypto/internal/boring/bbig
crypto/internal/bigmod
encoding/asn1
crypto/elliptic
crypto/rand
crypto/internal/hpke
crypto/ed25519
crypto/internal/mlkem768
net/textproto
vendor/golang.org/x/net/http/httpproxy
crypto/rsa
crypto/x509/pkix
vendor/golang.org/x/crypto/cryptobyte
vendor/golang.org/x/net/http/httpguts
mime/multipart
crypto/ecdsa
crypto/x509
crypto/tls
net/http/httptrace
net/http
golang.org/x/net/context/ctxhttp
net/http/httputil
golang.org/x/oauth2/internal
golang.org/x/oauth2
github.com/confluentinc/ccloud-sdk-go-v2/kafkarest/v3
```