### PR TITLE
Tableflow: Update SDK to align with latest API Specs.

### DIFF
--- a/tableflow/v1/api/openapi.yaml
+++ b/tableflow/v1/api/openapi.yaml
@@ -989,13 +989,13 @@ paths:
             --url https://api.confluent.cloud/tableflow/v1/tableflow-topics \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
             --header 'content-type: application/json' \
-            --data '{"spec":{"display_name":"topic_1","suspended":false,"config":{"retention_ms":"7776000000","record_failure_strategy":"SUSPEND","error_handling":{"mode":"SUSPEND"}},"storage":{"kind":"ByobAws","bucket_name":"bucket_1","provider_integration_id":"cspi-stgce89r7"},"table_formats":["DELTA"],"environment":{"id":"env-00000"},"kafka_cluster":{"id":"lkc-00000","environment":"string"}}}'
+            --data '{"spec":{"display_name":"topic_1","suspended":false,"config":{"retention_ms":"7776000000","data_retention_ms":"2592000000","record_failure_strategy":"SUSPEND","error_handling":{"mode":"SUSPEND"}},"storage":{"kind":"ByobAws","bucket_name":"bucket_1","provider_integration_id":"cspi-stgce89r7"},"table_formats":["DELTA"],"environment":{"id":"env-00000"},"kafka_cluster":{"id":"lkc-00000","environment":"string"}}}'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           MediaType mediaType = MediaType.parse("application/json");
-          RequestBody body = RequestBody.create(mediaType, "{\"spec\":{\"display_name\":\"topic_1\",\"suspended\":false,\"config\":{\"retention_ms\":\"7776000000\",\"record_failure_strategy\":\"SUSPEND\",\"error_handling\":{\"mode\":\"SUSPEND\"}},\"storage\":{\"kind\":\"ByobAws\",\"bucket_name\":\"bucket_1\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"table_formats\":[\"DELTA\"],\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\",\"environment\":\"string\"}}}");
+          RequestBody body = RequestBody.create(mediaType, "{\"spec\":{\"display_name\":\"topic_1\",\"suspended\":false,\"config\":{\"retention_ms\":\"7776000000\",\"data_retention_ms\":\"2592000000\",\"record_failure_strategy\":\"SUSPEND\",\"error_handling\":{\"mode\":\"SUSPEND\"}},\"storage\":{\"kind\":\"ByobAws\",\"bucket_name\":\"bucket_1\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"table_formats\":[\"DELTA\"],\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\",\"environment\":\"string\"}}}");
           Request request = new Request.Builder()
             .url("https://api.confluent.cloud/tableflow/v1/tableflow-topics")
             .post(body)
@@ -1009,10 +1009,11 @@ paths:
           \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/tableflow/v1/tableflow-topics\"\
           \n\n\tpayload := strings.NewReader(\"{\\\"spec\\\":{\\\"display_name\\\"\
           :\\\"topic_1\\\",\\\"suspended\\\":false,\\\"config\\\":{\\\"retention_ms\\\
-          \":\\\"7776000000\\\",\\\"record_failure_strategy\\\":\\\"SUSPEND\\\",\\\
-          \"error_handling\\\":{\\\"mode\\\":\\\"SUSPEND\\\"}},\\\"storage\\\":{\\\
-          \"kind\\\":\\\"ByobAws\\\",\\\"bucket_name\\\":\\\"bucket_1\\\",\\\"provider_integration_id\\\
-          \":\\\"cspi-stgce89r7\\\"},\\\"table_formats\\\":[\\\"DELTA\\\"],\\\"environment\\\
+          \":\\\"7776000000\\\",\\\"data_retention_ms\\\":\\\"2592000000\\\",\\\"\
+          record_failure_strategy\\\":\\\"SUSPEND\\\",\\\"error_handling\\\":{\\\"\
+          mode\\\":\\\"SUSPEND\\\"}},\\\"storage\\\":{\\\"kind\\\":\\\"ByobAws\\\"\
+          ,\\\"bucket_name\\\":\\\"bucket_1\\\",\\\"provider_integration_id\\\":\\\
+          \"cspi-stgce89r7\\\"},\\\"table_formats\\\":[\\\"DELTA\\\"],\\\"environment\\\
           \":{\\\"id\\\":\\\"env-00000\\\"},\\\"kafka_cluster\\\":{\\\"id\\\":\\\"\
           lkc-00000\\\",\\\"environment\\\":\\\"string\\\"}}}\")\n\n\treq, _ := http.NewRequest(\"\
           POST\", url, payload)\n\n\treq.Header.Add(\"content-type\", \"application/json\"\
@@ -1026,7 +1027,7 @@ paths:
 
           conn = http.client.HTTPSConnection("api.confluent.cloud")
 
-          payload = "{\"spec\":{\"display_name\":\"topic_1\",\"suspended\":false,\"config\":{\"retention_ms\":\"7776000000\",\"record_failure_strategy\":\"SUSPEND\",\"error_handling\":{\"mode\":\"SUSPEND\"}},\"storage\":{\"kind\":\"ByobAws\",\"bucket_name\":\"bucket_1\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"table_formats\":[\"DELTA\"],\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\",\"environment\":\"string\"}}}"
+          payload = "{\"spec\":{\"display_name\":\"topic_1\",\"suspended\":false,\"config\":{\"retention_ms\":\"7776000000\",\"data_retention_ms\":\"2592000000\",\"record_failure_strategy\":\"SUSPEND\",\"error_handling\":{\"mode\":\"SUSPEND\"}},\"storage\":{\"kind\":\"ByobAws\",\"bucket_name\":\"bucket_1\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"table_formats\":[\"DELTA\"],\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\",\"environment\":\"string\"}}}"
 
           headers = {
               'content-type': "application/json",
@@ -1073,6 +1074,7 @@ paths:
               suspended: false,
               config: {
                 retention_ms: '7776000000',
+                data_retention_ms: '2592000000',
                 record_failure_strategy: 'SUSPEND',
                 error_handling: {mode: 'SUSPEND'}
               },
@@ -1099,7 +1101,7 @@ paths:
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"spec\":{\"display_name\":\"topic_1\",\"suspended\":false,\"config\":{\"retention_ms\":\"7776000000\",\"record_failure_strategy\":\"SUSPEND\",\"error_handling\":{\"mode\":\"SUSPEND\"}},\"storage\":{\"kind\":\"ByobAws\",\"bucket_name\":\"bucket_1\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"table_formats\":[\"DELTA\"],\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\",\"environment\":\"string\"}}}");
+          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"spec\":{\"display_name\":\"topic_1\",\"suspended\":false,\"config\":{\"retention_ms\":\"7776000000\",\"data_retention_ms\":\"2592000000\",\"record_failure_strategy\":\"SUSPEND\",\"error_handling\":{\"mode\":\"SUSPEND\"}},\"storage\":{\"kind\":\"ByobAws\",\"bucket_name\":\"bucket_1\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"table_formats\":[\"DELTA\"],\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\",\"environment\":\"string\"}}}");
 
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
@@ -1108,7 +1110,7 @@ paths:
           var request = new RestRequest(Method.POST);
           request.AddHeader("content-type", "application/json");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("application/json", "{\"spec\":{\"display_name\":\"topic_1\",\"suspended\":false,\"config\":{\"retention_ms\":\"7776000000\",\"record_failure_strategy\":\"SUSPEND\",\"error_handling\":{\"mode\":\"SUSPEND\"}},\"storage\":{\"kind\":\"ByobAws\",\"bucket_name\":\"bucket_1\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"table_formats\":[\"DELTA\"],\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\",\"environment\":\"string\"}}}", ParameterType.RequestBody);
+          request.AddParameter("application/json", "{\"spec\":{\"display_name\":\"topic_1\",\"suspended\":false,\"config\":{\"retention_ms\":\"7776000000\",\"data_retention_ms\":\"2592000000\",\"record_failure_strategy\":\"SUSPEND\",\"error_handling\":{\"mode\":\"SUSPEND\"}},\"storage\":{\"kind\":\"ByobAws\",\"bucket_name\":\"bucket_1\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"table_formats\":[\"DELTA\"],\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\",\"environment\":\"string\"}}}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /tableflow/v1/tableflow-topics/{display_name}:
     delete:
@@ -2080,13 +2082,13 @@ paths:
             --url 'https://api.confluent.cloud/tableflow/v1/tableflow-topics/{display_name}' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
             --header 'content-type: application/json' \
-            --data '{"spec":{"display_name":"topic_1","suspended":false,"config":{"retention_ms":"7776000000","record_failure_strategy":"SUSPEND","error_handling":{"mode":"SUSPEND"}},"storage":{"kind":"ByobAws","bucket_name":"bucket_1","provider_integration_id":"cspi-stgce89r7"},"table_formats":["DELTA"],"environment":{"id":"env-00000"},"kafka_cluster":{"id":"string","environment":"string"}}}'
+            --data '{"spec":{"display_name":"topic_1","suspended":false,"config":{"retention_ms":"7776000000","data_retention_ms":"2592000000","record_failure_strategy":"SUSPEND","error_handling":{"mode":"SUSPEND"}},"storage":{"kind":"ByobAws","bucket_name":"bucket_1","provider_integration_id":"cspi-stgce89r7"},"table_formats":["DELTA"],"environment":{"id":"env-00000"},"kafka_cluster":{"id":"string","environment":"string"}}}'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           MediaType mediaType = MediaType.parse("application/json");
-          RequestBody body = RequestBody.create(mediaType, "{\"spec\":{\"display_name\":\"topic_1\",\"suspended\":false,\"config\":{\"retention_ms\":\"7776000000\",\"record_failure_strategy\":\"SUSPEND\",\"error_handling\":{\"mode\":\"SUSPEND\"}},\"storage\":{\"kind\":\"ByobAws\",\"bucket_name\":\"bucket_1\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"table_formats\":[\"DELTA\"],\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"string\",\"environment\":\"string\"}}}");
+          RequestBody body = RequestBody.create(mediaType, "{\"spec\":{\"display_name\":\"topic_1\",\"suspended\":false,\"config\":{\"retention_ms\":\"7776000000\",\"data_retention_ms\":\"2592000000\",\"record_failure_strategy\":\"SUSPEND\",\"error_handling\":{\"mode\":\"SUSPEND\"}},\"storage\":{\"kind\":\"ByobAws\",\"bucket_name\":\"bucket_1\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"table_formats\":[\"DELTA\"],\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"string\",\"environment\":\"string\"}}}");
           Request request = new Request.Builder()
             .url("https://api.confluent.cloud/tableflow/v1/tableflow-topics/{display_name}")
             .patch(body)
@@ -2100,10 +2102,11 @@ paths:
           \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/tableflow/v1/tableflow-topics/{display_name}\"\
           \n\n\tpayload := strings.NewReader(\"{\\\"spec\\\":{\\\"display_name\\\"\
           :\\\"topic_1\\\",\\\"suspended\\\":false,\\\"config\\\":{\\\"retention_ms\\\
-          \":\\\"7776000000\\\",\\\"record_failure_strategy\\\":\\\"SUSPEND\\\",\\\
-          \"error_handling\\\":{\\\"mode\\\":\\\"SUSPEND\\\"}},\\\"storage\\\":{\\\
-          \"kind\\\":\\\"ByobAws\\\",\\\"bucket_name\\\":\\\"bucket_1\\\",\\\"provider_integration_id\\\
-          \":\\\"cspi-stgce89r7\\\"},\\\"table_formats\\\":[\\\"DELTA\\\"],\\\"environment\\\
+          \":\\\"7776000000\\\",\\\"data_retention_ms\\\":\\\"2592000000\\\",\\\"\
+          record_failure_strategy\\\":\\\"SUSPEND\\\",\\\"error_handling\\\":{\\\"\
+          mode\\\":\\\"SUSPEND\\\"}},\\\"storage\\\":{\\\"kind\\\":\\\"ByobAws\\\"\
+          ,\\\"bucket_name\\\":\\\"bucket_1\\\",\\\"provider_integration_id\\\":\\\
+          \"cspi-stgce89r7\\\"},\\\"table_formats\\\":[\\\"DELTA\\\"],\\\"environment\\\
           \":{\\\"id\\\":\\\"env-00000\\\"},\\\"kafka_cluster\\\":{\\\"id\\\":\\\"\
           string\\\",\\\"environment\\\":\\\"string\\\"}}}\")\n\n\treq, _ := http.NewRequest(\"\
           PATCH\", url, payload)\n\n\treq.Header.Add(\"content-type\", \"application/json\"\
@@ -2117,7 +2120,7 @@ paths:
 
           conn = http.client.HTTPSConnection("api.confluent.cloud")
 
-          payload = "{\"spec\":{\"display_name\":\"topic_1\",\"suspended\":false,\"config\":{\"retention_ms\":\"7776000000\",\"record_failure_strategy\":\"SUSPEND\",\"error_handling\":{\"mode\":\"SUSPEND\"}},\"storage\":{\"kind\":\"ByobAws\",\"bucket_name\":\"bucket_1\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"table_formats\":[\"DELTA\"],\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"string\",\"environment\":\"string\"}}}"
+          payload = "{\"spec\":{\"display_name\":\"topic_1\",\"suspended\":false,\"config\":{\"retention_ms\":\"7776000000\",\"data_retention_ms\":\"2592000000\",\"record_failure_strategy\":\"SUSPEND\",\"error_handling\":{\"mode\":\"SUSPEND\"}},\"storage\":{\"kind\":\"ByobAws\",\"bucket_name\":\"bucket_1\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"table_formats\":[\"DELTA\"],\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"string\",\"environment\":\"string\"}}}"
 
           headers = {
               'content-type': "application/json",
@@ -2164,6 +2167,7 @@ paths:
               suspended: false,
               config: {
                 retention_ms: '7776000000',
+                data_retention_ms: '2592000000',
                 record_failure_strategy: 'SUSPEND',
                 error_handling: {mode: 'SUSPEND'}
               },
@@ -2190,7 +2194,7 @@ paths:
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"spec\":{\"display_name\":\"topic_1\",\"suspended\":false,\"config\":{\"retention_ms\":\"7776000000\",\"record_failure_strategy\":\"SUSPEND\",\"error_handling\":{\"mode\":\"SUSPEND\"}},\"storage\":{\"kind\":\"ByobAws\",\"bucket_name\":\"bucket_1\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"table_formats\":[\"DELTA\"],\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"string\",\"environment\":\"string\"}}}");
+          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"spec\":{\"display_name\":\"topic_1\",\"suspended\":false,\"config\":{\"retention_ms\":\"7776000000\",\"data_retention_ms\":\"2592000000\",\"record_failure_strategy\":\"SUSPEND\",\"error_handling\":{\"mode\":\"SUSPEND\"}},\"storage\":{\"kind\":\"ByobAws\",\"bucket_name\":\"bucket_1\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"table_formats\":[\"DELTA\"],\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"string\",\"environment\":\"string\"}}}");
 
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
@@ -2199,7 +2203,7 @@ paths:
           var request = new RestRequest(Method.PATCH);
           request.AddHeader("content-type", "application/json");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("application/json", "{\"spec\":{\"display_name\":\"topic_1\",\"suspended\":false,\"config\":{\"retention_ms\":\"7776000000\",\"record_failure_strategy\":\"SUSPEND\",\"error_handling\":{\"mode\":\"SUSPEND\"}},\"storage\":{\"kind\":\"ByobAws\",\"bucket_name\":\"bucket_1\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"table_formats\":[\"DELTA\"],\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"string\",\"environment\":\"string\"}}}", ParameterType.RequestBody);
+          request.AddParameter("application/json", "{\"spec\":{\"display_name\":\"topic_1\",\"suspended\":false,\"config\":{\"retention_ms\":\"7776000000\",\"data_retention_ms\":\"2592000000\",\"record_failure_strategy\":\"SUSPEND\",\"error_handling\":{\"mode\":\"SUSPEND\"}},\"storage\":{\"kind\":\"ByobAws\",\"bucket_name\":\"bucket_1\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"table_formats\":[\"DELTA\"],\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"string\",\"environment\":\"string\"}}}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /tableflow/v1/catalog-integrations:
     get:
@@ -2834,13 +2838,13 @@ paths:
             --url https://api.confluent.cloud/tableflow/v1/catalog-integrations \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
             --header 'content-type: application/json' \
-            --data '{"spec":{"display_name":"catalog_integration_1","suspended":false,"config":{"kind":"AwsGlue","provider_integration_id":"cspi-stgce89r7"},"environment":{"id":"env-00000"},"kafka_cluster":{"id":"lkc-00000","environment":"string"}}}'
+            --data '{"spec":{"display_name":"catalog_integration_1","suspended":false,"config":{"kind":"AwsGlue","provider_integration_id":"cspi-stgce89r7","custom_database":"string"},"environment":{"id":"env-00000"},"kafka_cluster":{"id":"lkc-00000","environment":"string"}}}'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           MediaType mediaType = MediaType.parse("application/json");
-          RequestBody body = RequestBody.create(mediaType, "{\"spec\":{\"display_name\":\"catalog_integration_1\",\"suspended\":false,\"config\":{\"kind\":\"AwsGlue\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\",\"environment\":\"string\"}}}");
+          RequestBody body = RequestBody.create(mediaType, "{\"spec\":{\"display_name\":\"catalog_integration_1\",\"suspended\":false,\"config\":{\"kind\":\"AwsGlue\",\"provider_integration_id\":\"cspi-stgce89r7\",\"custom_database\":\"string\"},\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\",\"environment\":\"string\"}}}");
           Request request = new Request.Builder()
             .url("https://api.confluent.cloud/tableflow/v1/catalog-integrations")
             .post(body)
@@ -2855,20 +2859,21 @@ paths:
           \n\n\tpayload := strings.NewReader(\"{\\\"spec\\\":{\\\"display_name\\\"\
           :\\\"catalog_integration_1\\\",\\\"suspended\\\":false,\\\"config\\\":{\\\
           \"kind\\\":\\\"AwsGlue\\\",\\\"provider_integration_id\\\":\\\"cspi-stgce89r7\\\
-          \"},\\\"environment\\\":{\\\"id\\\":\\\"env-00000\\\"},\\\"kafka_cluster\\\
-          \":{\\\"id\\\":\\\"lkc-00000\\\",\\\"environment\\\":\\\"string\\\"}}}\"\
-          )\n\n\treq, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"\
-          content-type\", \"application/json\")\n\treq.Header.Add(\"Authorization\"\
-          , \"Basic REPLACE_BASIC_AUTH\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\
-          \n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\t\
-          fmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+          \",\\\"custom_database\\\":\\\"string\\\"},\\\"environment\\\":{\\\"id\\\
+          \":\\\"env-00000\\\"},\\\"kafka_cluster\\\":{\\\"id\\\":\\\"lkc-00000\\\"\
+          ,\\\"environment\\\":\\\"string\\\"}}}\")\n\n\treq, _ := http.NewRequest(\"\
+          POST\", url, payload)\n\n\treq.Header.Add(\"content-type\", \"application/json\"\
+          )\n\treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\
+          \tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody,\
+          \ _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
+          \n}"
       - lang: Python
         source: |-
           import http.client
 
           conn = http.client.HTTPSConnection("api.confluent.cloud")
 
-          payload = "{\"spec\":{\"display_name\":\"catalog_integration_1\",\"suspended\":false,\"config\":{\"kind\":\"AwsGlue\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\",\"environment\":\"string\"}}}"
+          payload = "{\"spec\":{\"display_name\":\"catalog_integration_1\",\"suspended\":false,\"config\":{\"kind\":\"AwsGlue\",\"provider_integration_id\":\"cspi-stgce89r7\",\"custom_database\":\"string\"},\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\",\"environment\":\"string\"}}}"
 
           headers = {
               'content-type': "application/json",
@@ -2913,7 +2918,11 @@ paths:
             spec: {
               display_name: 'catalog_integration_1',
               suspended: false,
-              config: {kind: 'AwsGlue', provider_integration_id: 'cspi-stgce89r7'},
+              config: {
+                kind: 'AwsGlue',
+                provider_integration_id: 'cspi-stgce89r7',
+                custom_database: 'string'
+              },
               environment: {id: 'env-00000'},
               kafka_cluster: {id: 'lkc-00000', environment: 'string'}
             }
@@ -2931,7 +2940,7 @@ paths:
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"spec\":{\"display_name\":\"catalog_integration_1\",\"suspended\":false,\"config\":{\"kind\":\"AwsGlue\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\",\"environment\":\"string\"}}}");
+          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"spec\":{\"display_name\":\"catalog_integration_1\",\"suspended\":false,\"config\":{\"kind\":\"AwsGlue\",\"provider_integration_id\":\"cspi-stgce89r7\",\"custom_database\":\"string\"},\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\",\"environment\":\"string\"}}}");
 
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
@@ -2940,7 +2949,7 @@ paths:
           var request = new RestRequest(Method.POST);
           request.AddHeader("content-type", "application/json");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("application/json", "{\"spec\":{\"display_name\":\"catalog_integration_1\",\"suspended\":false,\"config\":{\"kind\":\"AwsGlue\",\"provider_integration_id\":\"cspi-stgce89r7\"},\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\",\"environment\":\"string\"}}}", ParameterType.RequestBody);
+          request.AddParameter("application/json", "{\"spec\":{\"display_name\":\"catalog_integration_1\",\"suspended\":false,\"config\":{\"kind\":\"AwsGlue\",\"provider_integration_id\":\"cspi-stgce89r7\",\"custom_database\":\"string\"},\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\",\"environment\":\"string\"}}}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
   /tableflow/v1/catalog-integrations/{id}:
     delete:
@@ -3899,13 +3908,13 @@ paths:
             --url 'https://api.confluent.cloud/tableflow/v1/catalog-integrations/{id}' \
             --header 'Authorization: Basic REPLACE_BASIC_AUTH' \
             --header 'content-type: application/json' \
-            --data '{"spec":{"display_name":"catalog_integration_1","suspended":false,"config":{"kind":"AwsGlue"},"environment":{"id":"env-00000"},"kafka_cluster":{"id":"lkc-00000"}}}'
+            --data '{"spec":{"display_name":"catalog_integration_1","suspended":false,"config":{"kind":"AwsGlue","custom_database":"string"},"environment":{"id":"env-00000"},"kafka_cluster":{"id":"lkc-00000"}}}'
       - lang: Java
         source: |-
           OkHttpClient client = new OkHttpClient();
 
           MediaType mediaType = MediaType.parse("application/json");
-          RequestBody body = RequestBody.create(mediaType, "{\"spec\":{\"display_name\":\"catalog_integration_1\",\"suspended\":false,\"config\":{\"kind\":\"AwsGlue\"},\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\"}}}");
+          RequestBody body = RequestBody.create(mediaType, "{\"spec\":{\"display_name\":\"catalog_integration_1\",\"suspended\":false,\"config\":{\"kind\":\"AwsGlue\",\"custom_database\":\"string\"},\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\"}}}");
           Request request = new Request.Builder()
             .url("https://api.confluent.cloud/tableflow/v1/catalog-integrations/{id}")
             .patch(body)
@@ -3919,12 +3928,13 @@ paths:
           \n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://api.confluent.cloud/tableflow/v1/catalog-integrations/{id}\"\
           \n\n\tpayload := strings.NewReader(\"{\\\"spec\\\":{\\\"display_name\\\"\
           :\\\"catalog_integration_1\\\",\\\"suspended\\\":false,\\\"config\\\":{\\\
-          \"kind\\\":\\\"AwsGlue\\\"},\\\"environment\\\":{\\\"id\\\":\\\"env-00000\\\
-          \"},\\\"kafka_cluster\\\":{\\\"id\\\":\\\"lkc-00000\\\"}}}\")\n\n\treq,\
-          \ _ := http.NewRequest(\"PATCH\", url, payload)\n\n\treq.Header.Add(\"content-type\"\
-          , \"application/json\")\n\treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\"\
-          )\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\
-          \tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
+          \"kind\\\":\\\"AwsGlue\\\",\\\"custom_database\\\":\\\"string\\\"},\\\"\
+          environment\\\":{\\\"id\\\":\\\"env-00000\\\"},\\\"kafka_cluster\\\":{\\\
+          \"id\\\":\\\"lkc-00000\\\"}}}\")\n\n\treq, _ := http.NewRequest(\"PATCH\"\
+          , url, payload)\n\n\treq.Header.Add(\"content-type\", \"application/json\"\
+          )\n\treq.Header.Add(\"Authorization\", \"Basic REPLACE_BASIC_AUTH\")\n\n\
+          \tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody,\
+          \ _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\
           \n}"
       - lang: Python
         source: |-
@@ -3932,7 +3942,7 @@ paths:
 
           conn = http.client.HTTPSConnection("api.confluent.cloud")
 
-          payload = "{\"spec\":{\"display_name\":\"catalog_integration_1\",\"suspended\":false,\"config\":{\"kind\":\"AwsGlue\"},\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\"}}}"
+          payload = "{\"spec\":{\"display_name\":\"catalog_integration_1\",\"suspended\":false,\"config\":{\"kind\":\"AwsGlue\",\"custom_database\":\"string\"},\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\"}}}"
 
           headers = {
               'content-type': "application/json",
@@ -3977,7 +3987,7 @@ paths:
             spec: {
               display_name: 'catalog_integration_1',
               suspended: false,
-              config: {kind: 'AwsGlue'},
+              config: {kind: 'AwsGlue', custom_database: 'string'},
               environment: {id: 'env-00000'},
               kafka_cluster: {id: 'lkc-00000'}
             }
@@ -3995,7 +4005,7 @@ paths:
           headers = curl_slist_append(headers, "Authorization: Basic REPLACE_BASIC_AUTH");
           curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"spec\":{\"display_name\":\"catalog_integration_1\",\"suspended\":false,\"config\":{\"kind\":\"AwsGlue\"},\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\"}}}");
+          curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\"spec\":{\"display_name\":\"catalog_integration_1\",\"suspended\":false,\"config\":{\"kind\":\"AwsGlue\",\"custom_database\":\"string\"},\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\"}}}");
 
           CURLcode ret = curl_easy_perform(hnd);
       - lang: C#
@@ -4004,7 +4014,7 @@ paths:
           var request = new RestRequest(Method.PATCH);
           request.AddHeader("content-type", "application/json");
           request.AddHeader("Authorization", "Basic REPLACE_BASIC_AUTH");
-          request.AddParameter("application/json", "{\"spec\":{\"display_name\":\"catalog_integration_1\",\"suspended\":false,\"config\":{\"kind\":\"AwsGlue\"},\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\"}}}", ParameterType.RequestBody);
+          request.AddParameter("application/json", "{\"spec\":{\"display_name\":\"catalog_integration_1\",\"suspended\":false,\"config\":{\"kind\":\"AwsGlue\",\"custom_database\":\"string\"},\"environment\":{\"id\":\"env-00000\"},\"kafka_cluster\":{\"id\":\"lkc-00000\"}}}", ParameterType.RequestBody);
           IRestResponse response = client.Execute(request);
 components:
   responses:
@@ -4407,7 +4417,7 @@ components:
             that the ID will not be reclaimed and reused after an object is deleted
             ("time"); however, it may collide with IDs for other object `kinds` or
             objects of the same `kind` within a different scope/namespace ("space").
-          example: dlz-f3a90de
+          example: tci-f3a90de
           maxLength: 255
           readOnly: true
           type: string
@@ -4482,6 +4492,14 @@ components:
 
             The minimum allowed value is "86400000" milliseconds (equivalent to 24 hours).
           example: "7776000000"
+          format: int64
+          type: string
+        data_retention_ms:
+          description: |
+            The maximum age, in milliseconds, of data to retain in the table for the Tableflow-enabled topic.
+
+            The minimum allowed value is "2592000000" milliseconds (equivalent to 30 days).
+          example: "2592000000"
           format: int64
           type: string
         record_failure_strategy:
@@ -4632,6 +4650,9 @@ components:
           example: cspi-stgce89r7
           type: string
           x-immutable: true
+        custom_database:
+          description: The custom database name to use in AWS Glue.
+          type: string
       required:
       - kind
       - provider_integration_id
@@ -4660,6 +4681,9 @@ components:
           type: string
         allowed_scope:
           description: Allowed scope of the Snowflake Open Catalog.
+          type: string
+        custom_namespace:
+          description: The custom namespace to use in Snowflake Open Catalog.
           type: string
       required:
       - allowed_scope
@@ -4690,6 +4714,9 @@ components:
         client_secret:
           description: The OAuth client secret used for authentication with the Unity
             Catalog.
+          type: string
+        custom_schema:
+          description: The custom schema name to use in Unity Catalog.
           type: string
       required:
       - catalog_name
@@ -4724,6 +4751,9 @@ components:
         allowed_scope:
           description: Allowed scope of the Snowflake Open Catalog.
           type: string
+        custom_namespace:
+          description: The custom namespace to use in Snowflake Open Catalog.
+          type: string
       required:
       - kind
       type: object
@@ -4736,6 +4766,9 @@ components:
           - AwsGlue
           type: string
           x-immutable: true
+        custom_database:
+          description: The custom database name to use in AWS Glue.
+          type: string
       required:
       - kind
       type: object
@@ -4760,6 +4793,9 @@ components:
         client_secret:
           description: The OAuth client secret used for authentication with the Unity
             Catalog.
+          type: string
+        custom_schema:
+          description: The custom schema name to use in Unity Catalog.
           type: string
       required:
       - kind

--- a/tableflow/v1/api_catalog_integrations_tableflow_v1.go
+++ b/tableflow/v1/api_catalog_integrations_tableflow_v1.go
@@ -42,14 +42,14 @@ var (
 type CatalogIntegrationsTableflowV1Api interface {
 
 	/*
-			CreateTableflowV1CatalogIntegration Create a Catalog Integration
+		CreateTableflowV1CatalogIntegration Create a Catalog Integration
 
-			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-		Make a request to create a catalog integration.
+	Make a request to create a catalog integration.
 
-			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-			 @return ApiCreateTableflowV1CatalogIntegrationRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @return ApiCreateTableflowV1CatalogIntegrationRequest
 	*/
 	CreateTableflowV1CatalogIntegration(ctx _context.Context) ApiCreateTableflowV1CatalogIntegrationRequest
 
@@ -58,15 +58,15 @@ type CatalogIntegrationsTableflowV1Api interface {
 	CreateTableflowV1CatalogIntegrationExecute(r ApiCreateTableflowV1CatalogIntegrationRequest) (TableflowV1CatalogIntegration, *_nethttp.Response, error)
 
 	/*
-			DeleteTableflowV1CatalogIntegration Delete a Catalog Integration
+		DeleteTableflowV1CatalogIntegration Delete a Catalog Integration
 
-			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-		Make a request to delete a catalog integration.
+	Make a request to delete a catalog integration.
 
-			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-			 @param id The unique identifier for the catalog integration.
-			 @return ApiDeleteTableflowV1CatalogIntegrationRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param id The unique identifier for the catalog integration.
+		 @return ApiDeleteTableflowV1CatalogIntegrationRequest
 	*/
 	DeleteTableflowV1CatalogIntegration(ctx _context.Context, id string) ApiDeleteTableflowV1CatalogIntegrationRequest
 
@@ -74,15 +74,15 @@ type CatalogIntegrationsTableflowV1Api interface {
 	DeleteTableflowV1CatalogIntegrationExecute(r ApiDeleteTableflowV1CatalogIntegrationRequest) (*_nethttp.Response, error)
 
 	/*
-			GetTableflowV1CatalogIntegration Read a Catalog Integration
+		GetTableflowV1CatalogIntegration Read a Catalog Integration
 
-			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-		Make a request to read a catalog integration.
+	Make a request to read a catalog integration.
 
-			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-			 @param id The unique identifier for the catalog integration.
-			 @return ApiGetTableflowV1CatalogIntegrationRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param id The unique identifier for the catalog integration.
+		 @return ApiGetTableflowV1CatalogIntegrationRequest
 	*/
 	GetTableflowV1CatalogIntegration(ctx _context.Context, id string) ApiGetTableflowV1CatalogIntegrationRequest
 
@@ -91,14 +91,14 @@ type CatalogIntegrationsTableflowV1Api interface {
 	GetTableflowV1CatalogIntegrationExecute(r ApiGetTableflowV1CatalogIntegrationRequest) (TableflowV1CatalogIntegration, *_nethttp.Response, error)
 
 	/*
-			ListTableflowV1CatalogIntegrations List of Catalog Integrations
+		ListTableflowV1CatalogIntegrations List of Catalog Integrations
 
-			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-		Retrieve a sorted, filtered, paginated list of all catalog integrations.
+	Retrieve a sorted, filtered, paginated list of all catalog integrations.
 
-			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-			 @return ApiListTableflowV1CatalogIntegrationsRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @return ApiListTableflowV1CatalogIntegrationsRequest
 	*/
 	ListTableflowV1CatalogIntegrations(ctx _context.Context) ApiListTableflowV1CatalogIntegrationsRequest
 
@@ -107,17 +107,17 @@ type CatalogIntegrationsTableflowV1Api interface {
 	ListTableflowV1CatalogIntegrationsExecute(r ApiListTableflowV1CatalogIntegrationsRequest) (TableflowV1CatalogIntegrationList, *_nethttp.Response, error)
 
 	/*
-			UpdateTableflowV1CatalogIntegration Update a Catalog Integration
+		UpdateTableflowV1CatalogIntegration Update a Catalog Integration
 
-			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-		Make a request to update a catalog integration.
+	Make a request to update a catalog integration.
 
 
 
-			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-			 @param id The unique identifier for the catalog integration.
-			 @return ApiUpdateTableflowV1CatalogIntegrationRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param id The unique identifier for the catalog integration.
+		 @return ApiUpdateTableflowV1CatalogIntegrationRequest
 	*/
 	UpdateTableflowV1CatalogIntegration(ctx _context.Context, id string) ApiUpdateTableflowV1CatalogIntegrationRequest
 

--- a/tableflow/v1/api_regions_tableflow_v1.go
+++ b/tableflow/v1/api_regions_tableflow_v1.go
@@ -41,14 +41,14 @@ var (
 type RegionsTableflowV1Api interface {
 
 	/*
-			ListTableflowV1Regions List of Regions
+		ListTableflowV1Regions List of Regions
 
-			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-		Retrieve a sorted, filtered, paginated list of all regions.
+	Retrieve a sorted, filtered, paginated list of all regions.
 
-			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-			 @return ApiListTableflowV1RegionsRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @return ApiListTableflowV1RegionsRequest
 	*/
 	ListTableflowV1Regions(ctx _context.Context) ApiListTableflowV1RegionsRequest
 

--- a/tableflow/v1/api_tableflow_topics_tableflow_v1.go
+++ b/tableflow/v1/api_tableflow_topics_tableflow_v1.go
@@ -42,14 +42,14 @@ var (
 type TableflowTopicsTableflowV1Api interface {
 
 	/*
-			CreateTableflowV1TableflowTopic Create a Tableflow Topic
+		CreateTableflowV1TableflowTopic Create a Tableflow Topic
 
-			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-		Make a request to create a tableflow topic.
+	Make a request to create a tableflow topic.
 
-			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-			 @return ApiCreateTableflowV1TableflowTopicRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @return ApiCreateTableflowV1TableflowTopicRequest
 	*/
 	CreateTableflowV1TableflowTopic(ctx _context.Context) ApiCreateTableflowV1TableflowTopicRequest
 
@@ -58,15 +58,15 @@ type TableflowTopicsTableflowV1Api interface {
 	CreateTableflowV1TableflowTopicExecute(r ApiCreateTableflowV1TableflowTopicRequest) (TableflowV1TableflowTopic, *_nethttp.Response, error)
 
 	/*
-			DeleteTableflowV1TableflowTopic Delete a Tableflow Topic
+		DeleteTableflowV1TableflowTopic Delete a Tableflow Topic
 
-			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-		Make a request to delete a tableflow topic.
+	Make a request to delete a tableflow topic.
 
-			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-			 @param displayName The name of the Kafka topic for which Tableflow is enabled.
-			 @return ApiDeleteTableflowV1TableflowTopicRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param displayName The name of the Kafka topic for which Tableflow is enabled.
+		 @return ApiDeleteTableflowV1TableflowTopicRequest
 	*/
 	DeleteTableflowV1TableflowTopic(ctx _context.Context, displayName string) ApiDeleteTableflowV1TableflowTopicRequest
 
@@ -74,15 +74,15 @@ type TableflowTopicsTableflowV1Api interface {
 	DeleteTableflowV1TableflowTopicExecute(r ApiDeleteTableflowV1TableflowTopicRequest) (*_nethttp.Response, error)
 
 	/*
-			GetTableflowV1TableflowTopic Read a Tableflow Topic
+		GetTableflowV1TableflowTopic Read a Tableflow Topic
 
-			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-		Make a request to read a tableflow topic.
+	Make a request to read a tableflow topic.
 
-			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-			 @param displayName The name of the Kafka topic for which Tableflow is enabled.
-			 @return ApiGetTableflowV1TableflowTopicRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param displayName The name of the Kafka topic for which Tableflow is enabled.
+		 @return ApiGetTableflowV1TableflowTopicRequest
 	*/
 	GetTableflowV1TableflowTopic(ctx _context.Context, displayName string) ApiGetTableflowV1TableflowTopicRequest
 
@@ -91,14 +91,14 @@ type TableflowTopicsTableflowV1Api interface {
 	GetTableflowV1TableflowTopicExecute(r ApiGetTableflowV1TableflowTopicRequest) (TableflowV1TableflowTopic, *_nethttp.Response, error)
 
 	/*
-			ListTableflowV1TableflowTopics List of Tableflow Topics
+		ListTableflowV1TableflowTopics List of Tableflow Topics
 
-			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-		Retrieve a sorted, filtered, paginated list of all tableflow topics.
+	Retrieve a sorted, filtered, paginated list of all tableflow topics.
 
-			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-			 @return ApiListTableflowV1TableflowTopicsRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @return ApiListTableflowV1TableflowTopicsRequest
 	*/
 	ListTableflowV1TableflowTopics(ctx _context.Context) ApiListTableflowV1TableflowTopicsRequest
 
@@ -107,17 +107,17 @@ type TableflowTopicsTableflowV1Api interface {
 	ListTableflowV1TableflowTopicsExecute(r ApiListTableflowV1TableflowTopicsRequest) (TableflowV1TableflowTopicList, *_nethttp.Response, error)
 
 	/*
-			UpdateTableflowV1TableflowTopic Update a Tableflow Topic
+		UpdateTableflowV1TableflowTopic Update a Tableflow Topic
 
-			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-		Make a request to update a tableflow topic.
+	Make a request to update a tableflow topic.
 
 
 
-			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-			 @param displayName The name of the Kafka topic for which Tableflow is enabled.
-			 @return ApiUpdateTableflowV1TableflowTopicRequest
+		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		 @param displayName The name of the Kafka topic for which Tableflow is enabled.
+		 @return ApiUpdateTableflowV1TableflowTopicRequest
 	*/
 	UpdateTableflowV1TableflowTopic(ctx _context.Context, displayName string) ApiUpdateTableflowV1TableflowTopicRequest
 

--- a/tableflow/v1/docs/TableflowV1CatalogIntegrationAwsGlueSpec.md
+++ b/tableflow/v1/docs/TableflowV1CatalogIntegrationAwsGlueSpec.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Kind** | **string** | The type of the catalog integration. | 
 **ProviderIntegrationId** | **string** | The provider integration id. | 
+**CustomDatabase** | Pointer to **string** | The custom database name to use in AWS Glue. | [optional] 
 
 ## Methods
 
@@ -65,6 +66,31 @@ and a boolean to check if the value has been set.
 
 SetProviderIntegrationId sets ProviderIntegrationId field to given value.
 
+
+### GetCustomDatabase
+
+`func (o *TableflowV1CatalogIntegrationAwsGlueSpec) GetCustomDatabase() string`
+
+GetCustomDatabase returns the CustomDatabase field if non-nil, zero value otherwise.
+
+### GetCustomDatabaseOk
+
+`func (o *TableflowV1CatalogIntegrationAwsGlueSpec) GetCustomDatabaseOk() (*string, bool)`
+
+GetCustomDatabaseOk returns a tuple with the CustomDatabase field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetCustomDatabase
+
+`func (o *TableflowV1CatalogIntegrationAwsGlueSpec) SetCustomDatabase(v string)`
+
+SetCustomDatabase sets CustomDatabase field to given value.
+
+### HasCustomDatabase
+
+`func (o *TableflowV1CatalogIntegrationAwsGlueSpec) HasCustomDatabase() bool`
+
+HasCustomDatabase returns a boolean if a field has been set.
 
 
 ### AsTableflowV1CatalogIntegrationSpecConfigOneOf

--- a/tableflow/v1/docs/TableflowV1CatalogIntegrationAwsGlueUpdateSpec.md
+++ b/tableflow/v1/docs/TableflowV1CatalogIntegrationAwsGlueUpdateSpec.md
@@ -5,6 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Kind** | **string** | The type of the catalog integration. | 
+**CustomDatabase** | Pointer to **string** | The custom database name to use in AWS Glue. | [optional] 
 
 ## Methods
 
@@ -44,6 +45,31 @@ and a boolean to check if the value has been set.
 
 SetKind sets Kind field to given value.
 
+
+### GetCustomDatabase
+
+`func (o *TableflowV1CatalogIntegrationAwsGlueUpdateSpec) GetCustomDatabase() string`
+
+GetCustomDatabase returns the CustomDatabase field if non-nil, zero value otherwise.
+
+### GetCustomDatabaseOk
+
+`func (o *TableflowV1CatalogIntegrationAwsGlueUpdateSpec) GetCustomDatabaseOk() (*string, bool)`
+
+GetCustomDatabaseOk returns a tuple with the CustomDatabase field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetCustomDatabase
+
+`func (o *TableflowV1CatalogIntegrationAwsGlueUpdateSpec) SetCustomDatabase(v string)`
+
+SetCustomDatabase sets CustomDatabase field to given value.
+
+### HasCustomDatabase
+
+`func (o *TableflowV1CatalogIntegrationAwsGlueUpdateSpec) HasCustomDatabase() bool`
+
+HasCustomDatabase returns a boolean if a field has been set.
 
 
 ### AsTableflowV1CatalogIntegrationUpdateSpecConfigOneOf

--- a/tableflow/v1/docs/TableflowV1CatalogIntegrationSnowflakeSpec.md
+++ b/tableflow/v1/docs/TableflowV1CatalogIntegrationSnowflakeSpec.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **ClientSecret** | **string** | The client secret of the catalog integration. | 
 **Warehouse** | **string** | Warehouse name of the Snowflake Open Catalog. | 
 **AllowedScope** | **string** | Allowed scope of the Snowflake Open Catalog. | 
+**CustomNamespace** | Pointer to **string** | The custom namespace to use in Snowflake Open Catalog. | [optional] 
 
 ## Methods
 
@@ -149,6 +150,31 @@ and a boolean to check if the value has been set.
 
 SetAllowedScope sets AllowedScope field to given value.
 
+
+### GetCustomNamespace
+
+`func (o *TableflowV1CatalogIntegrationSnowflakeSpec) GetCustomNamespace() string`
+
+GetCustomNamespace returns the CustomNamespace field if non-nil, zero value otherwise.
+
+### GetCustomNamespaceOk
+
+`func (o *TableflowV1CatalogIntegrationSnowflakeSpec) GetCustomNamespaceOk() (*string, bool)`
+
+GetCustomNamespaceOk returns a tuple with the CustomNamespace field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetCustomNamespace
+
+`func (o *TableflowV1CatalogIntegrationSnowflakeSpec) SetCustomNamespace(v string)`
+
+SetCustomNamespace sets CustomNamespace field to given value.
+
+### HasCustomNamespace
+
+`func (o *TableflowV1CatalogIntegrationSnowflakeSpec) HasCustomNamespace() bool`
+
+HasCustomNamespace returns a boolean if a field has been set.
 
 
 ### AsTableflowV1CatalogIntegrationSpecConfigOneOf

--- a/tableflow/v1/docs/TableflowV1CatalogIntegrationSnowflakeUpdateSpec.md
+++ b/tableflow/v1/docs/TableflowV1CatalogIntegrationSnowflakeUpdateSpec.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **ClientSecret** | Pointer to **string** | The client secret of the catalog integration. | [optional] 
 **Warehouse** | Pointer to **string** | Warehouse name of the Snowflake Open Catalog. | [optional] 
 **AllowedScope** | Pointer to **string** | Allowed scope of the Snowflake Open Catalog. | [optional] 
+**CustomNamespace** | Pointer to **string** | The custom namespace to use in Snowflake Open Catalog. | [optional] 
 
 ## Methods
 
@@ -174,6 +175,31 @@ SetAllowedScope sets AllowedScope field to given value.
 `func (o *TableflowV1CatalogIntegrationSnowflakeUpdateSpec) HasAllowedScope() bool`
 
 HasAllowedScope returns a boolean if a field has been set.
+
+### GetCustomNamespace
+
+`func (o *TableflowV1CatalogIntegrationSnowflakeUpdateSpec) GetCustomNamespace() string`
+
+GetCustomNamespace returns the CustomNamespace field if non-nil, zero value otherwise.
+
+### GetCustomNamespaceOk
+
+`func (o *TableflowV1CatalogIntegrationSnowflakeUpdateSpec) GetCustomNamespaceOk() (*string, bool)`
+
+GetCustomNamespaceOk returns a tuple with the CustomNamespace field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetCustomNamespace
+
+`func (o *TableflowV1CatalogIntegrationSnowflakeUpdateSpec) SetCustomNamespace(v string)`
+
+SetCustomNamespace sets CustomNamespace field to given value.
+
+### HasCustomNamespace
+
+`func (o *TableflowV1CatalogIntegrationSnowflakeUpdateSpec) HasCustomNamespace() bool`
+
+HasCustomNamespace returns a boolean if a field has been set.
 
 
 ### AsTableflowV1CatalogIntegrationUpdateSpecConfigOneOf

--- a/tableflow/v1/docs/TableflowV1CatalogIntegrationUnitySpec.md
+++ b/tableflow/v1/docs/TableflowV1CatalogIntegrationUnitySpec.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 **CatalogName** | **string** | The name of the catalog within Unity Catalog. | 
 **ClientId** | **string** | The OAuth client ID used to authenticate with the Unity Catalog. | 
 **ClientSecret** | **string** | The OAuth client secret used for authentication with the Unity Catalog. | 
+**CustomSchema** | Pointer to **string** | The custom schema name to use in Unity Catalog. | [optional] 
 
 ## Methods
 
@@ -128,6 +129,31 @@ and a boolean to check if the value has been set.
 
 SetClientSecret sets ClientSecret field to given value.
 
+
+### GetCustomSchema
+
+`func (o *TableflowV1CatalogIntegrationUnitySpec) GetCustomSchema() string`
+
+GetCustomSchema returns the CustomSchema field if non-nil, zero value otherwise.
+
+### GetCustomSchemaOk
+
+`func (o *TableflowV1CatalogIntegrationUnitySpec) GetCustomSchemaOk() (*string, bool)`
+
+GetCustomSchemaOk returns a tuple with the CustomSchema field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetCustomSchema
+
+`func (o *TableflowV1CatalogIntegrationUnitySpec) SetCustomSchema(v string)`
+
+SetCustomSchema sets CustomSchema field to given value.
+
+### HasCustomSchema
+
+`func (o *TableflowV1CatalogIntegrationUnitySpec) HasCustomSchema() bool`
+
+HasCustomSchema returns a boolean if a field has been set.
 
 
 ### AsTableflowV1CatalogIntegrationSpecConfigOneOf

--- a/tableflow/v1/docs/TableflowV1CatalogIntegrationUnityUpdateSpec.md
+++ b/tableflow/v1/docs/TableflowV1CatalogIntegrationUnityUpdateSpec.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 **CatalogName** | Pointer to **string** | The name of the catalog within Unity Catalog. | [optional] 
 **ClientId** | Pointer to **string** | The OAuth client ID used to authenticate with the Unity Catalog. | [optional] 
 **ClientSecret** | Pointer to **string** | The OAuth client secret used for authentication with the Unity Catalog. | [optional] 
+**CustomSchema** | Pointer to **string** | The custom schema name to use in Unity Catalog. | [optional] 
 
 ## Methods
 
@@ -148,6 +149,31 @@ SetClientSecret sets ClientSecret field to given value.
 `func (o *TableflowV1CatalogIntegrationUnityUpdateSpec) HasClientSecret() bool`
 
 HasClientSecret returns a boolean if a field has been set.
+
+### GetCustomSchema
+
+`func (o *TableflowV1CatalogIntegrationUnityUpdateSpec) GetCustomSchema() string`
+
+GetCustomSchema returns the CustomSchema field if non-nil, zero value otherwise.
+
+### GetCustomSchemaOk
+
+`func (o *TableflowV1CatalogIntegrationUnityUpdateSpec) GetCustomSchemaOk() (*string, bool)`
+
+GetCustomSchemaOk returns a tuple with the CustomSchema field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetCustomSchema
+
+`func (o *TableflowV1CatalogIntegrationUnityUpdateSpec) SetCustomSchema(v string)`
+
+SetCustomSchema sets CustomSchema field to given value.
+
+### HasCustomSchema
+
+`func (o *TableflowV1CatalogIntegrationUnityUpdateSpec) HasCustomSchema() bool`
+
+HasCustomSchema returns a boolean if a field has been set.
 
 
 ### AsTableflowV1CatalogIntegrationUpdateSpecConfigOneOf

--- a/tableflow/v1/docs/TableflowV1TableFlowTopicConfigsSpec.md
+++ b/tableflow/v1/docs/TableflowV1TableFlowTopicConfigsSpec.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **EnableCompaction** | Pointer to **bool** | This flag determines whether to enable compaction for the Tableflow enabled topic. | [optional] [readonly] 
 **EnablePartitioning** | Pointer to **bool** | This flag determines whether to enable partitioning for the Tableflow enabled topic. | [optional] [readonly] 
 **RetentionMs** | Pointer to **string** | The maximum age, in milliseconds, of snapshots (for Iceberg) or versions (for Delta) to retain in the table for the Tableflow-enabled topic (snapshot/version expiration).  The default value is \&quot;604800000\&quot; milliseconds (equivalent to 7 days).  The minimum allowed value is \&quot;86400000\&quot; milliseconds (equivalent to 24 hours).  | [optional] 
+**DataRetentionMs** | Pointer to **string** | The maximum age, in milliseconds, of data to retain in the table for the Tableflow-enabled topic.  The minimum allowed value is \&quot;2592000000\&quot; milliseconds (equivalent to 30 days).  | [optional] 
 **RecordFailureStrategy** | Pointer to **string** | The strategy to handle record failures in the Tableflow enabled topic during materialization.  For &#x60;SKIP&#x60;, we skip the bad records and move to the next record,  and for &#x60;SUSPEND&#x60;, we suspend the materialization of the topic.  | [optional] [default to "SUSPEND"]
 **ErrorHandling** | Pointer to [**TableflowV1TableFlowTopicConfigsSpecErrorHandlingOneOf**](TableflowV1TableFlowTopicConfigsSpecErrorHandlingOneOf.md) | The error mode to handle record failures in the Tableflow enabled topic during materialization.  for &#x60;SKIP&#x60;, we skip the bad records and move to the next record,  for &#x60;SUSPEND&#x60;, we suspend the materialization of the topic,  and for &#x60;LOG&#x60;, we log the bad records to the DLQ and continue processing the rest of the records.  | [optional] 
 
@@ -103,6 +104,31 @@ SetRetentionMs sets RetentionMs field to given value.
 `func (o *TableflowV1TableFlowTopicConfigsSpec) HasRetentionMs() bool`
 
 HasRetentionMs returns a boolean if a field has been set.
+
+### GetDataRetentionMs
+
+`func (o *TableflowV1TableFlowTopicConfigsSpec) GetDataRetentionMs() string`
+
+GetDataRetentionMs returns the DataRetentionMs field if non-nil, zero value otherwise.
+
+### GetDataRetentionMsOk
+
+`func (o *TableflowV1TableFlowTopicConfigsSpec) GetDataRetentionMsOk() (*string, bool)`
+
+GetDataRetentionMsOk returns a tuple with the DataRetentionMs field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetDataRetentionMs
+
+`func (o *TableflowV1TableFlowTopicConfigsSpec) SetDataRetentionMs(v string)`
+
+SetDataRetentionMs sets DataRetentionMs field to given value.
+
+### HasDataRetentionMs
+
+`func (o *TableflowV1TableFlowTopicConfigsSpec) HasDataRetentionMs() bool`
+
+HasDataRetentionMs returns a boolean if a field has been set.
 
 ### GetRecordFailureStrategy
 

--- a/tableflow/v1/model_tableflow_v1_catalog_integration_aws_glue_spec.go
+++ b/tableflow/v1/model_tableflow_v1_catalog_integration_aws_glue_spec.go
@@ -40,6 +40,8 @@ type TableflowV1CatalogIntegrationAwsGlueSpec struct {
 	Kind string `json:"kind,omitempty"`
 	// The provider integration id.
 	ProviderIntegrationId string `json:"provider_integration_id,omitempty"`
+	// The custom database name to use in AWS Glue.
+	CustomDatabase *string `json:"custom_database,omitempty"`
 }
 
 // NewTableflowV1CatalogIntegrationAwsGlueSpec instantiates a new TableflowV1CatalogIntegrationAwsGlueSpec object
@@ -109,10 +111,43 @@ func (o *TableflowV1CatalogIntegrationAwsGlueSpec) SetProviderIntegrationId(v st
 	o.ProviderIntegrationId = v
 }
 
+// GetCustomDatabase returns the CustomDatabase field value if set, zero value otherwise.
+func (o *TableflowV1CatalogIntegrationAwsGlueSpec) GetCustomDatabase() string {
+	if o == nil || o.CustomDatabase == nil {
+		var ret string
+		return ret
+	}
+	return *o.CustomDatabase
+}
+
+// GetCustomDatabaseOk returns a tuple with the CustomDatabase field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TableflowV1CatalogIntegrationAwsGlueSpec) GetCustomDatabaseOk() (*string, bool) {
+	if o == nil || o.CustomDatabase == nil {
+		return nil, false
+	}
+	return o.CustomDatabase, true
+}
+
+// HasCustomDatabase returns a boolean if a field has been set.
+func (o *TableflowV1CatalogIntegrationAwsGlueSpec) HasCustomDatabase() bool {
+	if o != nil && o.CustomDatabase != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCustomDatabase gets a reference to the given string and assigns it to the CustomDatabase field.
+func (o *TableflowV1CatalogIntegrationAwsGlueSpec) SetCustomDatabase(v string) {
+	o.CustomDatabase = &v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *TableflowV1CatalogIntegrationAwsGlueSpec) Redact() {
 	o.recurseRedact(&o.Kind)
 	o.recurseRedact(&o.ProviderIntegrationId)
+	o.recurseRedact(o.CustomDatabase)
 }
 
 func (o *TableflowV1CatalogIntegrationAwsGlueSpec) recurseRedact(v interface{}) {
@@ -152,6 +187,9 @@ func (o TableflowV1CatalogIntegrationAwsGlueSpec) MarshalJSON() ([]byte, error) 
 	}
 	if true {
 		toSerialize["provider_integration_id"] = o.ProviderIntegrationId
+	}
+	if o.CustomDatabase != nil {
+		toSerialize["custom_database"] = o.CustomDatabase
 	}
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)

--- a/tableflow/v1/model_tableflow_v1_catalog_integration_aws_glue_update_spec.go
+++ b/tableflow/v1/model_tableflow_v1_catalog_integration_aws_glue_update_spec.go
@@ -38,6 +38,8 @@ import (
 type TableflowV1CatalogIntegrationAwsGlueUpdateSpec struct {
 	// The type of the catalog integration.
 	Kind string `json:"kind,omitempty"`
+	// The custom database name to use in AWS Glue.
+	CustomDatabase *string `json:"custom_database,omitempty"`
 }
 
 // NewTableflowV1CatalogIntegrationAwsGlueUpdateSpec instantiates a new TableflowV1CatalogIntegrationAwsGlueUpdateSpec object
@@ -82,9 +84,42 @@ func (o *TableflowV1CatalogIntegrationAwsGlueUpdateSpec) SetKind(v string) {
 	o.Kind = v
 }
 
+// GetCustomDatabase returns the CustomDatabase field value if set, zero value otherwise.
+func (o *TableflowV1CatalogIntegrationAwsGlueUpdateSpec) GetCustomDatabase() string {
+	if o == nil || o.CustomDatabase == nil {
+		var ret string
+		return ret
+	}
+	return *o.CustomDatabase
+}
+
+// GetCustomDatabaseOk returns a tuple with the CustomDatabase field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TableflowV1CatalogIntegrationAwsGlueUpdateSpec) GetCustomDatabaseOk() (*string, bool) {
+	if o == nil || o.CustomDatabase == nil {
+		return nil, false
+	}
+	return o.CustomDatabase, true
+}
+
+// HasCustomDatabase returns a boolean if a field has been set.
+func (o *TableflowV1CatalogIntegrationAwsGlueUpdateSpec) HasCustomDatabase() bool {
+	if o != nil && o.CustomDatabase != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCustomDatabase gets a reference to the given string and assigns it to the CustomDatabase field.
+func (o *TableflowV1CatalogIntegrationAwsGlueUpdateSpec) SetCustomDatabase(v string) {
+	o.CustomDatabase = &v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *TableflowV1CatalogIntegrationAwsGlueUpdateSpec) Redact() {
 	o.recurseRedact(&o.Kind)
+	o.recurseRedact(o.CustomDatabase)
 }
 
 func (o *TableflowV1CatalogIntegrationAwsGlueUpdateSpec) recurseRedact(v interface{}) {
@@ -121,6 +156,9 @@ func (o TableflowV1CatalogIntegrationAwsGlueUpdateSpec) MarshalJSON() ([]byte, e
 	toSerialize := map[string]interface{}{}
 	if true {
 		toSerialize["kind"] = o.Kind
+	}
+	if o.CustomDatabase != nil {
+		toSerialize["custom_database"] = o.CustomDatabase
 	}
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)

--- a/tableflow/v1/model_tableflow_v1_catalog_integration_snowflake_spec.go
+++ b/tableflow/v1/model_tableflow_v1_catalog_integration_snowflake_spec.go
@@ -48,6 +48,8 @@ type TableflowV1CatalogIntegrationSnowflakeSpec struct {
 	Warehouse string `json:"warehouse,omitempty"`
 	// Allowed scope of the Snowflake Open Catalog.
 	AllowedScope string `json:"allowed_scope,omitempty"`
+	// The custom namespace to use in Snowflake Open Catalog.
+	CustomNamespace *string `json:"custom_namespace,omitempty"`
 }
 
 // NewTableflowV1CatalogIntegrationSnowflakeSpec instantiates a new TableflowV1CatalogIntegrationSnowflakeSpec object
@@ -217,6 +219,38 @@ func (o *TableflowV1CatalogIntegrationSnowflakeSpec) SetAllowedScope(v string) {
 	o.AllowedScope = v
 }
 
+// GetCustomNamespace returns the CustomNamespace field value if set, zero value otherwise.
+func (o *TableflowV1CatalogIntegrationSnowflakeSpec) GetCustomNamespace() string {
+	if o == nil || o.CustomNamespace == nil {
+		var ret string
+		return ret
+	}
+	return *o.CustomNamespace
+}
+
+// GetCustomNamespaceOk returns a tuple with the CustomNamespace field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TableflowV1CatalogIntegrationSnowflakeSpec) GetCustomNamespaceOk() (*string, bool) {
+	if o == nil || o.CustomNamespace == nil {
+		return nil, false
+	}
+	return o.CustomNamespace, true
+}
+
+// HasCustomNamespace returns a boolean if a field has been set.
+func (o *TableflowV1CatalogIntegrationSnowflakeSpec) HasCustomNamespace() bool {
+	if o != nil && o.CustomNamespace != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCustomNamespace gets a reference to the given string and assigns it to the CustomNamespace field.
+func (o *TableflowV1CatalogIntegrationSnowflakeSpec) SetCustomNamespace(v string) {
+	o.CustomNamespace = &v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *TableflowV1CatalogIntegrationSnowflakeSpec) Redact() {
 	o.recurseRedact(&o.Kind)
@@ -225,6 +259,7 @@ func (o *TableflowV1CatalogIntegrationSnowflakeSpec) Redact() {
 	o.recurseRedact(&o.ClientSecret)
 	o.recurseRedact(&o.Warehouse)
 	o.recurseRedact(&o.AllowedScope)
+	o.recurseRedact(o.CustomNamespace)
 }
 
 func (o *TableflowV1CatalogIntegrationSnowflakeSpec) recurseRedact(v interface{}) {
@@ -276,6 +311,9 @@ func (o TableflowV1CatalogIntegrationSnowflakeSpec) MarshalJSON() ([]byte, error
 	}
 	if true {
 		toSerialize["allowed_scope"] = o.AllowedScope
+	}
+	if o.CustomNamespace != nil {
+		toSerialize["custom_namespace"] = o.CustomNamespace
 	}
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)

--- a/tableflow/v1/model_tableflow_v1_catalog_integration_snowflake_update_spec.go
+++ b/tableflow/v1/model_tableflow_v1_catalog_integration_snowflake_update_spec.go
@@ -48,6 +48,8 @@ type TableflowV1CatalogIntegrationSnowflakeUpdateSpec struct {
 	Warehouse *string `json:"warehouse,omitempty"`
 	// Allowed scope of the Snowflake Open Catalog.
 	AllowedScope *string `json:"allowed_scope,omitempty"`
+	// The custom namespace to use in Snowflake Open Catalog.
+	CustomNamespace *string `json:"custom_namespace,omitempty"`
 }
 
 // NewTableflowV1CatalogIntegrationSnowflakeUpdateSpec instantiates a new TableflowV1CatalogIntegrationSnowflakeUpdateSpec object
@@ -252,6 +254,38 @@ func (o *TableflowV1CatalogIntegrationSnowflakeUpdateSpec) SetAllowedScope(v str
 	o.AllowedScope = &v
 }
 
+// GetCustomNamespace returns the CustomNamespace field value if set, zero value otherwise.
+func (o *TableflowV1CatalogIntegrationSnowflakeUpdateSpec) GetCustomNamespace() string {
+	if o == nil || o.CustomNamespace == nil {
+		var ret string
+		return ret
+	}
+	return *o.CustomNamespace
+}
+
+// GetCustomNamespaceOk returns a tuple with the CustomNamespace field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TableflowV1CatalogIntegrationSnowflakeUpdateSpec) GetCustomNamespaceOk() (*string, bool) {
+	if o == nil || o.CustomNamespace == nil {
+		return nil, false
+	}
+	return o.CustomNamespace, true
+}
+
+// HasCustomNamespace returns a boolean if a field has been set.
+func (o *TableflowV1CatalogIntegrationSnowflakeUpdateSpec) HasCustomNamespace() bool {
+	if o != nil && o.CustomNamespace != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCustomNamespace gets a reference to the given string and assigns it to the CustomNamespace field.
+func (o *TableflowV1CatalogIntegrationSnowflakeUpdateSpec) SetCustomNamespace(v string) {
+	o.CustomNamespace = &v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *TableflowV1CatalogIntegrationSnowflakeUpdateSpec) Redact() {
 	o.recurseRedact(&o.Kind)
@@ -260,6 +294,7 @@ func (o *TableflowV1CatalogIntegrationSnowflakeUpdateSpec) Redact() {
 	o.recurseRedact(o.ClientSecret)
 	o.recurseRedact(o.Warehouse)
 	o.recurseRedact(o.AllowedScope)
+	o.recurseRedact(o.CustomNamespace)
 }
 
 func (o *TableflowV1CatalogIntegrationSnowflakeUpdateSpec) recurseRedact(v interface{}) {
@@ -311,6 +346,9 @@ func (o TableflowV1CatalogIntegrationSnowflakeUpdateSpec) MarshalJSON() ([]byte,
 	}
 	if o.AllowedScope != nil {
 		toSerialize["allowed_scope"] = o.AllowedScope
+	}
+	if o.CustomNamespace != nil {
+		toSerialize["custom_namespace"] = o.CustomNamespace
 	}
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)

--- a/tableflow/v1/model_tableflow_v1_catalog_integration_unity_spec.go
+++ b/tableflow/v1/model_tableflow_v1_catalog_integration_unity_spec.go
@@ -46,6 +46,8 @@ type TableflowV1CatalogIntegrationUnitySpec struct {
 	ClientId string `json:"client_id,omitempty"`
 	// The OAuth client secret used for authentication with the Unity Catalog.
 	ClientSecret string `json:"client_secret,omitempty"`
+	// The custom schema name to use in Unity Catalog.
+	CustomSchema *string `json:"custom_schema,omitempty"`
 }
 
 // NewTableflowV1CatalogIntegrationUnitySpec instantiates a new TableflowV1CatalogIntegrationUnitySpec object
@@ -190,6 +192,38 @@ func (o *TableflowV1CatalogIntegrationUnitySpec) SetClientSecret(v string) {
 	o.ClientSecret = v
 }
 
+// GetCustomSchema returns the CustomSchema field value if set, zero value otherwise.
+func (o *TableflowV1CatalogIntegrationUnitySpec) GetCustomSchema() string {
+	if o == nil || o.CustomSchema == nil {
+		var ret string
+		return ret
+	}
+	return *o.CustomSchema
+}
+
+// GetCustomSchemaOk returns a tuple with the CustomSchema field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TableflowV1CatalogIntegrationUnitySpec) GetCustomSchemaOk() (*string, bool) {
+	if o == nil || o.CustomSchema == nil {
+		return nil, false
+	}
+	return o.CustomSchema, true
+}
+
+// HasCustomSchema returns a boolean if a field has been set.
+func (o *TableflowV1CatalogIntegrationUnitySpec) HasCustomSchema() bool {
+	if o != nil && o.CustomSchema != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCustomSchema gets a reference to the given string and assigns it to the CustomSchema field.
+func (o *TableflowV1CatalogIntegrationUnitySpec) SetCustomSchema(v string) {
+	o.CustomSchema = &v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *TableflowV1CatalogIntegrationUnitySpec) Redact() {
 	o.recurseRedact(&o.Kind)
@@ -197,6 +231,7 @@ func (o *TableflowV1CatalogIntegrationUnitySpec) Redact() {
 	o.recurseRedact(&o.CatalogName)
 	o.recurseRedact(&o.ClientId)
 	o.recurseRedact(&o.ClientSecret)
+	o.recurseRedact(o.CustomSchema)
 }
 
 func (o *TableflowV1CatalogIntegrationUnitySpec) recurseRedact(v interface{}) {
@@ -245,6 +280,9 @@ func (o TableflowV1CatalogIntegrationUnitySpec) MarshalJSON() ([]byte, error) {
 	}
 	if true {
 		toSerialize["client_secret"] = o.ClientSecret
+	}
+	if o.CustomSchema != nil {
+		toSerialize["custom_schema"] = o.CustomSchema
 	}
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)

--- a/tableflow/v1/model_tableflow_v1_catalog_integration_unity_update_spec.go
+++ b/tableflow/v1/model_tableflow_v1_catalog_integration_unity_update_spec.go
@@ -46,6 +46,8 @@ type TableflowV1CatalogIntegrationUnityUpdateSpec struct {
 	ClientId *string `json:"client_id,omitempty"`
 	// The OAuth client secret used for authentication with the Unity Catalog.
 	ClientSecret *string `json:"client_secret,omitempty"`
+	// The custom schema name to use in Unity Catalog.
+	CustomSchema *string `json:"custom_schema,omitempty"`
 }
 
 // NewTableflowV1CatalogIntegrationUnityUpdateSpec instantiates a new TableflowV1CatalogIntegrationUnityUpdateSpec object
@@ -218,6 +220,38 @@ func (o *TableflowV1CatalogIntegrationUnityUpdateSpec) SetClientSecret(v string)
 	o.ClientSecret = &v
 }
 
+// GetCustomSchema returns the CustomSchema field value if set, zero value otherwise.
+func (o *TableflowV1CatalogIntegrationUnityUpdateSpec) GetCustomSchema() string {
+	if o == nil || o.CustomSchema == nil {
+		var ret string
+		return ret
+	}
+	return *o.CustomSchema
+}
+
+// GetCustomSchemaOk returns a tuple with the CustomSchema field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TableflowV1CatalogIntegrationUnityUpdateSpec) GetCustomSchemaOk() (*string, bool) {
+	if o == nil || o.CustomSchema == nil {
+		return nil, false
+	}
+	return o.CustomSchema, true
+}
+
+// HasCustomSchema returns a boolean if a field has been set.
+func (o *TableflowV1CatalogIntegrationUnityUpdateSpec) HasCustomSchema() bool {
+	if o != nil && o.CustomSchema != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCustomSchema gets a reference to the given string and assigns it to the CustomSchema field.
+func (o *TableflowV1CatalogIntegrationUnityUpdateSpec) SetCustomSchema(v string) {
+	o.CustomSchema = &v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *TableflowV1CatalogIntegrationUnityUpdateSpec) Redact() {
 	o.recurseRedact(&o.Kind)
@@ -225,6 +259,7 @@ func (o *TableflowV1CatalogIntegrationUnityUpdateSpec) Redact() {
 	o.recurseRedact(o.CatalogName)
 	o.recurseRedact(o.ClientId)
 	o.recurseRedact(o.ClientSecret)
+	o.recurseRedact(o.CustomSchema)
 }
 
 func (o *TableflowV1CatalogIntegrationUnityUpdateSpec) recurseRedact(v interface{}) {
@@ -273,6 +308,9 @@ func (o TableflowV1CatalogIntegrationUnityUpdateSpec) MarshalJSON() ([]byte, err
 	}
 	if o.ClientSecret != nil {
 		toSerialize["client_secret"] = o.ClientSecret
+	}
+	if o.CustomSchema != nil {
+		toSerialize["custom_schema"] = o.CustomSchema
 	}
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)

--- a/tableflow/v1/model_tableflow_v1_table_flow_topic_configs_spec.go
+++ b/tableflow/v1/model_tableflow_v1_table_flow_topic_configs_spec.go
@@ -42,6 +42,8 @@ type TableflowV1TableFlowTopicConfigsSpec struct {
 	EnablePartitioning *bool `json:"enable_partitioning,omitempty"`
 	// The maximum age, in milliseconds, of snapshots (for Iceberg) or versions (for Delta) to retain in the table for the Tableflow-enabled topic (snapshot/version expiration).  The default value is \"604800000\" milliseconds (equivalent to 7 days).  The minimum allowed value is \"86400000\" milliseconds (equivalent to 24 hours).
 	RetentionMs *string `json:"retention_ms,omitempty"`
+	// The maximum age, in milliseconds, of data to retain in the table for the Tableflow-enabled topic.  The minimum allowed value is \"2592000000\" milliseconds (equivalent to 30 days).
+	DataRetentionMs *string `json:"data_retention_ms,omitempty"`
 	// The strategy to handle record failures in the Tableflow enabled topic during materialization.  For `SKIP`, we skip the bad records and move to the next record,  and for `SUSPEND`, we suspend the materialization of the topic.
 	// Deprecated
 	RecordFailureStrategy *string `json:"record_failure_strategy,omitempty"`
@@ -166,6 +168,38 @@ func (o *TableflowV1TableFlowTopicConfigsSpec) SetRetentionMs(v string) {
 	o.RetentionMs = &v
 }
 
+// GetDataRetentionMs returns the DataRetentionMs field value if set, zero value otherwise.
+func (o *TableflowV1TableFlowTopicConfigsSpec) GetDataRetentionMs() string {
+	if o == nil || o.DataRetentionMs == nil {
+		var ret string
+		return ret
+	}
+	return *o.DataRetentionMs
+}
+
+// GetDataRetentionMsOk returns a tuple with the DataRetentionMs field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TableflowV1TableFlowTopicConfigsSpec) GetDataRetentionMsOk() (*string, bool) {
+	if o == nil || o.DataRetentionMs == nil {
+		return nil, false
+	}
+	return o.DataRetentionMs, true
+}
+
+// HasDataRetentionMs returns a boolean if a field has been set.
+func (o *TableflowV1TableFlowTopicConfigsSpec) HasDataRetentionMs() bool {
+	if o != nil && o.DataRetentionMs != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetDataRetentionMs gets a reference to the given string and assigns it to the DataRetentionMs field.
+func (o *TableflowV1TableFlowTopicConfigsSpec) SetDataRetentionMs(v string) {
+	o.DataRetentionMs = &v
+}
+
 // GetRecordFailureStrategy returns the RecordFailureStrategy field value if set, zero value otherwise.
 // Deprecated
 func (o *TableflowV1TableFlowTopicConfigsSpec) GetRecordFailureStrategy() string {
@@ -238,6 +272,7 @@ func (o *TableflowV1TableFlowTopicConfigsSpec) Redact() {
 	o.recurseRedact(o.EnableCompaction)
 	o.recurseRedact(o.EnablePartitioning)
 	o.recurseRedact(o.RetentionMs)
+	o.recurseRedact(o.DataRetentionMs)
 	o.recurseRedact(o.RecordFailureStrategy)
 	o.recurseRedact(o.ErrorHandling)
 }
@@ -282,6 +317,9 @@ func (o TableflowV1TableFlowTopicConfigsSpec) MarshalJSON() ([]byte, error) {
 	}
 	if o.RetentionMs != nil {
 		toSerialize["retention_ms"] = o.RetentionMs
+	}
+	if o.DataRetentionMs != nil {
+		toSerialize["data_retention_ms"] = o.DataRetentionMs
 	}
 	if o.RecordFailureStrategy != nil {
 		toSerialize["record_failure_strategy"] = o.RecordFailureStrategy


### PR DESCRIPTION
What
-----
- Tableflow service is extending support for user defined namespaces to catalog integration resources. The PR updates the ccloud sdk, to align it with the corresponding API Spec changes.

output for go vet
```
go vet -v
internal/goarch
internal/coverage/rtcov
internal/byteorder
internal/godebugs
internal/msan
math/bits
internal/asan
internal/goos
internal/profilerecord
internal/trace/tracev2
internal/unsafeheader
internal/goexperiment
unicode
unicode/utf8
internal/itoa
encoding
cmp
unicode/utf16
crypto/internal/fips140/alias
crypto/internal/fips140deps/byteorder
internal/runtime/gc
internal/runtime/math
vendor/golang.org/x/crypto/cryptobyte/asn1
internal/nettrace
container/list
vendor/golang.org/x/crypto/internal/alias
log/internal
internal/runtime/strconv
crypto/internal/boring/sig
crypto/internal/fips140/subtle
internal/cpu
sync/atomic
internal/abi
math
internal/chacha8rand
crypto/internal/fips140deps/cpu
internal/runtime/sys
internal/runtime/atomic
internal/bytealg
internal/synctest
internal/race
internal/runtime/exithook
internal/sync
internal/runtime/maps
internal/stringslite
runtime
sync
weak
crypto/subtle
iter
internal/reflectlite
maps
slices
internal/testlog
internal/singleflight
crypto/internal/fips140cache
internal/bisect
unique
sort
errors
internal/oserror
path
io
vendor/golang.org/x/net/dns/dnsmessage
math/rand/v2
strconv
internal/godebug
syscall
crypto/internal/randutil
internal/saferio
hash
strings
bytes
hash/crc32
crypto
encoding/base64
net/netip
reflect
crypto/internal/fips140deps/godebug
math/rand
vendor/golang.org/x/text/transform
crypto/internal/impl
bufio
crypto/internal/fips140
encoding/pem
net/http/internal/ascii
regexp/syntax
crypto/internal/fips140/sha256
crypto/internal/fips140/sha3
crypto/internal/fips140/sha512
regexp
crypto/sha3
internal/syscall/execenv
internal/syscall/unix
internal/routebsd
crypto/internal/fips140/hmac
time
crypto/internal/fips140hash
crypto/internal/fips140/check
crypto/internal/fips140/tls12
crypto/internal/fips140/edwards25519/field
crypto/internal/fips140/hkdf
crypto/internal/fips140/bigmod
crypto/fips140
crypto/internal/fips140/aes
crypto/internal/fips140/nistec/fiat
crypto/tls/internal/fips140tls
crypto/internal/fips140/tls13
crypto/internal/fips140/edwards25519
context
crypto/x509/internal/macos
io/fs
internal/poll
internal/fmtsort
encoding/binary
crypto/internal/fips140/nistec
internal/filepathlite
os
vendor/golang.org/x/crypto/internal/poly1305
crypto/internal/sysrand
io/ioutil
path/filepath
fmt
net
crypto/internal/entropy
crypto/internal/fips140/drbg
crypto/internal/fips140only
crypto/internal/fips140/ed25519
crypto/internal/fips140/ecdsa
crypto/internal/fips140/rsa
crypto/internal/fips140/ecdh
crypto/internal/fips140/mlkem
crypto/internal/fips140/aes/gcm
crypto/rc4
encoding/hex
crypto/md5
net/url
crypto/hkdf
encoding/json
encoding/xml
math/big
compress/flate
log
vendor/golang.org/x/text/unicode/norm
mime
vendor/golang.org/x/net/http2/hpack
crypto/cipher
mime/quotedprintable
net/http/internal
vendor/golang.org/x/text/unicode/bidi
compress/gzip
crypto/internal/boring
vendor/golang.org/x/crypto/chacha20
crypto/des
vendor/golang.org/x/text/secure/bidirule
crypto/aes
crypto/ecdh
crypto/sha512
crypto/sha1
crypto/sha256
crypto/hmac
vendor/golang.org/x/net/idna
vendor/golang.org/x/crypto/chacha20poly1305
crypto/internal/boring/bbig
crypto/dsa
crypto/rand
crypto/elliptic
encoding/asn1
crypto/rsa
crypto/ed25519
crypto/internal/hpke
crypto/x509/pkix
vendor/golang.org/x/crypto/cryptobyte
vendor/golang.org/x/net/http/httpproxy
net/textproto
crypto/ecdsa
vendor/golang.org/x/net/http/httpguts
mime/multipart
crypto/x509
crypto/tls
net/http/httptrace
net/http/internal/httpcommon
net/http
golang.org/x/net/context/ctxhttp
net/http/httputil
golang.org/x/oauth2/internal
golang.org/x/oauth2
github.com/confluentinc/ccloud-sdk-go-v2/tableflow/v1
```