### PR TITLE
Always add the tagging task into Semaphore to simplify the tagging process

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -11,6 +11,14 @@ semaphore:
   branches:
     - master
     - /^v\d+\.\d+\.\d+$/
+  tasks:
+    - name: Manual publish tag
+      branch: git-tag
+      pipeline_file: ".semaphore/git-tag.yml"
+      parameters:
+        - name: TAG
+          required: true
+          description: "Tag version to create (e.g., flink-gateway/v0.32.0)"
 make:
   enable: true
   enable_updates: true


### PR DESCRIPTION
## What
This PR mirrors:
https://github.com/confluentinc/ccloud-sdk-go-v2-internal/pull/776
