### PR TITLE
USTORAGE-26620: Add metadata_column_naming_scheme to tableflow/v1 SDK model

### DIFF
--- a/tableflow/v1/api/openapi.yaml
+++ b/tableflow/v1/api/openapi.yaml
@@ -4536,6 +4536,20 @@ components:
           - $ref: '#/components/schemas/tableflow.v1.ErrorHandlingLog'
           type: object
           x-one-of-name: TableflowV1TableFlowTopicConfigsSpecErrorHandlingOneOf
+        metadata_column_naming_scheme:
+          default: DEFAULT
+          description: |
+            The naming scheme for Tableflow's internal metadata columns (for example `$$offset` and `$$leader-epoch`) in the materialized table.
+
+            For `DEFAULT`, the metadata columns keep their default `$$`-prefixed names (for example `$$offset` and `$$leader-epoch`).
+
+            For `PORTABLE`, the metadata columns use portable `cflt_metadata_`-prefixed names that are queryable by engines such as Google BigQuery, with any hyphens replaced by underscores (for example `$$offset` becomes `cflt_metadata_offset` and `$$leader-epoch` becomes `cflt_metadata_leader_epoch`).
+
+            If not specified, `DEFAULT` is used.
+          type: string
+          x-extensible-enum:
+          - DEFAULT
+          - PORTABLE
       type: object
     tableflow.v1.ByobAwsSpec:
       description: The Tableflow storage config for BYOB enabled topic in AWS

--- a/tableflow/v1/docs/TableflowV1TableFlowTopicConfigsSpec.md
+++ b/tableflow/v1/docs/TableflowV1TableFlowTopicConfigsSpec.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **DataRetentionMs** | Pointer to **string** | The maximum age, in milliseconds, of data to retain in the table for the Tableflow-enabled topic.  The minimum allowed value is \&quot;2592000000\&quot; milliseconds (equivalent to 30 days).  | [optional] 
 **RecordFailureStrategy** | Pointer to **string** | The strategy to handle record failures in the Tableflow enabled topic during materialization.  For &#x60;SKIP&#x60;, we skip the bad records and move to the next record,  and for &#x60;SUSPEND&#x60;, we suspend the materialization of the topic.  | [optional] [default to "SUSPEND"]
 **ErrorHandling** | Pointer to [**TableflowV1TableFlowTopicConfigsSpecErrorHandlingOneOf**](TableflowV1TableFlowTopicConfigsSpecErrorHandlingOneOf.md) | The error mode to handle record failures in the Tableflow enabled topic during materialization.  for &#x60;SKIP&#x60;, we skip the bad records and move to the next record,  for &#x60;SUSPEND&#x60;, we suspend the materialization of the topic,  and for &#x60;LOG&#x60;, we log the bad records to the DLQ and continue processing the rest of the records.  | [optional] 
+**MetadataColumnNamingScheme** | Pointer to **string** | The naming scheme for Tableflow&#39;s internal metadata columns (for example &#x60;$$offset&#x60; and &#x60;$$leader-epoch&#x60;) in the materialized table.  For &#x60;DEFAULT&#x60;, the metadata columns keep their default &#x60;$$&#x60;-prefixed names (for example &#x60;$$offset&#x60; and &#x60;$$leader-epoch&#x60;).  For &#x60;PORTABLE&#x60;, the metadata columns use portable &#x60;cflt_metadata_&#x60;-prefixed names that are queryable by engines such as Google BigQuery, with any hyphens replaced by underscores (for example &#x60;$$offset&#x60; becomes &#x60;cflt_metadata_offset&#x60; and &#x60;$$leader-epoch&#x60; becomes &#x60;cflt_metadata_leader_epoch&#x60;).  If not specified, &#x60;DEFAULT&#x60; is used.  | [optional] [default to "DEFAULT"]
 
 ## Methods
 
@@ -179,6 +180,31 @@ SetErrorHandling sets ErrorHandling field to given value.
 `func (o *TableflowV1TableFlowTopicConfigsSpec) HasErrorHandling() bool`
 
 HasErrorHandling returns a boolean if a field has been set.
+
+### GetMetadataColumnNamingScheme
+
+`func (o *TableflowV1TableFlowTopicConfigsSpec) GetMetadataColumnNamingScheme() string`
+
+GetMetadataColumnNamingScheme returns the MetadataColumnNamingScheme field if non-nil, zero value otherwise.
+
+### GetMetadataColumnNamingSchemeOk
+
+`func (o *TableflowV1TableFlowTopicConfigsSpec) GetMetadataColumnNamingSchemeOk() (*string, bool)`
+
+GetMetadataColumnNamingSchemeOk returns a tuple with the MetadataColumnNamingScheme field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetMetadataColumnNamingScheme
+
+`func (o *TableflowV1TableFlowTopicConfigsSpec) SetMetadataColumnNamingScheme(v string)`
+
+SetMetadataColumnNamingScheme sets MetadataColumnNamingScheme field to given value.
+
+### HasMetadataColumnNamingScheme
+
+`func (o *TableflowV1TableFlowTopicConfigsSpec) HasMetadataColumnNamingScheme() bool`
+
+HasMetadataColumnNamingScheme returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/tableflow/v1/model_tableflow_v1_table_flow_topic_configs_spec.go
+++ b/tableflow/v1/model_tableflow_v1_table_flow_topic_configs_spec.go
@@ -49,6 +49,8 @@ type TableflowV1TableFlowTopicConfigsSpec struct {
 	RecordFailureStrategy *string `json:"record_failure_strategy,omitempty"`
 	// The error mode to handle record failures in the Tableflow enabled topic during materialization.  for `SKIP`, we skip the bad records and move to the next record,  for `SUSPEND`, we suspend the materialization of the topic,  and for `LOG`, we log the bad records to the DLQ and continue processing the rest of the records.
 	ErrorHandling *TableflowV1TableFlowTopicConfigsSpecErrorHandlingOneOf `json:"error_handling,omitempty"`
+	// The naming scheme for Tableflow's internal metadata columns (for example `$$offset` and `$$leader-epoch`) in the materialized table.  For `DEFAULT`, the metadata columns keep their default `$$`-prefixed names (for example `$$offset` and `$$leader-epoch`).  For `PORTABLE`, the metadata columns use portable `cflt_metadata_`-prefixed names that are queryable by engines such as Google BigQuery, with any hyphens replaced by underscores (for example `$$offset` becomes `cflt_metadata_offset` and `$$leader-epoch` becomes `cflt_metadata_leader_epoch`).  If not specified, `DEFAULT` is used.
+	MetadataColumnNamingScheme *string `json:"metadata_column_naming_scheme,omitempty"`
 }
 
 // NewTableflowV1TableFlowTopicConfigsSpec instantiates a new TableflowV1TableFlowTopicConfigsSpec object
@@ -59,6 +61,8 @@ func NewTableflowV1TableFlowTopicConfigsSpec() *TableflowV1TableFlowTopicConfigs
 	this := TableflowV1TableFlowTopicConfigsSpec{}
 	var recordFailureStrategy string = "SUSPEND"
 	this.RecordFailureStrategy = &recordFailureStrategy
+	var metadataColumnNamingScheme string = "DEFAULT"
+	this.MetadataColumnNamingScheme = &metadataColumnNamingScheme
 	return &this
 }
 
@@ -69,6 +73,8 @@ func NewTableflowV1TableFlowTopicConfigsSpecWithDefaults() *TableflowV1TableFlow
 	this := TableflowV1TableFlowTopicConfigsSpec{}
 	var recordFailureStrategy string = "SUSPEND"
 	this.RecordFailureStrategy = &recordFailureStrategy
+	var metadataColumnNamingScheme string = "DEFAULT"
+	this.MetadataColumnNamingScheme = &metadataColumnNamingScheme
 	return &this
 }
 
@@ -267,6 +273,38 @@ func (o *TableflowV1TableFlowTopicConfigsSpec) SetErrorHandling(v TableflowV1Tab
 	o.ErrorHandling = &v
 }
 
+// GetMetadataColumnNamingScheme returns the MetadataColumnNamingScheme field value if set, zero value otherwise.
+func (o *TableflowV1TableFlowTopicConfigsSpec) GetMetadataColumnNamingScheme() string {
+	if o == nil || o.MetadataColumnNamingScheme == nil {
+		var ret string
+		return ret
+	}
+	return *o.MetadataColumnNamingScheme
+}
+
+// GetMetadataColumnNamingSchemeOk returns a tuple with the MetadataColumnNamingScheme field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TableflowV1TableFlowTopicConfigsSpec) GetMetadataColumnNamingSchemeOk() (*string, bool) {
+	if o == nil || o.MetadataColumnNamingScheme == nil {
+		return nil, false
+	}
+	return o.MetadataColumnNamingScheme, true
+}
+
+// HasMetadataColumnNamingScheme returns a boolean if a field has been set.
+func (o *TableflowV1TableFlowTopicConfigsSpec) HasMetadataColumnNamingScheme() bool {
+	if o != nil && o.MetadataColumnNamingScheme != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMetadataColumnNamingScheme gets a reference to the given string and assigns it to the MetadataColumnNamingScheme field.
+func (o *TableflowV1TableFlowTopicConfigsSpec) SetMetadataColumnNamingScheme(v string) {
+	o.MetadataColumnNamingScheme = &v
+}
+
 // Redact resets all sensitive fields to their zero value.
 func (o *TableflowV1TableFlowTopicConfigsSpec) Redact() {
 	o.recurseRedact(o.EnableCompaction)
@@ -275,6 +313,7 @@ func (o *TableflowV1TableFlowTopicConfigsSpec) Redact() {
 	o.recurseRedact(o.DataRetentionMs)
 	o.recurseRedact(o.RecordFailureStrategy)
 	o.recurseRedact(o.ErrorHandling)
+	o.recurseRedact(o.MetadataColumnNamingScheme)
 }
 
 func (o *TableflowV1TableFlowTopicConfigsSpec) recurseRedact(v interface{}) {
@@ -326,6 +365,9 @@ func (o TableflowV1TableFlowTopicConfigsSpec) MarshalJSON() ([]byte, error) {
 	}
 	if o.ErrorHandling != nil {
 		toSerialize["error_handling"] = o.ErrorHandling
+	}
+	if o.MetadataColumnNamingScheme != nil {
+		toSerialize["metadata_column_naming_scheme"] = o.MetadataColumnNamingScheme
 	}
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)


### PR DESCRIPTION
## Summary

Adds the `metadata_column_naming_scheme` config to the `tableflow/v1` model (`TableflowV1TableFlowTopicConfigsSpec`) in the public SDK — the SDK that CLI and Terraform consume.

**Source of truth: confluentinc/api#2612 (merged)** added this field to the Tableflow `tableflow.v1` OpenAPI spec; this PR is the corresponding public-SDK change. The internal-SDK counterpart is confluentinc/ccloud-sdk-go-v2-internal#837.

Optional `x-extensible-enum` string with values `DEFAULT` and `PORTABLE`, `default: DEFAULT`. Applied the same way `record_failure_strategy` was:
- struct field + `Get`/`GetOk`/`Has`/`Set` + both constructors set the `DEFAULT` default + `Redact` + `MarshalJSON`
- embedded `tableflow/v1/api/openapi.yaml`
- `tableflow/v1/docs/TableflowV1TableFlowTopicConfigsSpec.md`

`DEFAULT` keeps the metadata columns' `$$`-prefixed names; `PORTABLE` uses portable `cflt_metadata_`-prefixed names (hyphens replaced by underscores) queryable by engines such as BigQuery.

Since confluentinc/api#2612 has merged, the embedded spec here matches the published contract.

## go vet

This is a hand-applied change to generated code, so `go vet -v ./v1/...` confirms it compiles, the new field's json struct tag is well-formed, and the target packages are part of the build (no diagnostics; exit 0):

```
$ go vet -v ./v1/...
github.com/confluentinc/ccloud-sdk-go-v2/tableflow/v1
github.com/confluentinc/ccloud-sdk-go-v2/tableflow/v1/api
```
