### PR TITLE
[ORC-9984] Cmk v2 decode 409 error on deletion.

### DIFF
--- a/cmk/v2/api_clusters_cmk_v2.go
+++ b/cmk/v2/api_clusters_cmk_v2.go
@@ -43,14 +43,14 @@ var (
 type ClustersCmkV2Api interface {
 
 	/*
-		CreateCmkV2Cluster Create a Cluster
+			CreateCmkV2Cluster Create a Cluster
 
-		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Make a request to create a cluster.
+		Make a request to create a cluster.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @return ApiCreateCmkV2ClusterRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @return ApiCreateCmkV2ClusterRequest
 	*/
 	CreateCmkV2Cluster(ctx _context.Context) ApiCreateCmkV2ClusterRequest
 
@@ -59,15 +59,15 @@ type ClustersCmkV2Api interface {
 	CreateCmkV2ClusterExecute(r ApiCreateCmkV2ClusterRequest) (CmkV2Cluster, *_nethttp.Response, error)
 
 	/*
-		DeleteCmkV2Cluster Delete a Cluster
+			DeleteCmkV2Cluster Delete a Cluster
 
-		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Make a request to delete a cluster.
+		Make a request to delete a cluster.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param id The unique identifier for the cluster.
-		 @return ApiDeleteCmkV2ClusterRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param id The unique identifier for the cluster.
+			 @return ApiDeleteCmkV2ClusterRequest
 	*/
 	DeleteCmkV2Cluster(ctx _context.Context, id string) ApiDeleteCmkV2ClusterRequest
 
@@ -75,15 +75,15 @@ type ClustersCmkV2Api interface {
 	DeleteCmkV2ClusterExecute(r ApiDeleteCmkV2ClusterRequest) (*_nethttp.Response, error)
 
 	/*
-		GetCmkV2Cluster Read a Cluster
+			GetCmkV2Cluster Read a Cluster
 
-		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Make a request to read a cluster.
+		Make a request to read a cluster.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param id The unique identifier for the cluster.
-		 @return ApiGetCmkV2ClusterRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param id The unique identifier for the cluster.
+			 @return ApiGetCmkV2ClusterRequest
 	*/
 	GetCmkV2Cluster(ctx _context.Context, id string) ApiGetCmkV2ClusterRequest
 
@@ -92,14 +92,14 @@ type ClustersCmkV2Api interface {
 	GetCmkV2ClusterExecute(r ApiGetCmkV2ClusterRequest) (CmkV2Cluster, *_nethttp.Response, error)
 
 	/*
-		ListCmkV2Clusters List of Clusters
+			ListCmkV2Clusters List of Clusters
 
-		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Retrieve a sorted, filtered, paginated list of all clusters.
+		Retrieve a sorted, filtered, paginated list of all clusters.
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @return ApiListCmkV2ClustersRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @return ApiListCmkV2ClustersRequest
 	*/
 	ListCmkV2Clusters(ctx _context.Context) ApiListCmkV2ClustersRequest
 
@@ -108,17 +108,17 @@ type ClustersCmkV2Api interface {
 	ListCmkV2ClustersExecute(r ApiListCmkV2ClustersRequest) (CmkV2ClusterList, *_nethttp.Response, error)
 
 	/*
-		UpdateCmkV2Cluster Update a Cluster
+			UpdateCmkV2Cluster Update a Cluster
 
-		[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
+			[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
-	Make a request to update a cluster.
+		Make a request to update a cluster.
 
 
 
-		 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		 @param id The unique identifier for the cluster.
-		 @return ApiUpdateCmkV2ClusterRequest
+			 @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 @param id The unique identifier for the cluster.
+			 @return ApiUpdateCmkV2ClusterRequest
 	*/
 	UpdateCmkV2Cluster(ctx _context.Context, id string) ApiUpdateCmkV2ClusterRequest
 
@@ -443,6 +443,16 @@ func (a *ClustersCmkV2ApiService) DeleteCmkV2ClusterExecute(r ApiDeleteCmkV2Clus
 			return localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
+			var v Failure
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 409 {
 			var v Failure
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {


### PR DESCRIPTION
With deletion protection, the server may return 409 when the client tries to delete a cluster with deletion protection set, and we would like the error to be decoded.